### PR TITLE
partial OE submodule checkout optimization

### DIFF
--- a/third_party/openenclave/Makefile
+++ b/third_party/openenclave/Makefile
@@ -48,8 +48,13 @@ $(TOP)/build/bin/myst-gdb:
 ##
 ##==============================================================================
 
+FETCH_SUBMODULE = git submodule update --init --progress
+
 submodule:
-	git submodule update --recursive --init --progress $(CURDIR)/openenclave
+	$(FETCH_SUBMODULE) $(CURDIR)/openenclave
+	( cd openenclave; $(FETCH_SUBMODULE) tools/oeedger8r-cpp )
+	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/mbedtls/mbedtls )
+	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/snmalloc )
 
 ##==============================================================================
 ##


### PR DESCRIPTION
This change optimizes the OE submodule checkout process by only checking out what is actually needed to perform the build.