### PR TITLE
support for parallel builds and build cache

### DIFF
--- a/crt/Makefile
+++ b/crt/Makefile
@@ -28,7 +28,7 @@ endif
 
 LIBCC = -lgcc
 
-MUSLSRC=$(BUILDDIR)/crt-musl
+MUSLSRC=$(TOP)/third_party/musl/crt/musl
 
 -include $(MUSLSRC)/objects.mak
 

--- a/doc/build-cache-howto.md
+++ b/doc/build-cache-howto.md
@@ -1,0 +1,24 @@
+The Mystikos build cache
+========================
+
+To enable the Mystikos build cache, define the following environment variable
+before building.
+
+```
+export MYST_USE_BUILD_CACHE=1
+```
+
+When enabled, the build scripts cache various build artifacts under the
+following directory.
+
+```
+~/.mystikos/cache
+```
+
+Subsequent builds of the current tree or freshly cloned trees use this cache
+to avoid downloading and rebuilding these artifacts again and again.
+
+When caching the build output from submodules, the build scripts use commit
+hashes to determine whether cache is out of date.
+
+To remove the cache, simply remove the ~/.mystikos/cache directory.

--- a/kernel/atoi.c
+++ b/kernel/atoi.c
@@ -4,4 +4,4 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 
-#include "../third_party/musl/musl/src/stdlib/atoi.c"
+#include "../third_party/musl/crt/musl/src/stdlib/atoi.c"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,11 @@
+.NOTPARALLEL:
+
 TOP=$(abspath ..)
 include $(TOP)/defs.mak
 
 DIRS =
+
+DIRS += myst
 
 ifdef MYST_ENABLE_EXT2FS
 DIRS += ext2
@@ -35,7 +39,6 @@ DIRS += nbio
 DIRS += thread
 DIRS += gdb
 DIRS += dlopen
-DIRS += myst
 DIRS += pipe
 DIRS += spawn
 DIRS += fstat
@@ -53,7 +56,13 @@ DIRS += pipesz
 DIRS += futex
 DIRS += round
 DIRS += signal
+DIRS += tlscert
+DIRS += wake_and_kill
+
+ifndef MYST_SKIP_LIBCXX_TESTS
 DIRS += libcxx
+endif
+
 DIRS += tlscert
 DIRS += wake_and_kill
 

--- a/tests/alpine/Makefile
+++ b/tests/alpine/Makefile
@@ -5,7 +5,10 @@ URL=https://nl.alpinelinux.org/alpine/v3.12/releases/x86_64/alpine-minirootfs-3.
 
 TARGZ=alpine-minirootfs.tar.gz
 
-all: myst appdir rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) appdir
+	$(MAKE) rootfs
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/cpuid/Makefile
+++ b/tests/cpuid/Makefile
@@ -9,7 +9,9 @@ ifdef STRACE
 OPTS = --strace
 endif
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: cpuid.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/curl/Makefile
+++ b/tests/curl/Makefile
@@ -13,7 +13,10 @@ ifdef EXPORT
 OPTS = --export-rootfs
 endif
 
-all: myst appdir rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) appdir
+	$(MAKE) rootfs
 
 tests:
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /curl https://www.microsoft.com 2>&1 > /dev/null

--- a/tests/dladdr/Makefile
+++ b/tests/dladdr/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -rdynamic -Wall -g -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: dladdr.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/dlopen/Makefile
+++ b/tests/dlopen/Makefile
@@ -4,7 +4,9 @@ include $(TOP)/defs.mak
 IMG=myst-alpine
 APPDIR=$(CURDIR)/appdir
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: $(APPDIR)/dlopen
 	$(BINDIR)/myst mkcpio appdir rootfs

--- a/tests/dup/Makefile
+++ b/tests/dup/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: dup.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/envp/Makefile
+++ b/tests/envp/Makefile
@@ -7,7 +7,9 @@ LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
 export UUID_051005DCD0B0448AAD4746E8538F4D81=12345
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: envp.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/epoll/Makefile
+++ b/tests/epoll/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: epoll.c server.c client.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/ext2/crypt/Makefile
+++ b/tests/ext2/crypt/Makefile
@@ -10,7 +10,9 @@ KEYFILE=$(SUBOBJDIR)/keyfile
 KEY := $(shell cat $(KEYFILE) | hexdump -v -e '/1 "%02x"' 2> /dev/null)
 ROOTHASH=$(SUBOBJDIR)/roothash
 
