### PR TITLE
msync system call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,10 @@ tests/hostfs/appdir/
 tests/ext2/crypt/appdir/
 tests/ext2/verity/appdir/
 tests/myst/exec-package-ext2/myst/
+tests/msync/appdir/
+tests/tlscert/appdir/
+tests/wake_and_kill/appdir/
+third_party/musl/crt/musl/
+tests/msync/tests
+tests/network/appdir/
+third_party/musl/pristine/musl/

--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -38,4 +38,8 @@ int myst_register_process_mapping(pid_t pid, void* addr, size_t size);
 
 int myst_release_process_mappings(pid_t pid);
 
+int myst_msync(void* addr, size_t length, int flags);
+
+int myst_mman_close_notify(int fd);
+
 #endif /* _MYST_MMANUTILS_H */

--- a/kernel/libc.c
+++ b/kernel/libc.c
@@ -720,7 +720,7 @@ ssize_t pread(int fd, void* buf, size_t count, off_t offset)
     return myst_syscall_ret(myst_syscall_pread(fd, buf, count, offset));
 }
 
-ssize_t myst_pwrite(int fd, const void* buf, size_t count, off_t offset)
+ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset)
 {
     return myst_syscall_ret(myst_syscall_pwrite(fd, buf, count, offset));
 }
@@ -798,6 +798,15 @@ ssize_t readlink(const char* pathname, char* buf, size_t bufsiz)
 int symlink(const char* target, const char* linkpath)
 {
     return (int)myst_syscall_ret(myst_syscall_symlink(target, linkpath));
+}
+
+int fcntl(int fd, int cmd, ...)
+{
+    va_list ap;
+    va_start(ap, cmd);
+    long arg = va_arg(ap, long);
+    va_end(ap);
+    return (int)myst_syscall_ret(myst_syscall_fcntl(fd, cmd, arg));
 }
 
 /*

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -734,6 +734,7 @@ long myst_syscall_close(int fd)
 
     ECHECK((*fdops->fd_close)(device, object));
     ECHECK(myst_fdtable_remove(fdtable, fd));
+    ECHECK(myst_mman_close_notify(fd));
 
 done:
     return ret;
@@ -2717,8 +2718,7 @@ long myst_syscall(long n, long params[6])
 
             _strace(n, "addr=%p length=%zu flags=%d ", addr, length, flags);
 
-            /* ATTN: hook up implementation */
-            BREAK(_return(n, 0));
+            BREAK(_return(n, myst_msync(addr, length, flags)));
         }
         case SYS_mincore:
             /* ATTN: hook up implementation */

--- a/tests/msync/Makefile
+++ b/tests/msync/Makefile
@@ -1,0 +1,40 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+TARGET2=$(SUBOBJDIR)/msync
+
+all:
+	$(MAKE) myst
+	$(MAKE) $(TARGET2)
+	$(MAKE) rootfs
+
+rootfs: msync.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/msync msync.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+$(TARGET2): msync.c
+	mkdir -p $(SUBOBJDIR)
+	$(CC) $(CFLAGS) msync.c -o $(TARGET2)
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+tests: test1 test2
+
+test1:
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/msync $(OPTS)
+
+test2:
+	$(TARGET2)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs $(TARGET2)

