### PR TITLE
sig_kill for cross process signals

### DIFF
--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -243,5 +243,6 @@ long myst_syscall_mount(
     const void* data);
 
 long myst_syscall_umount2(const char* target, int flags);
+long myst_syscall_kill(int pid, int sig);
 
 #endif /* _MYST_SYSCALL_H */

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -12,6 +12,7 @@
 #include <myst/defs.h>
 #include <myst/fdtable.h>
 #include <myst/setjmp.h>
+#include <myst/spinlock.h>
 #include <myst/tcall.h>
 #include <myst/types.h>
 
@@ -45,6 +46,8 @@ struct myst_td
 };
 
 bool myst_valid_td(const void* td);
+
+extern myst_spinlock_t myst_process_list_lock;
 
 typedef struct
 {
@@ -128,6 +131,15 @@ struct myst_thread
         /* the copy of the CRT data made by myst_exec() */
         void* exec_crt_data;
         size_t exec_crt_size;
+
+        /* lock when enumerating all threads in this process
+           while enumerating over thread->group_prev/next */
+        myst_spinlock_t thread_group_lock;
+
+        /* use this lock when using */
+        /* myst_process_list_lock */
+        myst_thread_t* prev_process_thread;
+        myst_thread_t* next_process_thread;
     } main;
 
     volatile _Atomic enum myst_thread_status status;
@@ -159,6 +171,10 @@ struct myst_thread
     void* unmapself_addr;
     size_t unmapself_length;
 
+    // linked list of threads in process
+    // lock points to the one in the main thread. Use when
+    // iterating over the list.
+    myst_spinlock_t* thread_lock;
     struct myst_thread* group_prev;
     struct myst_thread* group_next;
 };
@@ -248,8 +264,10 @@ MYST_INLINE bool myst_is_process_thread(const myst_thread_t* thread)
 MYST_INLINE myst_thread_t* myst_find_process_thread(myst_thread_t* thread)
 {
     myst_thread_t* t = NULL;
-    for (t = thread; t != NULL && myst_is_process_thread(t); t = t->group_prev)
+    myst_spin_lock(thread->thread_lock);
+    for (t = thread; t != NULL && !myst_is_process_thread(t); t = t->group_prev)
         ;
+    myst_spin_unlock(thread->thread_lock);
     return t;
 }
 

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -261,6 +261,14 @@ static int _create_main_thread(uint64_t event, myst_thread_t** thread_out)
     thread->tid = pid;
     thread->event = event;
     thread->target_td = myst_get_fsbase();
+    thread->main.thread_group_lock = MYST_SPINLOCK_INITIALIZER;
+    thread->thread_lock = &thread->main.thread_group_lock;
+
+    // Initial process list is just us. All new processes will be inserted in
+    // the list. Dont need to set these as they are already NULL, but being here
+    // helps to track where main threads are created and torn down!
+    // thread->main.prev_process_thread = NULL;
+    // thread->main.next_process_thread = NULL;
 
     /* allocate the new fdtable for this process */
     ECHECK(myst_fdtable_create(&thread->fdtable));

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -227,7 +227,6 @@ long myst_signal_deliver(
         // previous delivery to be handled.
         while (thread->signal.pending & mask)
             ;
-
         thread->signal.siginfos[signum - 1] = siginfo;
         thread->signal.pending |= mask;
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -35,6 +35,8 @@
 
 myst_thread_t* __myst_main_thread;
 
+myst_spinlock_t myst_process_list_lock = MYST_SPINLOCK_INITIALIZER;
+
 /* The total number of threads running (including the main thread) */
 static _Atomic(size_t) _num_threads = 1;
 
@@ -336,6 +338,7 @@ myst_thread_t* myst_find_thread(int tid)
     if (target == NULL)
     {
         // Search backward in the doubly linked list for a match
+        myst_spin_lock(thread->thread_lock);
         for (t = thread->group_prev; t != NULL; t = t->group_prev)
         {
             if (t->tid == tid)
@@ -344,6 +347,7 @@ myst_thread_t* myst_find_thread(int tid)
                 break;
             }
         }
+        myst_spin_unlock(thread->thread_lock);
     }
 
     return target;
@@ -487,8 +491,8 @@ long myst_run_thread(uint64_t cookie, uint64_t event)
                 // __unmapself() when it invoke SYS_unmap.
                 if (thread->unmapself_addr)
                 {
-                    myst_munmap(thread->unmapself_addr,
-                        thread->unmapself_length);
+                    myst_munmap(
+                        thread->unmapself_addr, thread->unmapself_length);
                 }
 
                 /* unmap any mapping made by the process */
@@ -497,6 +501,9 @@ long myst_run_thread(uint64_t cookie, uint64_t event)
         }
 
         myst_zombify_thread(thread);
