### PR TITLE
Handle statfs and fstatfs

### DIFF
--- a/hostfs/hostfs.c
+++ b/hostfs/hostfs.c
@@ -877,6 +877,52 @@ done:
     return ret;
 }
 
+static int _fs_statfs(myst_fs_t* fs, const char* pathname, struct statfs* buf)
+{
+    int ret = 0;
+    hostfs_t* hostfs = (hostfs_t*)fs;
+    char path[PATH_MAX];
+    long tret;
+
+    if (!_hostfs_valid(hostfs) || !pathname || !buf)
+        ERAISE(-EINVAL);
+
+    ECHECK(_fixup_path(hostfs, path, sizeof(path), pathname));
+
+    long params[6] = {(long)path, (long)buf};
+    ECHECK((tret = myst_tcall(SYS_statfs, params)));
+
+    if (tret != 0)
+        ERAISE(-EINVAL);
+
+    ret = tret;
+
+done:
+    return ret;
+}
+
+static int _fs_fstatfs(myst_fs_t* fs, myst_file_t* file, struct statfs* buf)
+{
+    int ret = 0;
+    hostfs_t* hostfs = (hostfs_t*)fs;
+    long tret;
+
+    if (!_hostfs_valid(hostfs) || !_file_valid(file) || !buf)
+        ERAISE(-EINVAL);
+
+    long params[6] = {file->fd, (long)buf};
+    ECHECK((tret = myst_tcall(SYS_fstatfs, params)));
+
+    if (tret != 0)
+        ERAISE(-EINVAL);
+
+    ret = tret;
+
+done:
+    return ret;
+}
+
+
 int myst_init_hostfs(myst_fs_t** fs_out)
 {
     int ret = 0;
@@ -929,6 +975,8 @@ int myst_init_hostfs(myst_fs_t** fs_out)
         .fs_dup = _fs_dup,
         .fs_target_fd = _fs_target_fd,
         .fs_get_events = _fs_get_events,
+        .fs_statfs = _fs_statfs,
+        .fs_fstatfs = _fs_fstatfs,
     };
     // clang-format on
 

--- a/include/myst/fs.h
+++ b/include/myst/fs.h
@@ -7,6 +7,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/statfs.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -133,6 +134,10 @@ struct myst_fs
     int (*fs_target_fd)(myst_fs_t* fs, myst_file_t* file);
 
     int (*fs_get_events)(myst_fs_t* fs, myst_file_t* file);
+
+    int (*fs_statfs)(myst_fs_t* fs, const char* path, struct statfs* buf);
+
+    int (*fs_fstatfs)(myst_fs_t* fs, myst_file_t* file, struct statfs* buf);
 };
 
 int myst_remove_fd_link(myst_fs_t* fs, myst_file_t* file, int fd);

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -1658,6 +1658,52 @@ done:
     return ret;
 }
 
+static int _statfs(struct statfs* buf)
+{
+    int ret = 0;
+
+    if (!buf)
+        ERAISE(-EINVAL);
+
+    memset(buf, 0, sizeof(struct statfs));
+    buf->f_type = 0x858458f6; //RAMFS_MAGIC from man(2) statfs
+    buf->f_bsize = BLKSIZE;
+
+done:
+    return ret;
+}
+
+static int _fs_statfs(myst_fs_t* fs, const char* path, struct statfs* buf)
+{
+    int ret = 0;
+    ramfs_t* ramfs = (ramfs_t*)fs;
+    inode_t* inode;
+
+    if (!_ramfs_valid(ramfs) || !path || !buf)
+        ERAISE(-EINVAL);
+
+    /* Check if path exists */
+    ECHECK(_path_to_inode(ramfs, path, false, NULL, &inode));
+    ECHECK(_statfs(buf));
+
+done:
+    return ret;
+}
+
+static int _fs_fstatfs(myst_fs_t* fs, myst_file_t* file, struct statfs* buf)
+{
+    int ret = 0;
+    ramfs_t* ramfs = (ramfs_t*)fs;
+
+    if (!_ramfs_valid(ramfs) || !_file_valid(file) || !buf)
+        ERAISE(-EINVAL);
+
+    ECHECK(_statfs(buf));
+
+done:
+    return ret;
+}
+
 int myst_init_ramfs(myst_fs_t** fs_out)
 {
     int ret = 0;
@@ -1710,6 +1756,8 @@ int myst_init_ramfs(myst_fs_t** fs_out)
         .fs_dup = _fs_dup,
         .fs_target_fd = _fs_target_fd,
         .fs_get_events = _fs_get_events,
+        .fs_statfs = _fs_statfs,
+        .fs_fstatfs = _fs_fstatfs,
     };
     // clang-format on
     inode_t* root_inode = NULL;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1184,6 +1184,23 @@ done:
     return ret;
 }
 
