### PR TITLE
LTP: Setting alpine image version to 3.7 in Dockerfile

### DIFF
--- a/tests/ltp/Dockerfile
+++ b/tests/ltp/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.7
 
 RUN apk add bash build-base automake \
     autoconf linux-headers glib bison flex gawk xz 


### PR DESCRIPTION
LTP test suite is built with musl-gcc in alpine image. 
Setting alpine image version to 3.7 since latest version causes trouble.

Verified that with alpine:3.7 it is built successfully and LTP tests run and pass.

@jxyang @paulcallen @bodzhang 