### PR TITLE
OCALL guards

### DIFF
--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -783,7 +783,7 @@ static long _poll(struct pollfd* fds, nfds_t nfds, int timeout)
 
     if (!fds && nfds > 0)
     {
-        ret = -EINVAL;
+        ret = -EFAULT;
         goto done;
     }
 


### PR DESCRIPTION
This change adds additional OCALL guards to protect against untrusted manipulation of output values.