-all: deps rootfs
+all:
+	$(MAKE) deps
+	$(MAKE) rootfs
 
 rootfs: main.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/ext2/verity/Makefile
+++ b/tests/ext2/verity/Makefile
@@ -10,7 +10,9 @@ ROOTHASH=$(SUBOBJDIR)/roothash
 PUBKEY=$(SUBOBJDIR)/public.pem
 PRIVKEY=$(SUBOBJDIR)/private.pem
 
-all: deps rootfs
+all:
+	$(MAKE) deps
+	$(MAKE) rootfs
 
 rootfs: main.c $(PUBKEY)
 	mkdir -p $(APPDIR)/bin

--- a/tests/fstat/Makefile
+++ b/tests/fstat/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: fstat.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/futex/Makefile
+++ b/tests/futex/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: futex.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/gdb/Makefile
+++ b/tests/gdb/Makefile
@@ -18,7 +18,9 @@ GDB_MATCH=Breakpoint 1, .................. in print_hello ()
 # runtest timeouts cause gdb to hang
 export NOTIMEOUT=1
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: helloworld.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/getcwd/Makefile
+++ b/tests/getcwd/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: getcwd.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/getpid/Makefile
+++ b/tests/getpid/Makefile
@@ -5,10 +5,12 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: getpid.c
-	mkdir -p $(APPDIR)/bin
+	 mkdir -p $(APPDIR)/bin
 	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/getpid getpid.c $(LDFLAGS)
 	$(MYST) mkcpio $(APPDIR) rootfs
 

--- a/tests/hello/Makefile
+++ b/tests/hello/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: hello.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/hostfs/Makefile
+++ b/tests/hostfs/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: hostfs.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/ids/Makefile
+++ b/tests/ids/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: ids.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/inotify/Makefile
+++ b/tests/inotify/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: inotify.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/libc/Makefile
+++ b/tests/libc/Makefile
@@ -1,3 +1,5 @@
+.NOTPARALLEL:
+
 TOP = $(abspath ../..)
 include $(TOP)/defs.mak
 
@@ -28,7 +30,7 @@ $(APPDIR):
 	cp $(CURDIR)/failed.txt $(APPDIR)
 
 $(APPDIR)/target:
-	sudo docker run --rm -v $(APPDIR):/appdir $(IMG) bash -c "make -C appdir"
+	sudo docker run --rm -v $(APPDIR):/appdir $(IMG) bash -c "make -j -C appdir"
 	touch $(APPDIR)/target
 
 ifdef FAILED

--- a/tests/libcxx/Makefile
+++ b/tests/libcxx/Makefile
@@ -24,9 +24,16 @@ else
   TEST_FILE2 = builttests_exe2.passed
   TEST_FILE3 = builttests_exe3.passed
   STATUS=PASSED
+  export TIMEOUT=10000
 endif
 
-all: clean myst $(APPDIR) $(APPDIR)/bin/run $(ROOTFS) $(ROOTHASH)
+all:
+	$(MAKE) clean
+	$(MAKE) myst
+	$(MAKE) $(APPDIR)
+	$(MAKE) $(APPDIR)/bin/run
+	$(MAKE) $(ROOTFS)
+	$(MAKE) $(ROOTHASH)
 
 libcxx-tests: llvm-project
 	mkdir libcxx-tests

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -7,7 +7,9 @@ APPBUILDER=$(TOP)/scripts/appbuilder
 TEST_FILE=ltp_enabled.txt
 TESTS=$(shell cat $(TEST_FILE))
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 $(APPDIR): buildltp.sh
 	@ rm -fr ltp

--- a/tests/myst/exec-signed-1/Makefile
+++ b/tests/myst/exec-signed-1/Makefile
@@ -40,8 +40,8 @@ build: clean-exec-signed-1
 mkcpio: build
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
 
-sign: mkcpio pem 
+sign: mkcpio pem
 	$(PREFIX) $(MYST) sign rootfs private.pem config.json
 