--- a/tests/msync/msync.c
+++ b/tests/msync/msync.c
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 4096
+#endif
+
+static int _writen(int fd, const void* data, size_t size)
+{
+    ssize_t ret = -1;
+    const uint8_t* p = (const uint8_t*)data;
+    size_t r = size;
+
+    while (r > 0)
+    {
+        ssize_t n = write(fd, p, r);
+
+        if (n == 0)
+            break;
+        else if (n < 0)
+            goto done;
+
+        p += n;
+        r -= (size_t)n;
+    }
+
+    ret = 0;
+
+done:
+
+    return ret;
+}
+
+static int _readn(int fd, void* data, size_t size)
+{
+    ssize_t ret = -1;
+    uint8_t* p = (uint8_t*)data;
+    size_t r = size;
+
+    while (r > 0)
+    {
+        ssize_t n = read(fd, p, r);
+
+        if (n <= 0)
+            goto done;
+
+        p += n;
+        r -= (size_t)n;
+    }
+
+    ret = 0;
+
+done:
+
+    return ret;
+}
+
+static bool _check_page(uint8_t page[PAGE_SIZE], uint8_t byte)
+{
+    for (size_t i = 0; i < PAGE_SIZE; i++)
+    {
+        if (page[i] != byte)
+            return false;
+    }
+
+    return true;
+}
+
+int main(int argc, const char* argv[])
+{
+    const size_t num_pages = 8;
+    uint8_t page[PAGE_SIZE];
+    int fd;
+    struct stat st;
+
+    /* create a new file */
+    assert((fd = open("/msync", O_CREAT | O_TRUNC | O_RDWR, 0666)) >= 0);
+
+    /* create a file where each page is filled with a specific byte value */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        const uint8_t byte = (uint8_t)i;
+        memset(page, byte, sizeof(page));
+        assert(_writen(fd, page, sizeof(page)) == 0);
+    }
+
+    /* check the size of the file */
+    assert(fstat(fd, &st) == 0);
+    assert(st.st_size == num_pages * sizeof(page));
+
+    /* map the file onto memory */
+    const size_t length = st.st_size;
+    const int prot = PROT_READ | PROT_WRITE;
+    const int flags = MAP_PRIVATE | MAP_SHARED;
+    uint8_t* addr = mmap(NULL, length, prot, flags, fd, 0);
+    assert(addr != MAP_FAILED);
+
+    /* perform a second mapping of the same file */
+    uint8_t* addr2 = mmap(NULL, length, prot, flags, fd, 0);
+    assert(addr2 != MAP_FAILED);
+
+    /* touch every byte of the mapping (causing it to be paged in) */
+    {
+        int sum = 0;
+
+        for (size_t i = 0; i < num_pages * PAGE_SIZE; i++)
+        {
+            sum += addr2[i];
+        }
+
+        printf("sum=%d\n", sum);
+    }
+
+    /* check that the memory mapped image matches the file */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        /* check that the current page consists of the given byte */
+        uint8_t* p = addr + (i * PAGE_SIZE);
+        const uint8_t byte = (uint8_t)i;
+        assert(_check_page(p, byte) == true);
+    }
+
+    /* update the memory mapped image by changing the page byte values */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        uint8_t* p = addr + (i * PAGE_SIZE);
+        const uint8_t byte = (uint8_t)(i + 1);
+        memset(p, byte, PAGE_SIZE);
+    }
+
+    /* sync the pages back to disk one page at a time */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        uint8_t* p = addr + (i * PAGE_SIZE);
+        assert(msync(p, PAGE_SIZE, MS_SYNC) == 0);
+    }
+
+    /* check that the other memory mapped (addr2) region was also updated */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        /* check that the current page consists of the given byte */
+        uint8_t* p = addr2 + (i * PAGE_SIZE);
+        const uint8_t byte = (uint8_t)(i + 1);
+        assert(_check_page(p, byte) == true);
+    }
+
+    /* remove the memory mappings */
+    assert(munmap(addr, length) == 0);
+    assert(munmap(addr2, length) == 0);
+
+    /* close the file (which implicitly removes the file mapping) */
+    assert(close(fd) == 0);
+
+    /* reopen the file and check that it has actually changed */
+    {
+        assert((fd = open("/msync", O_RDONLY)) >= 0);
+
+        for (size_t i = 0; i < num_pages; i++)
+        {
+            const uint8_t byte = (uint8_t)(i + 1);
+            memset(page, 0, sizeof(page));
+            assert(_readn(fd, page, PAGE_SIZE) == 0);
+            assert(_check_page(page, byte) == true);
+        }
+
+        assert(close(fd) == 0);
+    }
+
+    printf("=== passed test (%s)\n", argv[0]);
+
+    return 0;
+}


### PR DESCRIPTION
Handle msync system call by adding **msync mapping structures** which are:
- created by mmap(), 
- flushed by msync(), and 
- freed by munmap() and close() (via myst_mman_close_notify).