### PR TITLE
add myst command line options to control config

### DIFF
--- a/kernel/mount.c
+++ b/kernel/mount.c
@@ -9,9 +9,9 @@
 #include <myst/cpio.h>
 #include <myst/eraise.h>
 #include <myst/ext2.h>
-#include <myst/hostfs.h>
 #include <myst/fssig.h>
 #include <myst/hex.h>
+#include <myst/hostfs.h>
 #include <myst/kernel.h>
 #include <myst/mount.h>
 #include <myst/pubkey.h>

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -42,8 +42,8 @@
 #include <myst/fs.h>
 #include <myst/fsgs.h>
 #include <myst/gcov.h>
-#include <myst/hostfs.h>
 #include <myst/hex.h>
+#include <myst/hostfs.h>
 #include <myst/id.h>
 #include <myst/initfini.h>
 #include <myst/inotifydev.h>
@@ -3592,10 +3592,13 @@ long myst_syscall(long n, long params[6])
             _strace(
                 n,
                 "fd=%d offset=%ld len=%ld advice=%d",
-                fd, offset, len, advice);
+                fd,
+                offset,
+                len,
+                advice);
 
             /* ATTN: no-op */
-             BREAK(_return(n, 0));
+            BREAK(_return(n, 0));
         }
         case SYS_timer_create:
             break;

--- a/solutions/attested_tls/app/tlscli.c
+++ b/solutions/attested_tls/app/tlscli.c
@@ -24,8 +24,8 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-#include "tee.h"
 #include "peer_tee_identity.h"
+#include "tee.h"
 
 #define DEBUG_LEVEL 1
 

--- a/tests/myst/exec-not-signed/Makefile
+++ b/tests/myst/exec-not-signed/Makefile
@@ -14,6 +14,8 @@ include $(TOP)/rules.mak
 
 tests:
 	$(RUNTEST) $(MAKE) test-a
+	$(RUNTEST) $(MAKE) test-config
+	$(RUNTEST) $(MAKE) test-mem-size
 
 test-a:
 	rm -rf $(APPDIR) result rootfs
@@ -28,6 +30,34 @@ test-a:
 	grep -E "argv\[4]=yellow" result
 	grep -E "TESTNAME=tests/myst/exec-not-signed" result
 	@ echo "=== passed test (myst: exec-not-signed)"
+
+test-mem-size:
+	rm -rf $(APPDIR) result rootfs
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
+	$(MYST_EXEC) rootfs --user-mem-size 20m /bin/$(APPNAME) red green blue yellow > result
+	grep -E "argv\[0]=/bin/hello" result
+	grep -E "argv\[1]=red" result
+	grep -E "argv\[2]=green" result
+	grep -E "argv\[3]=blue" result
+	grep -E "argv\[4]=yellow" result
+	grep -E "TESTNAME=tests/myst/exec-not-signed" result
+	@ echo "=== passed test (myst: exec-not-signed-config)"
+
+test-config:
+	rm -rf $(APPDIR) result rootfs
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
+	$(MYST_EXEC) rootfs --app-config-path config.json /bin/$(APPNAME) red green blue yellow > result
+	grep -E "argv\[0]=/bin/hello" result
+	grep -E "argv\[1]=red" result
+	grep -E "argv\[2]=green" result
+	grep -E "argv\[3]=blue" result
+	grep -E "argv\[4]=yellow" result
+	grep -E "TESTNAME=tests/myst/exec-not-signed" result
+	@ echo "=== passed test (myst: exec-not-signed-mem-size)"
 
 clean-exec-not-signed:
 	rm -rf $(APPDIR) result rootfs

--- a/tests/myst/exec-not-signed/config.json
+++ b/tests/myst/exec-not-signed/config.json
@@ -4,17 +4,17 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "KernelMemSize": "65m",
-    "StackMemSize": "65m",
+    "KernelMemSize": "8m",
+    "StackMemSize": "256k",
     "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 
     // Mystikos specific values
-    "UserMemSize": "100m",
+    "UserMemSize": "30m",
     "ApplicationPath": "/bin/hello",
-    "ApplicationParameters": ["Enclave-red", "Enclave-blue", "Enclave-green", "Enclave-yellow"],
-    "HostApplicationParameters": false,
-    "EnvironmentVariables": ["ENC-PATH=/bin", "ENC-HOME=/root"],
-    "HostEnvironmentVariables": ["PATH", "VARIABLE2"]
+    "ApplicationParameters": ["Enclave-red", "Enclave-blue", "Enclave-green", "Enclave-yellow", "Enclave-pink"],
+    "HostApplicationParameters": true,
+    "EnvironmentVariables": ["ENC-ENVP-1=Enclave_envp_1", "ENC-ENVP-2=Enclave_envp_1"],
+    "HostEnvironmentVariables": ["TESTNAME"]
 }

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -25,6 +25,7 @@
 #include <myst/fssig.h>
 #include <myst/getopt.h>
 #include <myst/options.h>
+#include <myst/round.h>
 #include <myst/shm.h>
 #include <openenclave/host.h>
 