-run: sign 
+run: sign
 	$(PREFIX) $(APPNAME).signed/bin/myst $(EXEC) $(APPNAME).signed/rootfs /bin/$(APPNAME) red green blue yellow

--- a/tests/myst/exec-signed-2/Makefile
+++ b/tests/myst/exec-signed-2/Makefile
@@ -10,7 +10,7 @@ REDEFINE_TESTS=1
 
 include $(TOP)/rules.mak
 
-tests:	
+tests:
 	$(RUNTEST) $(MAKE) exec-signed
 
 exec-signed:

--- a/tests/nbio/Makefile
+++ b/tests/nbio/Makefile
@@ -7,7 +7,9 @@ LDFLAGS = -Wl,-rpath=/lib -L$(APPDIR)/lib
 
 export LD_LIBRARY_PATH=$(APPDIR)/lib
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: nbio.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/oe/gencreds/Makefile
+++ b/tests/oe/gencreds/Makefile
@@ -7,7 +7,9 @@ LDFLAGS += -L$(LIBDIR) -lopenenclave
 
 INCLUDES += $(OEENCLAVE_INCLUDES)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: gencreds.c
 	mkdir -p $(SUBBINDIR)

--- a/tests/oe/seal/Makefile
+++ b/tests/oe/seal/Makefile
@@ -7,7 +7,9 @@ LDFLAGS += -L$(LIBDIR) -lopenenclave -lmbedcrypto
 
 INCLUDES += $(OEENCLAVE_INCLUDES)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: seal.c
 	mkdir -p $(SUBBINDIR)

--- a/tests/pipe/Makefile
+++ b/tests/pipe/Makefile
@@ -5,7 +5,9 @@ CFLAGS = -Wall -g -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 APPDIR = $(SUBOBJDIR)/appdir
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: pipe.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/pipesz/Makefile
+++ b/tests/pipesz/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: pipesz.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/poll/Makefile
+++ b/tests/poll/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: poll.c server.c client.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/pollpipe/Makefile
+++ b/tests/pollpipe/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: pollpipe.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/popen/Makefile
+++ b/tests/popen/Makefile
@@ -5,7 +5,9 @@ APPDIR = $(SUBOBJDIR)/appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: popen.c sh.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/pthread/Makefile
+++ b/tests/pthread/Makefile
@@ -4,7 +4,9 @@ include $(TOP)/defs.mak
 CFLAGS = -Wall -g -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: pthread.c
 	mkdir -p appdir/bin

--- a/tests/rdtsc/Makefile
+++ b/tests/rdtsc/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: rdtsc.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/sendmsg/Makefile
+++ b/tests/sendmsg/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: sendmsg.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/shlib/Makefile
+++ b/tests/shlib/Makefile
@@ -7,7 +7,9 @@ LDFLAGS = -Wl,-rpath=/lib -L$(APPDIR)/lib -lfoo
 
 export LD_LIBRARY_PATH=$(APPDIR)/lib
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: foo.c shlib.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/signal/Makefile
+++ b/tests/signal/Makefile
@@ -7,7 +7,9 @@ LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
 #OPTS = --strace
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: signal.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/sockets/Makefile
+++ b/tests/sockets/Makefile
@@ -5,7 +5,9 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: sockets.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/spawn/Makefile
+++ b/tests/spawn/Makefile
@@ -5,7 +5,9 @@ APPDIR = $(SUBOBJDIR)/appdir
 CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: spawn.c child.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/sysinfo/Makefile
+++ b/tests/sysinfo/Makefile
@@ -6,7 +6,9 @@ APPDIR = appdir
 CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: $(PROG).c
 	mkdir -p $(APPDIR)/bin

--- a/tests/system/Makefile
+++ b/tests/system/Makefile
@@ -5,7 +5,9 @@ APPDIR = $(SUBOBJDIR)/appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: system.c sh.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/thread/Makefile
+++ b/tests/thread/Makefile
@@ -6,7 +6,9 @@ CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 CC = $(MUSL_GCC)
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: thread.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/tlscert/Makefile
+++ b/tests/tlscert/Makefile
@@ -4,7 +4,9 @@ include $(TOP)/defs.mak
 APPDIR = appdir
 CFLAGS = -fPIC -g
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: tlscert.c
 	mkdir -p $(APPDIR)/