+
+        /* Send a SIGCHLD to the parent process */
+        myst_syscall_kill(thread->ppid, SIGCHLD);
 
         {
             myst_assume(_num_threads > 1);
@@ -577,10 +584,13 @@ static long _syscall_clone(
         child->pid = parent->pid;
         child->crt_td = newtls;
         child->run_thread = myst_run_thread;
+        child->thread_lock = parent->thread_lock;
 
         // Link up parent, child, and the previous head child of the parent,
         // if there is one, in the same thread group.
+
         myst_thread_t* prev_head_child = parent->group_next;
+        myst_spin_lock(parent->thread_lock);
         parent->group_next = child;
         child->group_prev = parent;
         if (prev_head_child)
@@ -588,6 +598,7 @@ static long _syscall_clone(
             child->group_next = prev_head_child;
             prev_head_child->group_prev = child;
         }
+        myst_spin_unlock(parent->thread_lock);
 
         // Inherit signal dispositions
         child->signal.sigactions = parent->signal.sigactions;
@@ -643,10 +654,12 @@ static long _syscall_clone_vfork(
         child->magic = MYST_THREAD_MAGIC;
         child->fdtable = parent->fdtable;
         child->sid = parent->sid;
-        child->ppid = parent->ppid;
+        child->ppid = parent->pid;
         child->pid = myst_generate_tid();
         child->tid = child->pid;
         child->run_thread = myst_run_thread;
+        child->main.thread_group_lock = MYST_SPINLOCK_INITIALIZER;
+        child->thread_lock = &child->main.thread_group_lock;
 
         if (myst_fdtable_clone(parent->fdtable, &child->fdtable) != 0)
             ERAISE(-ENOMEM);
@@ -659,6 +672,23 @@ static long _syscall_clone_vfork(
         child->clone.child_stack = child_stack;
         child->clone.flags = flags;
         child->clone.arg = arg;
+
+        myst_thread_t* parent_main_thread = parent;
+        if (!myst_is_process_thread(parent))
+            parent_main_thread = myst_find_process_thread(parent);
+
+        myst_assume(parent_main_thread != NULL);
+
+        /* add this main process thread to the process linked list */
+        myst_spin_lock(&myst_process_list_lock);
+        child->main.next_process_thread =
+            parent_main_thread->main.next_process_thread;
+        if (parent_main_thread->main.next_process_thread)
+            parent_main_thread->main.next_process_thread->main
+                .prev_process_thread = child;
+        child->main.prev_process_thread = parent_main_thread;
+        parent_main_thread->main.next_process_thread = child;
+        myst_spin_unlock(&myst_process_list_lock);
     }
 
     cookie = _get_cookie(child);
@@ -708,35 +738,44 @@ size_t myst_kill_thread_group()
     size_t count = 0;
 
     // Find the tail of the doubly linked list.
+    myst_spin_lock(thread->thread_lock);
     for (t = thread; t != NULL; t = t->group_next)
     {
         if (t->group_next == NULL)
             tail = t;
     }
+    myst_spin_unlock(thread->thread_lock);
     assert(tail);
 
     // Send termination signal to all running child threads.
+    myst_spin_lock(thread->thread_lock);
     for (t = tail; t != NULL; t = t->group_prev)
     {
         if (!myst_is_process_thread(t) && t->status == MYST_RUNNING)
         {
             count++;
+            myst_spin_unlock(thread->thread_lock);
             myst_signal_deliver(t, SIGKILL, 0);
             // Wake up the thread from futex_wait if necessary.
             if (t->signal.cond_wait)
                 myst_cond_signal(t->signal.cond_wait);
+            myst_spin_lock(thread->thread_lock);
         }
     }
+    myst_spin_unlock(thread->thread_lock);
 
     // Wait ~1 second for the child threads to hurry up and exit.
     int i = 0;
     while (i++ < 10)
     {
+        myst_spin_lock(thread->thread_lock);
         for (t = tail; t != NULL; t = t->group_prev)
         {
             if (t->status != MYST_KILLED && t->status != MYST_ZOMBIE)
                 break;
         }
+        myst_spin_unlock(thread->thread_lock);
+
         if (t == NULL)
             break;
 

--- a/tests/spawn/Makefile
+++ b/tests/spawn/Makefile
@@ -2,7 +2,7 @@ TOP=$(abspath ../..)
 include $(TOP)/defs.mak
 
 APPDIR = $(SUBOBJDIR)/appdir
-CFLAGS = -fPIC
+CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
 all: myst rootfs
@@ -11,6 +11,7 @@ rootfs: spawn.c child.c
 	mkdir -p $(APPDIR)/bin
 	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/spawn spawn.c $(LDFLAGS)
 	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/child child.c $(LDFLAGS)
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/child-signal child-signal.c $(LDFLAGS)
 	$(MYST) mkcpio $(APPDIR) rootfs
 
 ifdef STRACE

--- a/tests/spawn/child-signal.c
+++ b/tests/spawn/child-signal.c
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile int sigtest1_usr1 = 0;
+
+void sigtest1_handler(int signo)
+{
+    sigtest1_usr1 = 1;
+}
+
+// test is expecting a SIGUSR1 from parent
+int sigtest1()
+{
+    assert(sigtest1_usr1 == 0);
+    assert(signal(SIGUSR1, sigtest1_handler) == 0);
+
+    assert(kill(getppid(), SIGUSR1) == 0);
+
+    int iteration = 0;
+    while (sigtest1_usr1 != 1 && (iteration < 1000))
+    {
+        const uint64_t msec = 10;
+        struct timespec req = {.tv_sec = 0, .tv_nsec = msec * 1000000};
+        nanosleep(&req, NULL);
+        iteration++;
+    }
+
+    // we should have the SIGUSR1 from the parent by now
+    assert(sigtest1_usr1 == 1);
+
+    return 0;
+}
+
+int main(int argc, const char* argv[], const char* envp[])
+{
+    if ((argc = 2) && (strcmp(argv[1], "sigtest1") == 0))
+    {
+        assert(sigtest1() == 0);
+    }
+    else
+    {
+        assert(0);
+    }
+    return 0;
+}

--- a/tests/spawn/spawn.c
+++ b/tests/spawn/spawn.c
@@ -3,14 +3,17 @@
 
 #include <assert.h>
 #include <limits.h>
+#include <signal.h>
 #include <spawn.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
-int main(int argc, const char* argv[])
+int test_spawn1(int argc, const char* argv[])
 {
     int r;
     pid_t pid = 0;
@@ -51,6 +54,82 @@ int main(int argc, const char* argv[])
     printf("parent: exit status: %d\n", WEXITSTATUS(wstatus));
 
     printf("=== passed test (%s)\n", argv[0]);
+
+    return 0;
+}
+
+static volatile int sigtest1_usr1 = 0;
+static volatile int sig_handler_chld = 0;
+void test_spawn_sig_handler(int signo)
+{
+    switch (signo)
+    {
+        case SIGCHLD:
+            sig_handler_chld = 1;
+            break;
+        case SIGUSR1:
+            sigtest1_usr1 = 1;
+            break;
+        default:
+            assert(0);
+    }
+}
+
+int test_spawn_sig(int argc, const char* argv[])
+{
+    int r;
+    pid_t pid = 0;
+    char* const child_argv[] = {"/bin/child-signal", "sigtest1", NULL};
+    char* const child_envp[] = {"X=1", "Y=1", NULL};
+    int wstatus;
+
+    assert(sigtest1_usr1 == 0);
+    assert(signal(SIGUSR1, test_spawn_sig_handler) == 0);
+
+    assert(sig_handler_chld == 0);
+    assert(signal(SIGCHLD, test_spawn_sig_handler) == 0);
+
+    r = posix_spawn(&pid, child_argv[0], NULL, NULL, child_argv, child_envp);
+
+    if (r != 0)
+    {
+        printf("r=%d\n", r);
+        assert(0);
+    }
+
+    // Wait until we know the process is up
+    int iteration = 0;
+    while ((sigtest1_usr1 == 0) && (iteration < 1000))
+    {
+        const uint64_t msec = 10;
+        struct timespec req = {.tv_sec = 0, .tv_nsec = msec * 1000000};
+        nanosleep(&req, NULL);
+        iteration++;
+    }
+
+    // validate we got the SIGUSR1
+    assert(sigtest1_usr1 == 1);
+
+    // Now send a signal to the child
+    assert(kill(pid, SIGUSR1) == 0);
+
+    assert(waitpid(pid, &wstatus, 0) == pid);
+    assert(WIFEXITED(wstatus));
+    assert(WEXITSTATUS(wstatus) == 0);
+
+    // validate we got the SIGCHLD
+    assert(sig_handler_chld == 1);
+
+    printf("=== passed test (%s-sigtest1)\n", argv[0]);
+
+    return 0;
+}
+
+int main(int argc, const char* argv[])
+{
+    assert(test_spawn1(argc, argv) == 0);
+
+    assert(test_spawn_sig(argc, argv) == 0);
 
     return 0;
 }

--- a/tests/thread/thread.c
+++ b/tests/thread/thread.c
@@ -112,7 +112,7 @@ void test_detach_thread(void)
 
     while (counter != NUM_THREADS)
     {
-      ; // wait until all children are done.
+        ; // wait until all children are done.
     }
 
     printf("=== passed test (%s)\n", __FUNCTION__);


### PR DESCRIPTION
- Added list of process threads for each main process thread
- deliver cross process signals  by searching for pid via list of process threads
- added lock for process thread list
- added lock for intra process thread list
- generate SIGCHLD when child shuts down
- added test for sending signal from child to parent, sending signal from parent to child, check for SIGCHLD on shutdown of child