### PR TITLE
MYST_ROOTFS_PATH environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ tests/inotify/appdir/
 tests/hostfs/appdir/
 tests/ext2/crypt/appdir/
 tests/ext2/verity/appdir/
+tests/myst/exec-package-ext2/myst/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Today, two target implementations are provided:
 The minimalist kernel of Mystikos manages essential computing resources
 inside the TEE, such as CPU/threads, memory, files, networks, etc. It handles
 most of the syscalls that a normal operating system would handle (with
-[limits](SYSCALL-LIMITATIONS)).  Many syscalls are handled directly by the
+[limits](SYSCALL-LIMITATIONS.md)).  Many syscalls are handled directly by the
 kernel while others are delegated to the target.
 
 ![](./arch.png)
@@ -39,7 +39,7 @@ kernel while others are delegated to the target.
 
 Binary downloads of Mystikos will be made available in the future. 
 
-To build Mystikos from source, follow the [build instructions](BUILDING).
+To build Mystikos from source, follow the [build instructions](BUILDING.md).
 
 **NOTE** that Mystikos can only be built on **Ubuntu 18.04** due to current
 limitations in Open Enclave SDK.
@@ -84,7 +84,7 @@ your original message.
 
 # Contributing to Mystikos
 
-See the [Contributing Guide](CONTRIBUTING).
+See the [Contributing Guide](CONTRIBUTING.md).
 
 # Code of Conduct
 

--- a/notes.txt
+++ b/notes.txt
@@ -1,4 +1,0 @@
-
-
-    Crashed calling musl_syscall_variadic() from
-        ./musl/src/thread/x86_64/syscall_cp.s

--- a/tests/myst/Makefile
+++ b/tests/myst/Makefile
@@ -11,6 +11,7 @@ DIRS += exec-signed-2
 endif
 
 DIRS += exec-package
+DIRS += exec-package-ext2
 DIRS += dump-package
 
 include $(TOP)/rules.mak

--- a/tests/myst/exec-package-ext2/Makefile
+++ b/tests/myst/exec-package-ext2/Makefile
@@ -1,0 +1,42 @@
+TOP=$(abspath ../../..)
+include $(TOP)/defs.mak
+
+TMPDIR=$(SUBOBJDIR)/tmp
+APPDIR=$(TMPDIR)/appdir
+ROOTFS=$(TMPDIR)/rootfs
+PRIVKEY=$(TMPDIR)/private.pem
+PUBKEY=$(TMPDIR)/public.pem
+
+USER=$(shell id --user)
+GROUP=$(shell id --group)
+
+all: $(PUBKEY)
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) -Wall -o $(APPDIR)/bin/hello hello.c
+	sudo $(MYST) mkext2 --force --sign=$(PUBKEY):$(PRIVKEY) $(APPDIR) $(ROOTFS)
+	sudo chown $(USER).$(GROUP) $(ROOTFS)
+	$(MYST) package --pubkey=$(PUBKEY) $(PRIVKEY) config.json
+
+$(PUBKEY): $(PRIVKEY)
+	openssl rsa -in $(PRIVKEY) -pubout -out $(PUBKEY)
+
+$(PRIVKEY): $(TMPDIR)
+	openssl genrsa -out $(PRIVKEY) -3 3072
+
+$(TMPDIR):
+	mkdir -p $(TMPDIR)
+
+export MYST_ROOTFS_PATH=$(ROOTFS)
+
+tests:
+	$(RUNTEST) $(MYST) exec-sgx --pubkey=$(PUBKEY) $(ROOTFS) /bin/hello
+	$(RUNTEST) ./myst/bin/hello
+
+clean:
+	rm -rf $(APPDIR) myst $(PRIVKEY) $(PRIVKEY) $(ROOTFS)
+
+distclean:
+	rm -rf $(SUBOBJDIR)
+
+xxx:
+	ls -l $(ROOTFS)

--- a/tests/myst/exec-package-ext2/config.json
+++ b/tests/myst/exec-package-ext2/config.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.1",
+    "Debug": 1,
+    "KernelMemSize": "4m",
+    "StackMemSize": "256k",
+    "NumUserThreads": 2,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+    "UserMemSize": "40m",
+    "ApplicationPath": "/bin/hello",
+    "ApplicationParameters": [],
+    "HostApplicationParameters": false,
+    "EnvironmentVariables": [],
+    "HostEnvironmentVariables": []
+}

--- a/tests/myst/exec-package-ext2/hello.c
+++ b/tests/myst/exec-package-ext2/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("Hello!\n");
+    return 0;
+}

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -17,6 +17,7 @@
 #include <myst/getopt.h>
 #include <openenclave/bits/sgx/region.h>
 #include <openenclave/host.h>
+#include <myst/strings.h>
 
 #include "../config.h"
 #include "archive.h"
@@ -30,10 +31,11 @@
 
 _Static_assert(PAGE_SIZE == 4096, "");
 
-#define USAGE_PACKAGE \
-    "\
+#define USAGE_PACKAGE "\
 \n\
-Usage: %s package-sgx <app_dir> <pem_file> <config> [options]\n\
+Usage:\n\
+    %s package-sgx [options] <app_dir> <pem_file> <config>\n\
+    %s package-sgx [options] <pem_file> <config>\n\
 \n\
 Where:\n\
     package-sgx -- create an executable package to run on the SGX platform\n\
@@ -45,7 +47,9 @@ Where:\n\
     <config>    -- configuration for signing and application runtime\n\
 \n\
 and <options> are one of:\n\