--- a/tests/urandom/Makefile
+++ b/tests/urandom/Makefile
@@ -7,7 +7,9 @@ LDFLAGS = -Wl,-rpath=/lib -L$(APPDIR)/lib
 
 export LD_LIBRARY_PATH=$(APPDIR)/lib
 
-all: myst rootfs
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
 
 rootfs: urandom.c
 	mkdir -p $(APPDIR)/bin

--- a/tests/wake_and_kill/Makefile
+++ b/tests/wake_and_kill/Makefile
@@ -6,7 +6,8 @@ APPDIR = appdir
 CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-all: rootfs
+all:
+	$(MAKE) rootfs
 
 rootfs: $(PROG).c
 	mkdir -p $(APPDIR)/bin

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -4,3 +4,6 @@ include $(TOP)/defs.mak
 DIRS = openenclave musl mbedtls libc-test
 
 include $(TOP)/rules.mak
+
+distclean:
+	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) distclean $(NL) )

--- a/third_party/mbedtls/Makefile
+++ b/third_party/mbedtls/Makefile
@@ -3,9 +3,42 @@ include $(TOP)/defs.mak
 
 INSTALL_PREFIX=$(BUILDDIR)/mbedtls
 
-all: mbedtls
+URL=https://github.com/ARMmbed/mbedtls
+
+BRANCH=mbedtls-2.16
+
+# get the hash of the remote github repository (for the given branch)
+HASH=$(shell git ls-remote $(URL) -b $(BRANCH) | cut -f1 )
+
+CACHE_DIR=$(HOME)/.mystikos/cache/mbedtls
+
+ifdef MYST_USE_BUILD_CACHE
+CACHE_CHECK=$(wildcard $(CACHE_DIR)/$(HASH))
+endif
+
+all:
+ifeq ($(CACHE_CHECK),)
+	$(MAKE) mbedtls
+	$(MAKE) build
+else
+	$(MAKE) fetch_cache
+endif
+
+build:
 	rm -rf $(INSTALL_PREFIX)
 	$(MAKE) -C mbedtls install DESTDIR=$(INSTALL_PREFIX)
+	$(MAKE) cache
+
+fetch_cache:
+	rm -rf $(INSTALL_PREFIX)
+	cp -r $(CACHE_DIR)/$(HASH) $(INSTALL_PREFIX)
+
+cache:
+ifdef MYST_USE_BUILD_CACHE
+	rm -rf $(CACHE_DIR)/$(HASH)
+	mkdir -p $(CACHE_DIR)
+	cp -r $(INSTALL_PREFIX) $(CACHE_DIR)/$(HASH)
+endif
 
 clean:
 	( /usr/bin/test ! -d mbedtls || $(MAKE) -C mbedtls clean )
@@ -14,4 +47,7 @@ distclean:
 	rm -rf mbedtls
 
 mbedtls:
-	git clone https://github.com/ARMmbed/mbedtls -b mbedtls-2.16
+	git clone $(URL) -b $(BRANCH)
+
+hash:
+	echo $(HASH)

--- a/third_party/musl/Makefile
+++ b/third_party/musl/Makefile
@@ -1,6 +1,9 @@
 TOP = $(abspath $(CURDIR)/../..)
 include $(TOP)/defs.mak
 
-DIRS = submodule pristine crt
+DIRS = pristine crt
 
 include $(TOP)/rules.mak
+
+distclean:
+	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) distclean $(NL) )

--- a/third_party/musl/crt/Makefile
+++ b/third_party/musl/crt/Makefile
@@ -2,6 +2,19 @@ TOP=$(abspath ../../..)
 include $(TOP)/defs.mak
 include $(TOP)/config.mak
 
+URL=git://git.musl-libc.org/musl
+
+BRANCH=v1.2.0
+
+# get the hash of the remote github repository (for the given branch)
+HASH=$(shell git ls-remote $(URL) -b $(BRANCH) | cut -f1 )
+
+CACHE_DIR=$(HOME)/.mystikos/cache/musl/crt
+
+ifdef MYST_USE_BUILD_CACHE
+CACHE_CHECK=$(wildcard $(CACHE_DIR)/$(HASH))
+endif
+
 WHICH_GCC = $(shell which gcc)
 
 CFLAGS = -g -Werror -fPIC