+long myst_syscall_statfs(const char* path, struct statfs *buf)
+{
+    long ret = 0;
+    char suffix[PATH_MAX];
+    myst_fs_t* fs;
+    struct stat statbuf;
+
+    ECHECK(myst_mount_resolve(path, suffix, &fs));
+    ECHECK((*fs->fs_stat)(fs, suffix, &statbuf));
+
+    if (buf)
+        memset(buf, 0, sizeof(*buf));
+done:
+
+    return ret;
+}
+
 static char _hostname[HOST_NAME_MAX] = "TEE";
 static myst_spinlock_t _hostname_lock = MYST_SPINLOCK_INITIALIZER;
 
@@ -3240,10 +3257,9 @@ long myst_syscall(long n, long params[6])
 
             _strace(n, "path=%s buf=%p", path, buf);
 
-            if (buf)
-                memset(buf, 0, sizeof(*buf));
+            long ret = myst_syscall_statfs(path, buf);
 
-            BREAK(_return(n, 0));
+            BREAK(_return(n, ret));
         }
         case SYS_fstatfs:
             break;

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -610,6 +610,8 @@ long myst_tcall(long n, long params[6])
         case SYS_symlink:
         case SYS_lstat:
         case SYS_readlink:
+        case SYS_statfs:
+        case SYS_fstatfs:
         {
             return _forward_syscall(n, x1, x2, x3, x4, x5, x6);
         }

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -689,6 +689,8 @@ long myst_tcall(long n, long params[6])
         case SYS_symlink:
         case SYS_lstat:
         case SYS_readlink:
+        case SYS_statfs:
+        case SYS_fstatfs:
         {
             extern long myst_handle_tcall(long n, long params[6]);
             return myst_handle_tcall(n, params);

--- a/tests/fs/fs.c
+++ b/tests/fs/fs.c
@@ -563,6 +563,17 @@ void test_statfs(char* program_name)
     _passed(__FUNCTION__);
 }
 
+void test_fstatfs(char* program_name)
+{
+    int result;
+    struct statfs stats;
+    int fd = open(program_name, O_RDONLY);
+    result = fstatfs(fd, &stats);
+    assert(result == 0);
+
+    _passed(__FUNCTION__);
+}
+
 int main(int argc, char* argv[])
 {
     test_fstatat();
@@ -580,6 +591,7 @@ int main(int argc, char* argv[])
     test_tmpfile();
     test_pread_pwrite();
     test_statfs(argv[0]);
+    test_fstatfs(argv[0]);
 
     return 0;
 }

--- a/tests/fs/fs.c
+++ b/tests/fs/fs.c
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <sys/vfs.h>
 #include <unistd.h>
 
 const char alpha[] = "abcdefghijklmnopqrstuvwxyz";
@@ -547,7 +548,22 @@ static void test_fstatat(void)
     _passed(__FUNCTION__);
 }
 
-int main(void)
+void test_statfs(char* program_name)
+{
+    int result;
+    struct statfs stats;
+
+    // test statfs fails for non-existent file path
+    result = statfs("/unknown/file", &stats);
+    assert(result != 0);
+
+    result = statfs(program_name, &stats);
+    assert(result == 0);
+
+    _passed(__FUNCTION__);
+}
+
+int main(int argc, char* argv[])
 {
     test_fstatat();
     test_readv();
@@ -563,6 +579,7 @@ int main(void)
     test_symlink();
     test_tmpfile();
     test_pread_pwrite();
+    test_statfs(argv[0]);
 
     return 0;
 }