@@ -178,19 +179,28 @@ int exec_launch_enclave(
 #define USAGE_EXEC_SGX \
     "\
 \n\
-Usage: %s exec-sgx <rootfs> <application> <app_args...> [options]\n\
+Usage: %s exec-sgx <rootfs> [options] <application> <app_args...>\n\
 \n\
 Where:\n\
     exec-sgx      -- execute the specified <application> from within the\n\
                      <rootfs> with the <app_arguments> within an SGX enclave\n\
     <rootfs>      -- This is the CPIO archive (created via mkcpio) of the\n\
                      application directory\n\
-    <application> -- the application path from within <rootfs> to run within the SGX enclave\n\
+    <application> -- the application path from within <rootfs> to run within\n\
+                     the SGX enclave\n\
     <app_args>    -- the application arguments to pass through to\n\
                      <application>\n\
 \n\
-and <options> are one of:\n\
-    --help        -- this message\n\
+and [options] are one or more of:\n\
+    --help                          -- this message\n\
+    --user-mem-size <size>          -- for running an unsigned binary this overrides the\n\
+                                       default user memory size for an application.\n\
+                                       The <size> format is a number that is in\n\
+                                       bytes (<size>), in kilobytes (<size>k) or\n\
+                                       in megabytes (<size>m)\n\
+    --app-config-path <config.json> -- specifies the configuration json file for running an\n\
+                                       unsigned binary. The file can be the same \n\
+                                       one used for the signing process.\n\
 \n\
 "
 
@@ -209,6 +219,8 @@ int exec_action(int argc, const char* argv[], const char* envp[])
     int return_status;
     char archive_path[PATH_MAX];
     char rootfs_path[] = "/tmp/mystXXXXXX";
+    size_t user_mem_pages = 0;
+    const char* commandline_config = NULL;
 
     assert(strcmp(argv[1], "exec") == 0 || strcmp(argv[1], "exec-sgx") == 0);
 
@@ -227,7 +239,46 @@ int exec_action(int argc, const char* argv[], const char* envp[])
         if (cli_getopt(&argc, argv, "--export-ramfs", NULL) == 0)
             options.export_ramfs = true;
 
-        /* Get --export-ramfs option */
+        /* Get --user-mem-size option */
+        const char* mem_size = NULL;
+        if ((cli_getopt(&argc, argv, "--user-mem-size", &mem_size) == 0) &&
+            mem_size)
+        {
+            char* endptr = NULL;
+            user_mem_pages = strtoul(mem_size, &endptr, 10);
+            if (endptr[0] == '\0')
+            {
+                // nothing to do... in bytes
+            }
+            else if (strcasecmp(endptr, "k") == 0)
+            {
+                user_mem_pages *= 1024;
+            }
+            else if (strcasecmp(endptr, "m") == 0)
+            {
+                user_mem_pages *= 1024;
+                user_mem_pages *= 1024;
+            }
+            else
+            {
+                _err("--user-mem-size <size> -- The <size> format is a number "
+                     "that is in bytes (<size>), in kilobytes (<size>k) or "
+                     "in megabytes (<size>m)");
+            }
+            if (myst_round_up(user_mem_pages, PAGE_SIZE, &user_mem_pages) != 0)
+            {
+                _err("Failed to round up memory size to page size");
+            }
+
+            // Now convert to number of pages
+            user_mem_pages /= PAGE_SIZE;
+        }
+
+        /* Get --app-config option if it exists, otherwise we use default values
+         */
+        cli_getopt(&argc, argv, "--app-config-path", &commandline_config);
+
+        /* Get --help option */
         if ((cli_getopt(&argc, argv, "--help", NULL) == 0) ||
             (cli_getopt(&argc, argv, "-h", NULL) == 0))
         {
@@ -294,7 +345,11 @@ int exec_action(int argc, const char* argv[], const char* envp[])
     // note... we have no config, but this call will go looking in the enclave
     // if it is signed.
     if ((details = create_region_details_from_files(
-             program, rootfs, archive_path, NULL, 0)) == NULL)
+             program,
+             rootfs,
+             archive_path,
+             commandline_config,
+             user_mem_pages)) == NULL)
     {
         _err("Creating region data failed.");
     }

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -89,6 +89,12 @@ static void _get_options(int* argc, const char* argv[], struct options* options)
         if ((val = getenv("MYST_ENABLE_GCOV")) && strcmp(val, "1") == 0)
             options->export_ramfs = true;
     }
+
+    // Retrieve this setting as it is used in sgx option and we just ignore it
+    // here
+    const char* temp_setting = NULL;
+    cli_getopt(argc, argv, "--user-mem-size", &temp_setting);
+    cli_getopt(argc, argv, "--app-config-path", &temp_setting);
 }
 
 static void* _map_mmap_region(size_t length)

--- a/utils/verityblkdev.c
+++ b/utils/verityblkdev.c
@@ -198,7 +198,8 @@ static cache_block_t* _get_cache(blkdev_t* dev, uint64_t blkno)
             break;
     }
 
-    /* if found, not dirty, and not the only entry; move to the back of the LRU list */
+    /* if found, not dirty, and not the only entry; move to the back of the LRU
+     * list */
     if (p && p != head && !p->dirty)
     {
         _lru_remove(dev, p);


### PR DESCRIPTION
added two options for the `myst exec-sgx` command that can update
configuration for user memory for unsigned execution, plus the option to
pass the same signing config.json to unsigned executable execution
- `--user-mem-size <size>` for specifying user memory
- `--app-config-path <config.json>` for specifying whole config file

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>