@@ -14,45 +27,62 @@ ifdef MYST_ENABLE_GCOV
 CFLAGS += -fprofile-arcs -ftest-coverage
 endif
 
-MUSLSRC=$(BUILDDIR)/crt-musl
-
 THISDIR=$(CURDIR)
 
-all: muslsrc $(MUSLSRC)/config.mak
-	( cd $(MUSLSRC); $(MAKE) CC="$(WHICH_GCC) $(CFLAGS)" )
+all:
+ifeq ($(CACHE_CHECK),)
+	$(MAKE) build
+else
+	$(MAKE) fetch_cache
+endif
+
+fetch_cache:
+	rm -rf musl
+	cp -r $(CACHE_DIR)/$(HASH) musl
+
+build:
+	$(MAKE) musl
+	$(MAKE) musl/config.mak
+	( cd musl; $(MAKE) CC="$(WHICH_GCC) $(CFLAGS)" )
+	$(MAKE) cache
+
+cache:
+ifdef MYST_USE_BUILD_CACHE
+	rm -rf $(CACHE_DIR)/$(HASH)
+	mkdir -p $(CACHE_DIR)
+	cp -r musl $(CACHE_DIR)/$(HASH)
+endif
 
 clean:
-ifneq ($(wildcard $(MUSLSRC)),)
-	( cd $(MUSLSRC) && make clean )
-	rm -f $(MUSLSRC)/config.mak
+ifneq ($(wildcard musl),)
+	( cd musl && make clean )
+	rm -f musl/config.mak
 endif
 
 distclean:
-ifneq ($(wildcard $(MUSLSRC)),)
-	( cd $(MUSLSRC); make distclean )
+ifneq ($(wildcard musl),)
+	rm -rf musl
 endif
 
-$(MUSLSRC)/config.mak:
-	( cd $(MUSLSRC); ./configure --enable-debug=yes --disable-optimize )
+musl/config.mak:
+	( cd musl; ./configure --enable-debug=yes --disable-optimize )
 
 tests:
 
-genpatch: $(MUSLSRC)
+genpatch: musl
 	rm -f patch.diff
-	( cd $(MUSLSRC); git diff > $(THISDIR)/patch.diff )
-	( cd $(MUSLSRC); git diff --cached >> $(THISDIR)/patch.diff )
+	( cd musl; git diff > $(THISDIR)/patch.diff )
+	( cd musl; git diff --cached >> $(THISDIR)/patch.diff )
 
 PATCHDIR=$(TOP)/third_party/musl/crt
-
-muslsrc: $(MUSLSRC)
 
 NEWFILES =
 NEWFILES += src/internal/__popcountdi2.c
 NEWFILES += src/stdio/__fprintf_chk.c
 NEWFILES += src/stdio/__vfprintf_chk.c
 
-$(MUSLSRC):
+musl:
 	mkdir -p $(BUILDDIR)
-	git clone git://git.musl-libc.org/musl -b v1.2.0 $(MUSLSRC)
-	( cd $(MUSLSRC); git apply $(PATCHDIR)/patch.diff )
-	$(foreach i, $(NEWFILES), ( cd $(MUSLSRC); git add $(i) ); $(NL) )
+	git clone $(URL) -b $(BRANCH) musl
+	( cd musl; git apply $(PATCHDIR)/patch.diff )
+	$(foreach i, $(NEWFILES), ( cd musl; git add $(i) ); $(NL) )

--- a/third_party/musl/pristine/Makefile
+++ b/third_party/musl/pristine/Makefile
@@ -1,25 +1,55 @@
 TOP=$(abspath ../../.. )
 include $(TOP)/defs.mak
 
-PREFIX=$(TOP)/build/musl
+URL=git://git.musl-libc.org/musl
 
-MUSL_SRCDIR=$(BUILDDIR)/pristine-musl
+BRANCH=v1.2.0
 