--- a/tests/hostfs/hostfs.c
+++ b/tests/hostfs/hostfs.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/statfs.h>
 #include <sys/uio.h>
 #include <unistd.h>
 
@@ -69,6 +70,20 @@ int main(int argc, const char* argv[])
         assert((fd = open(filename, O_RDONLY, 0)) >= 0);
         assert(fstat(fd, &buf) == 0);
         assert(buf.st_size == sizeof(alpha));
+        assert(close(fd) == 0);
+    }
+
+    /* test statfs() */
+    {
+        struct statfs buf;
+        assert(statfs(filename, &buf) == 0);
+    }
+
+    /* test fstatfs() */
+    {
+        struct statfs buf;
+        assert((fd = open(filename, O_RDONLY, 0)) >= 0);
+        assert(fstatfs(fd, &buf) == 0);
         assert(close(fd) == 0);
     }
 

--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -1298,6 +1298,44 @@ done:
 }
 #endif
 
+#ifdef MYST_ENABLE_HOSTFS
+static long _statfs(const char* pathname, struct myst_statfs* buf)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_statfs_ocall(&retval, pathname, buf) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+#endif
+
+#ifdef MYST_ENABLE_HOSTFS
+static long _fstatfs(int fd, struct myst_statfs* buf)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_fstatfs_ocall(&retval, fd, buf) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+#endif
+
 long myst_handle_tcall(long n, long params[6])
 {
     const long a = params[0];
@@ -1497,6 +1535,14 @@ long myst_handle_tcall(long n, long params[6])
         case SYS_readlink:
         {
             return _readlink((const char*)a, (char*)b, (size_t)c);
+        }
+        case SYS_statfs:
+        {
+            return _statfs((const char*)a, (struct myst_statfs*)b);
+        }
+        case SYS_fstatfs:
+        {
+            return _fstatfs((int)a, (struct myst_statfs*)b);
         }
 #endif
         default:

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/statfs.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
@@ -327,4 +328,14 @@ long myst_symlink_ocall(const char* target, const char* linkpath)
 long myst_readlink_ocall(const char* pathname, char* buf, size_t bufsiz)
 {
     RETURN(readlink(pathname, buf, bufsiz));
+}
+
+long myst_statfs_ocall(const char* path, struct myst_statfs* buf)
+{
+    RETURN(statfs(path, (struct statfs*)buf));
+}
+
+long myst_fstatfs_ocall(int fd, struct myst_statfs* buf)
+{
+    RETURN(fstatfs(fd, (struct statfs*)buf));
 }

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -20,6 +20,7 @@ enclave
        long tv_nsec;
     };
 
+
     struct myst_stat
     {
         unsigned long st_dev;
@@ -37,6 +38,26 @@ enclave
         struct myst_timespec st_mtim;
         struct myst_timespec st_ctim;
     };
+
+    struct myst_fsid {
+	    int __val[2];
+    };
+    struct myst_statfs
+    {
+	    unsigned long f_type;
+        unsigned long f_bsize;
+	    unsigned long f_blocks;
+        unsigned long f_bfree;
+        unsigned long f_bavail;
+	    unsigned long f_files;
+        unsigned long f_ffree;
+	    struct myst_fsid f_fsid;
+	    unsigned long f_namelen;
+        unsigned long f_frsize;
+        unsigned long f_flags;
+        unsigned long f_spare[4];
+    };
+
 
     struct myst_linux_dirent64
     {
@@ -309,6 +330,14 @@ enclave
             [in, string] const char* pathname,
             [out, size=bufsiz] char* buf,
             size_t bufsiz);
+
+        long myst_statfs_ocall(
+            [in, string] const char* path,
+            [out] struct myst_statfs* buf);
+
+        long myst_fstatfs_ocall(
+            int fd,
+            [out] struct myst_statfs* buf);
 
         /*
         **======================================================================


### PR DESCRIPTION
This is to pass a dotnet 5 runtime [assertion in cgroup subsystem](https://github.com/dotnet/runtime/blob/v5.0.0-rtm.20519.4/src/coreclr/src/pal/src/misc/cgroup.cpp#L127-L137). 

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>