### PR TITLE
Disable broken pthread_cancel-sem_wait.exe test

### DIFF
--- a/tests/libc/all.txt
+++ b/tests/libc/all.txt
@@ -301,7 +301,6 @@
 /src/regression/printf-fmt-g-zeros.exe
 /src/regression/printf-fmt-n.exe
 /src/regression/pthread_atfork-errno-clobber.exe
-/src/regression/pthread_cancel-sem_wait.exe
 /src/regression/pthread_condattr_setclock.exe
 /src/regression/pthread_cond-smasher.exe
 /src/regression/pthread_cond_wait-cancel_ignored.exe

--- a/tests/libc/alltests.txt
+++ b/tests/libc/alltests.txt
@@ -14,7 +14,6 @@
 /src/functional/inet_pton.exe
 /src/functional/mbc.exe
 /src/functional/memstream.exe
-/src/regression/pthread_cancel-sem_wait.exe
 /src/functional/pthread_cond.exe
 /src/functional/pthread_tsd.exe
 /src/functional/qsort.exe

--- a/tests/libc/failed.txt
+++ b/tests/libc/failed.txt
@@ -42,3 +42,4 @@
 /src/regression/statvfs.exe
 /src/regression/syscall-sign-extend.exe
 /src/regression/tls_get_new-dtv.exe
+/src/regression/pthread_cancel-sem_wait.exe

--- a/tests/libc/run.c
+++ b/tests/libc/run.c
@@ -31,6 +31,10 @@ static void _run_tests(const char* test_file, bool passed)
 
         printf("=== start test: %s\n", line);
 
+        /* skip lines that begin with '#' */
+        if (line[0] == '#')
+            continue;
+
         char* const args[] = {(char*)line, NULL};
         char* const envp[] = {"VALUE=1", NULL};
 


### PR DESCRIPTION
The following test always fails on my bare metal machine.

```
/src/regression/pthread_cancel-sem_wait.exe
```

This change disables the test and adds comment-line processing to the **run.c** source.