-all: $(MUSL_SRCDIR) $(MUSL_SRCDIR)/config.mak
-	( cd $(MUSL_SRCDIR); make )
-	( cd $(MUSL_SRCDIR); make install )
+# get the hash of the remote github repository (for the given branch)
+HASH=$(shell git ls-remote $(URL) -b $(BRANCH) | cut -f1 )
+
+CACHE_DIR=$(HOME)/.mystikos/cache/musl/pristine
+
+ifdef MYST_USE_BUILD_CACHE
+CACHE_CHECK=$(wildcard $(CACHE_DIR)/$(HASH))
+endif
+
+PREFIX=$(BUILDDIR)/musl
+
+all:
+ifeq ($(CACHE_CHECK),)
+	$(MAKE) build
+else
+	$(MAKE) fetch_cache
+endif
+
+build:
+	$(MAKE) musl
+	$(MAKE) musl/config.mak
+	( cd musl; make install )
+	$(MAKE) cache
+
+fetch_cache:
+	rm -rf $(PREFIX)
+	mkdir -p $(BUILDDIR)
+	cp -r $(CACHE_DIR)/$(HASH) $(PREFIX)
+
+cache:
+ifdef MYST_USE_BUILD_CACHE
+	rm -rf $(CACHE_DIR)/$(HASH)
+	mkdir -p $(CACHE_DIR)
+	cp -r $(PREFIX) $(CACHE_DIR)/$(HASH)
+endif
 
 clean:
-	rm -rf $(MUSL_SRCDIR)
+	rm -rf musl
 
 distclean: clean
 
-$(MUSL_SRCDIR)/config.mak:
-	( cd $(MUSL_SRCDIR); ./configure --prefix=$(PREFIX) )
+musl/config.mak:
+	( cd musl; ./configure --prefix=$(PREFIX) )
 
-$(MUSL_SRCDIR):
-	rm -rf $(MUSL_SRCDIR)
-	mkdir -p $(BUILDDIR)
-	cp -r ../musl $(MUSL_SRCDIR)
+musl:
+	git clone $(URL) -b $(BRANCH)
 
 tests:

--- a/third_party/musl/submodule/Makefile
+++ b/third_party/musl/submodule/Makefile
@@ -1,4 +1,0 @@
-all:
-	(cd ..; git submodule update --init musl )
-
-clean:

--- a/third_party/openenclave/Makefile
+++ b/third_party/openenclave/Makefile
@@ -1,18 +1,30 @@
+.NOTPARALLEL:
+
 TOP=$(abspath $(CURDIR)/../..)
 
 BUILDDIR=${TOP}/build
 
-OECACHE_DIR=$(HOME)/.myst/oecache
+URL=https://github.com/openenclave/openenclave
+
+BRANCH=mystikos
+
+# get the hash of the remote github repository (for the given branch)
+HASH=$(shell git ls-remote $(URL) -b $(BRANCH) | cut -f1 )
+
+CACHE_DIR=$(HOME)/.mystikos/cache/openenclave
+
+CACHE=$(CACHE_DIR)/$(HASH)
 
 all: $(BUILDDIR)/include/openenclave
 
-ifdef MYST_USE_OECACHE
-OECACHE_CHECK=$(wildcard $(OECACHE_DIR)/__oe__/include/openenclave/enclave.h)
+ifdef MYST_USE_BUILD_CACHE
+CACHE_CHECK=$(wildcard $(CACHE))
+ANSIBLE_CACHE_CHECK=$(wildcard $(CACHE)/ansible.cache)
 endif
 
 $(BUILDDIR)/include/openenclave:
-ifeq ($(OECACHE_CHECK),)
-	$(MAKE) submodules
+ifeq ($(CACHE_CHECK),)
+	$(MAKE) submodule
 	$(MAKE) openenclave
 else
 	$(MAKE) fetch_oecache
@@ -23,7 +35,7 @@ fetch_oecache: $(TOP)/build/openenclave $(TOP)/build/bin/myst-gdb
 $(TOP)/build/openenclave:
 	mkdir -p $(BUILDDIR)
 	rm -rf $(BUILDDIR)/openenclave
-	cp -r $(OECACHE_DIR)/__oe__ $(BUILDDIR)/openenclave
+	cp -r $(CACHE) $(BUILDDIR)/openenclave
 
 $(TOP)/build/bin/myst-gdb:
 	mkdir -p $(BUILDDIR)/bin
@@ -32,12 +44,12 @@ $(TOP)/build/bin/myst-gdb:
 
 ##==============================================================================
 ##
