### PR TITLE
create tmp directory if it does not already exist

### DIFF
--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -130,7 +130,8 @@ static int _create_standard_directories(void)
 {
     int ret = 0;
 
-    if (mkdir("/tmp", 777) != 0)
+    /* create /tmp if it does not already exist */
+    if (myst_mkdirhier("/tmp", 777) != 0)
     {
         myst_eprintf("cannot create the /tmp directory\n");
         ERAISE(-EINVAL);


### PR DESCRIPTION
Create the /tmp directory only if it does not exist. This allows mystikos to work with Linux distros file systems where there is an empty /tmp directory in the rootfs.