### PR TITLE
allow hostname to be part of appconfig.json

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -48,6 +48,9 @@ typedef struct myst_kernel_args
     /* current working directory for app */
     const char* cwd;
 
+    /* configure hostname in kernel */
+    const char* hostname;
+
     /* The read-write-execute memory management pages */
     void* mman_data;
     size_t mman_size;

--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -245,4 +245,6 @@ long myst_syscall_mount(
 long myst_syscall_umount2(const char* target, int flags);
 long myst_syscall_kill(int pid, int sig);
 
+long myst_syscall_sethostname(const char* hostname, size_t len);
+
 #endif /* _MYST_SYSCALL_H */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -481,6 +481,10 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     if (thread->main.cwd == NULL)
         ERAISE(-ENOMEM);
 
+    if (args->hostname)
+        ECHECK(
+            myst_syscall_sethostname(args->hostname, strlen(args->hostname)));
+
     /* setup the TTY devices */
     if (_setup_tty() != 0)
     {

--- a/tests/myst/Makefile
+++ b/tests/myst/Makefile
@@ -14,5 +14,6 @@ DIRS += exec-package
 DIRS += dump-package
 
 DIRS += cwd-config
+DIRS += hostname-config
 
 include $(TOP)/rules.mak

--- a/tests/myst/hostname-config/Makefile
+++ b/tests/myst/hostname-config/Makefile
@@ -1,0 +1,33 @@
+TOP=$(abspath ../../..)
+include $(TOP)/defs.mak
+
+APPDIR = $(SUBOBJDIR)/appdir
+CFLAGS = -fPIC -g
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+all: myst rootfs
+
+build:	main.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/test main.c $(LDFLAGS)
+
+rootfs: build
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+tests: test-default-hostname test-override-hostname
+
+test-default-hostname: rootfs
+	$(RUNTEST) $(MYST_EXEC) rootfs $(OPTS) /bin/test TEE
+
+test-override-hostname: rootfs
+	$(RUNTEST) $(MYST_EXEC) rootfs $(OPTS) --app-config-path config1.json /bin/test test1
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs

--- a/tests/myst/hostname-config/config1.json
+++ b/tests/myst/hostname-config/config1.json
@@ -1,0 +1,21 @@
+{
+    // Mystikos configuration version number
+    "version": "0.1",
+
+    // OpenEnclave specific values
+    "Debug": 1,
+    "KernelMemSize": "8m",
+    "StackMemSize": "256k",
+    "NumUserThreads": 2,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+    "UserMemSize": "30m",
+    "ApplicationPath": "/bin/hello",
+    "Hostname": "test1",
+    "ApplicationParameters": ["Enclave-red", "Enclave-blue", "Enclave-green", "Enclave-yellow", "Enclave-pink"],
+    "HostApplicationParameters": true,
+    "EnvironmentVariables": ["ENC-ENVP-1=Enclave_envp_1", "ENC-ENVP-2=Enclave_envp_1"],
+    "HostEnvironmentVariables": ["TESTNAME"]
+}

--- a/tests/myst/hostname-config/main.c
+++ b/tests/myst/hostname-config/main.c
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <limits.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+/*
+    argv[1] = test name
+    argv[2] = expected hostname
+*/
+int test_hostname(int argc, const char* argv[])
+{
+    int r;
+    char hostname[HOST_NAME_MAX];
+    char new_hostname[] = "changed";
+
+    assert(argc == 2);
+
+    // Validate application hostname is correct to start with
+    assert(gethostname(hostname, sizeof(hostname)) == 0);
+    assert(strcmp(hostname, argv[1]) == 0);
+
+    // Change the name
+    assert(sethostname(new_hostname, sizeof(new_hostname)) == 0);
+
+    // Validate it was changed correctly
+    assert(gethostname(hostname, sizeof(hostname)) == 0);
+    assert(strcmp(hostname, new_hostname) == 0);
+
+    printf("=== passed test (%s-hostname-config)\n", argv[0]);
+
+    return 0;
+}
+
+int main(int argc, const char* argv[])
+{
+    assert(test_hostname(argc, argv) == 0);
+
+    return 0;
+}

--- a/tools/myst/config.c
+++ b/tools/myst/config.c
@@ -259,6 +259,13 @@ static json_result_t _json_read_callback(
                 else
                     CONFIG_RAISE(JSON_TYPE_MISMATCH);
             }
+            else if (json_match(parser, "Hostname") == JSON_OK)
+            {
+                if (type == JSON_TYPE_STRING)
+                    parsed_data->hostname = un->string;
+                else
+                    CONFIG_RAISE(JSON_TYPE_MISMATCH);
+            }
             else
             {
                 // Ignore everything we dont understand

--- a/tools/myst/config.h
+++ b/tools/myst/config.h
@@ -31,6 +31,7 @@ typedef struct _config_parsed_data_t
     char** host_environment_variables;
     size_t host_environment_variables_count;
     char* cwd;
+    char* hostname;
 
     // Internal data
     void* buffer;

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -176,7 +176,8 @@ int myst_enter_ecall(
     unsigned char have_config = 0;
     myst_args_t args;
     myst_args_t env;
-    const char* cwd = "/"; // default to root dir
+    const char* cwd = "/";       // default to root dir
+    const char* hostname = NULL; // kernel has a default
     const uint8_t* enclave_base;
     size_t enclave_size;
 
@@ -292,6 +293,12 @@ int myst_enter_ecall(
     if (have_config && parsed_config.cwd)
     {
         cwd = parsed_config.cwd;
+    }
+
+    // Override current working directory if present in config
+    if (have_config && parsed_config.hostname)
+    {
+        hostname = parsed_config.hostname;
     }
 
     /* Inject the MYST_TARGET environment variable */
@@ -531,6 +538,7 @@ int myst_enter_ecall(
         kargs.envc = env.size;
         kargs.envp = env.data;
         kargs.cwd = cwd;
+        kargs.hostname = hostname;
         kargs.mman_data = mman_data;
         kargs.mman_size = mman_size;
         kargs.rootfs_data = (void*)rootfs_data;

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -269,7 +269,8 @@ static int _enter_kernel(
     const elf_ehdr_t* ehdr = regions->libmystkernel.image_data;
     myst_kernel_entry_t entry;
     myst_args_t env;
-    const char* cwd = "/"; /* default */
+    const char* cwd = "/";       /* default */
+    const char* hostname = NULL; // kernel has a default
 
     if (err)
         *err = '\0';
@@ -329,6 +330,9 @@ static int _enter_kernel(
             /* only override if we have a cwd config item */
             if (parsed_data.cwd)
                 cwd = parsed_data.cwd;
+
+            if (parsed_data.hostname)
+                hostname = parsed_data.hostname;
         }
         else
         {
@@ -358,6 +362,7 @@ static int _enter_kernel(
     args.envc = env.size;
     args.envp = env.data;
     args.cwd = cwd;
+    args.hostname = hostname;
     args.mman_data = regions->mman_data;
     args.mman_size = regions->mman_size;
     args.rootfs_data = regions->rootfs_data;


### PR DESCRIPTION
* Added hostname as config parameter and plumbed through to kernel from
sgx and linux targets
* updated syscall_uname and syscall_sethostname to use and retrieve
hostname
* added unittest to validate
* fixed an existing memory leak in kernel and some formatting

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>