-## submodules:
+## submodule:
 ##
 ##==============================================================================
 
-submodules:
-	git submodule update --recursive --init --progress
+submodule:
+	git submodule update --recursive --init --progress $(CURDIR)/openenclave
 
 ##==============================================================================
 ##
@@ -48,7 +60,6 @@ submodules:
 OPENENCLAVE_INSTALL_PREFIX=$(BUILDDIR)/openenclave
 
 OPENENCLAVE_SRC = $(CURDIR)/openenclave
-
 OPENENCLAVE_BUILD = $(CURDIR)/openenclave/build
 
 .PHONY: openenclave
@@ -59,11 +70,21 @@ DEPENDENCY_TARGET = $(OPENENCLAVE_BUILD)/dependency_target
 openenclave: $(DEPENDENCY_TARGET) configure_oe install_oe
 
 $(DEPENDENCY_TARGET):
-ifneq ($(MYST_IGNORE_PREREQS),1)
-	sudo $(OPENENCLAVE_SRC)/scripts/ansible/install-ansible.sh
-	sudo ansible-playbook $(OPENENCLAVE_SRC)/scripts/ansible/oe-contributors-acc-setup-no-driver.yml
+ifeq ($(ANSIBLE_CACHE_CHECK),)
+	$(MAKE) ansible
+	mkdir -p $(CACHE)
+	touch $(CACHE)/ansible.cache
 endif
 	mkdir -p $(OPENENCLAVE_BUILD)
+
+ansible:
+ifneq ($(MYST_IGNORE_ANSIBLE),1)
+	$(MAKE) __ansible
+endif
+
+__ansible:
+	sudo $(OPENENCLAVE_SRC)/scripts/ansible/install-ansible.sh
+	sudo ansible-playbook $(OPENENCLAVE_SRC)/scripts/ansible/oe-contributors-acc-setup-no-driver.yml
 
 configure_oe: $(OPENENCLAVE_BUILD)/Makefile
 
@@ -83,14 +104,15 @@ $(OPENENCLAVE_BUILD)/Makefile:
 	rm -rf $(OPENENCLAVE_BUILD)
 	mkdir -p $(OPENENCLAVE_BUILD)
 	touch $(DEPENDENCY_TARGET)
-	( cd $(OPENENCLAVE_BUILD); cmake $(CMAKE_OPTS) .. )
+	( cd $(OPENENCLAVE_BUILD); cmake $(CMAKE_OPTS) $(OPENENCLAVE_SRC) )
 
 install_oe:
 	$(MAKE) -C $(OPENENCLAVE_BUILD) install
-ifdef MYST_USE_OECACHE
-	rm -rf $(OECACHE_DIR)
-	$(MAKE) -C $(OPENENCLAVE_BUILD) install DESTDIR=$(OECACHE_DIR)
-	mv $(OECACHE_DIR)/$(OPENENCLAVE_INSTALL_PREFIX) $(OECACHE_DIR)/__oe__
+ifdef MYST_USE_BUILD_CACHE
+	rm -rf $(CACHE)
+	$(MAKE) -C $(OPENENCLAVE_BUILD) install DESTDIR=$(CACHE_DIR)/tmp
+	mv $(CACHE_DIR)/tmp/$(OPENENCLAVE_INSTALL_PREFIX) $(CACHE)
+	rm -rf $(CACHE_DIR)/tmp
 endif
 	mkdir -p $(TOP)/build/bin
 	rm -f $(TOP)/build/bin/myst-gdb


### PR DESCRIPTION
This change supports parallel builds (make -j) and adds caching of third-party build artifacts (binaries, installed files, libraries, etc.). For details on how to use see:

https://github.com/deislabs/mystikos/blob/57584fa606a08a0b70555c8338a0613ec2898d1b/doc/build-cache-howto.md

Currently only third-party packages are cached. Later support might be added for caching other binaries that are expensive to build.

Total build times are shown for an **Intel Core i7**  bare-metal machine (**NUC7JY**), including a fresh checkout and build.

- **9 min 3 sec** (non-parallel build with **make**)
- **5 min 40 sec** (parallel build with **make -j**)
- **1 min 6 sec** (non-parallel build with caching enabled)
- **0 min 59 sec** (non-parallel build with caching enabled)