-    --help      -- this message\n\
+    --help                -- this message\n\
+    --pubkey=pem_file     -- trust disks signed by this key (repeatable)\n\
+    --roothash=ascii_file -- trust disks with this roothash (repeatable)\n\
 \n\
 "
 
@@ -115,10 +119,10 @@ int _package(int argc, const char* argv[])
         max_roothashes,
         &num_roothashes);
 
-    if ((argc < 5) || (cli_getopt(&argc, argv, "--help", NULL) == 0) ||
+    if ((argc < 4) || (cli_getopt(&argc, argv, "--help", NULL) == 0) ||
         (cli_getopt(&argc, argv, "-h", NULL) == 0))
     {
-        fprintf(stderr, USAGE_PACKAGE, argv[0]);
+        fprintf(stderr, USAGE_PACKAGE, argv[0], argv[0]);
         goto done;
     }
 
@@ -127,9 +131,19 @@ int _package(int argc, const char* argv[])
         (strcmp(argv[1], "package") == 0) ||
         (strcmp(argv[1], "package-sgx") == 0));
 
-    app_dir = argv[2];
-    pem_file = argv[3];
-    config_file = argv[4];
+    if (argc == 5)
+    {
+        app_dir = argv[2];
+        pem_file = argv[3];
+        config_file = argv[4];
+    }
+    else if (argc == 4)
+    {
+        app_dir = NULL;
+        pem_file = argv[2];
+        config_file = argv[3];
+    }
+
     create_archive(
         pubkeys, num_pubkeys, roothashes, num_roothashes, archive_file);
 
@@ -146,19 +160,41 @@ int _package(int argc, const char* argv[])
         goto done;
     }
 
-    const char* mkcpio_args[] = {argv[0], // ..../myst
-                                 "mkcpio",
-                                 app_dir,
-                                 rootfs_file};
-
-    if (_mkcpio(sizeof(mkcpio_args) / sizeof(mkcpio_args[0]), mkcpio_args) != 0)
+    if (app_dir)
     {
-        fprintf(
-            stderr,
-            "Failed to create root filesystem \"%s\" from directory \"%s\"\n",
-            rootfs_file,
-            app_dir);
-        goto done;
+        const char* mkcpio_args[] = {argv[0], // ..../myst
+                                     "mkcpio",
+                                     app_dir,
+                                     rootfs_file};
+
+        if (_mkcpio(
+                sizeof(mkcpio_args) / sizeof(mkcpio_args[0]), mkcpio_args) != 0)
+        {
+            fprintf(
+                stderr,
+                "Failed to create root filesystem \"%s\" from directory "
+                "\"%s\"\n",
+                rootfs_file,
+                app_dir);
+            goto done;
+        }
+    }
+    else
+    {
+        /* generate a dummy CPIO rootfs with one page of zero bytes */
+        int fd;
+        uint8_t page[PAGE_SIZE];
+        const int flags = O_CREAT | O_WRONLY | O_TRUNC;
+
+        if ((fd = open(rootfs_file, flags, 0666)) < 0)
+            _err("failed to create temporary file");
+
+        memset(page, 0, sizeof(page));
+
+        if (write(fd, page, sizeof(page)) != sizeof(page))
+            _err("failed to create file: %s", rootfs_file);
+
+        close(fd);
     }
 
     if (parse_config_from_file(config_file, &parsed_data) != 0)
@@ -391,6 +427,23 @@ done:
     return ret;
 }
 
+/* if this is the null rootfs (one page full of zeros) */
+static bool _is_null_rootfs(const void* s, size_t n)
+{
+    const uint8_t* p = s;
+
+    if (!s || n != PAGE_SIZE)
+        return false;
+
+    while (n--)
+    {
+        if (*p++)
+            return false;
+    }
+
+    return true;
+}
+
 // <app_name> [app args]
 int _exec_package(
     int argc,
@@ -570,6 +623,31 @@ int _exec_package(
     {
         fprintf(stderr, "Failed to extract all sections\n");
         goto done;
+    }
+
+    if (_is_null_rootfs(details->rootfs.buffer, details->rootfs.buffer_size))
+    {
+        char* env;
+
+        if (!(env = getenv("MYST_ROOTFS_PATH")))
+        {
+            fprintf(stderr, "MYST_ROOTFS_PATH is undefined\n");
+            goto done;
+        }
+
+        if (access(env, R_OK) != 0)
+        {
+            fprintf(stderr, "MYST_ROOTFS_PATH=%s not found\n", env);
+            goto done;
+        }
+
+        if (myst_strlcpy(options.rootfs, env, sizeof(options.rootfs)) >=
+            sizeof(options.rootfs))
+        {
+            fprintf(stderr, "MYST_ROOTFS_PATH is too long (> %zu)\n",
+                sizeof(options.rootfs));
+            goto done;
+        }
     }
 
     parsed_data.oe_num_heap_pages =


### PR DESCRIPTION
Pass the path of EXT2 root file systems to Mystikos packages through the **MYST_ROOTFS_PATH** environment variable. Also modified the **myst package** command to suppress the **<app_dir>** argument by allowing two usages.

```
myst package-sgx [options] <app_dir> <pem_file> <config>
myst package-sgx [options] <pem_file> <config>
```

Future: consider putting the **<app_dir>** argument last as follows.

```
myst package-sgx [options] <pem_file> <config> [<app_dir>]
```

Unfortunately this proposal would impact the current usage and so it requires more discussion.