### PR TITLE
Missed an update for configured user memory size

### DIFF
--- a/tests/myst/exec-not-signed/Makefile
+++ b/tests/myst/exec-not-signed/Makefile
@@ -36,7 +36,7 @@ test-mem-size:
 	mkdir -p $(APPDIR)/bin
 	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
-	$(MYST_EXEC) rootfs --user-mem-size 20m /bin/$(APPNAME) red green blue yellow > result
+	$(MYST_EXEC) rootfs --user-mem-size 1g /bin/$(APPNAME) red green blue yellow > result
 	grep -E "argv\[0]=/bin/hello" result
 	grep -E "argv\[1]=red" result
 	grep -E "argv\[2]=green" result

--- a/tools/myst/config.c
+++ b/tools/myst/config.c
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include "config.h"
 #include <memory.h>
+#include <myst/file.h>
 #include <myst/round.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include "myst/file.h"
+
+#include "config.h"
 
 #define CONFIG_RAISE(CONFIG_ERR)                            \
     do                                                      \

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -211,7 +211,17 @@ static void _load_regions(
         }
     }
 
-    if (!(r->mman_data = _map_mmap_region(DEFAULT_MMAN_SIZE)))
+    if (user_mem_size == 0)
+    {
+        r->mman_size = DEFAULT_MMAN_SIZE;
+    }
+    else
+    {
+        /* command line parsing gave pages. convert to size */
+        r->mman_size = user_mem_size;
+    }
+
+    if (!(r->mman_data = _map_mmap_region(r->mman_size)))
         _err("failed to map mmap region");
 
     /* Apply relocations to the libmystkernel.so image */
@@ -222,16 +232,6 @@ static void _load_regions(
             r->libmystkernel.reloc_size) != 0)
     {
         _err("failed to apply relocations to libmystkernel.so\n");
-    }
-
-    if (user_mem_size == 0)
-    {
-        r->mman_size = DEFAULT_MMAN_SIZE;
-    }
-    else
-    {
-        /* command line parsing gave pages. convert to size */
-        r->mman_size = user_mem_size;
     }
 }
 

--- a/tools/myst/host/regions.c
+++ b/tools/myst/host/regions.c
@@ -111,8 +111,9 @@ const region_details* create_region_details_from_package(
     _details.config.status = REGION_ITEM_BORROWED;
 
     if (user_pages == 0)
-        user_pages = DEFAULT_MMAN_SIZE;
-    _details.mman_size = user_pages * PAGE_SIZE;
+        _details.mman_size = DEFAULT_MMAN_SIZE;
+    else
+        _details.mman_size = user_pages * PAGE_SIZE;
 
     return &_details;
 }


### PR DESCRIPTION
on linux there was a mismatch between the setup of the mman region size and the size the kernel was trying to zero.
Now both match and we can allocate a GB or more user memory.

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>