### PR TITLE
Setting alpine image version to most recent compatible version 3.12.3

### DIFF
--- a/tests/ltp/Dockerfile
+++ b/tests/ltp/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.12.3
 
 RUN apk add bash build-base automake \
     autoconf linux-headers glib bison flex gawk xz 


### PR DESCRIPTION
3.7 is a very old version. Using most recent compatible alpine version 3.12.3
(Note: 3.13 is causing failure). 
We are using alpine container just to build LTP tests. 

cc @jxyang 