### PR TITLE
Allow oe_num_mem_pages to be overridden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ tests/hostfs/appdir/
 tests/ext2/crypt/appdir/
 tests/ext2/verity/appdir/
 tests/myst/exec-package-ext2/myst/
+tests/libcxx/appdir/
+tests/tlscert/appdir/
+tests/wake_and_kill/appdir/

--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -249,7 +249,7 @@ long myst_syscall_sethostname(const char* hostname, size_t len);
 
 long myst_syscall_kill(int pid, int sig);
 
-long myst_syscall_sendfile(int out_fd, int in_fd, off_t *offset, size_t count);
+long myst_syscall_sendfile(int out_fd, int in_fd, off_t* offset, size_t count);
 
 long myst_syscall_sethostname(const char* hostname, size_t len);
 

--- a/kernel/sendfile.c
+++ b/kernel/sendfile.c
@@ -3,7 +3,7 @@
 #include <myst/eraise.h>
 #include <myst/syscall.h>
 
-long myst_syscall_sendfile(int out_fd, int in_fd, off_t *offset, size_t count)
+long myst_syscall_sendfile(int out_fd, int in_fd, off_t* offset, size_t count)
 {
     long ret = 0;
     ssize_t nwritten = 0;

--- a/tests/myst/exec-package/Makefile
+++ b/tests/myst/exec-package/Makefile
@@ -15,38 +15,28 @@ tests:
 	$(RUNTEST) $(MAKE) run-package-no-args
 	$(RUNTEST) $(MAKE) run-package-from-bin-dir
 
-run-package-with-args:
+package:
 	rm -rf $(APPDIR) result private.pem public.pem myst
 	openssl genrsa -out private.pem -3 3072
 	openssl rsa -in private.pem -pubout -out public.pem
 	mkdir -p $(APPDIR)/bin
 	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(VALGRIND) $(MYST) package $(APPDIR) private.pem config.json
+
+run-package-with-args: package
 	./myst/bin/$(APPNAME) red green blue yellow | grep -v TESTNAME > result
 	diff result expected-args
 	rm -rf $(APPDIR) result private.pem public.pem myst
-	@ echo "=== passed test (myst: exec-signed)"
+	@ echo "=== passed test (myst: exec-package-with-args)"
 
-run-package-no-args:
-	rm -rf $(APPDIR) result private.pem public.pem myst
-	openssl genrsa -out private.pem -3 3072
-	openssl rsa -in private.pem -pubout -out public.pem
-	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
-	$(PREFIX) $(VALGRIND) $(MYST) package $(APPDIR) private.pem config.json
+run-package-no-args: package
 	./myst/bin/$(APPNAME) | grep -v TESTNAME > result
 	diff result expected-no-args
 	rm -rf $(APPDIR) result private.pem public.pem myst
-	@ echo "=== passed test (myst: exec-signed)"
+	@ echo "=== passed test (myst: exec-package-no-args)"
 
-run-package-from-bin-dir:
-	rm -rf $(APPDIR) result private.pem public.pem myst
-	openssl genrsa -out private.pem -3 3072
-	openssl rsa -in private.pem -pubout -out public.pem
-	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
-	$(PREFIX) $(VALGRIND) $(MYST) package $(APPDIR) private.pem config.json
+run-package-from-bin-dir: package
 	( cd myst/bin && ./$(APPNAME) red green blue yellow | grep -v TESTNAME > result)
 	diff myst/bin/result expected-args
 	rm -rf $(APPDIR) result private.pem public.pem myst/
-	@ echo "=== passed test (myst: exec-signed)"
+	@ echo "=== passed test (myst: exec-package-from-bin-dir)"

--- a/tools/myst/host/exec.h
+++ b/tools/myst/host/exec.h
@@ -14,6 +14,7 @@ int exec_launch_enclave(
     uint32_t flags,
     const char* argv[],
     const char* envp[],
-    struct myst_options* options);
+    struct myst_options* options,
+    oe_sgx_enclave_properties_t* enclave_properties);
 
 #endif /* _MYST_HOST_EXEC_H */

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -15,9 +15,9 @@
 
 #include <myst/elf.h>
 #include <myst/getopt.h>
+#include <myst/strings.h>
 #include <openenclave/bits/sgx/region.h>
 #include <openenclave/host.h>
-#include <myst/strings.h>
 
 #include "../config.h"
 #include "archive.h"
@@ -31,7 +31,8 @@
 
 _Static_assert(PAGE_SIZE == 4096, "");
 
-#define USAGE_PACKAGE "\
+#define USAGE_PACKAGE \
+    "\
 \n\
 Usage:\n\
     %s package-sgx [options] <app_dir> <pem_file> <config>\n\
@@ -644,14 +645,13 @@ int _exec_package(
         if (myst_strlcpy(options.rootfs, env, sizeof(options.rootfs)) >=
             sizeof(options.rootfs))
         {
-            fprintf(stderr, "MYST_ROOTFS_PATH is too long (> %zu)\n",
+            fprintf(
+                stderr,
+                "MYST_ROOTFS_PATH is too long (> %zu)\n",
                 sizeof(options.rootfs));
             goto done;
         }
     }
-
-    parsed_data.oe_num_heap_pages =
-        (details->rootfs.buffer_size + (5 * 1024 * 1024)) / PAGE_SIZE;
 
     // build argv with application name. If we are allowed command line args
     // then append them also
@@ -689,7 +689,7 @@ int _exec_package(
     }
 
     ret = exec_launch_enclave(
-        scratch_path, type, flags, exec_args, envp, &options);
+        scratch_path, type, flags, exec_args, envp, &options, NULL);
     if (ret != 0)
     {
         fprintf(stderr, "Enclave %s returned %d\n", scratch_path, ret);

--- a/tools/myst/host/regions.h
+++ b/tools/myst/host/regions.h
@@ -21,6 +21,7 @@ typedef struct _region_details_item
 typedef struct _region_details
 {
     size_t mman_size;
+    size_t oe_num_heap_pages;
     region_details_item enc;
     region_details_item crt;
     region_details_item kernel;

--- a/tools/myst/host/sign.c
+++ b/tools/myst/host/sign.c
@@ -367,8 +367,7 @@ int _sign(int argc, const char* argv[])
     struct stat st;
     stat(rootfs_file, &st);
 
-    parsed_data.oe_num_heap_pages =
-        (st.st_size + (5 * 1024 * 1024)) / PAGE_SIZE;
+    parsed_data.oe_num_heap_pages = make_oe_num_heap_pages(st.st_size);
 
     if (write_oe_config_fd(fd, &parsed_data) != 0)
     {

--- a/tools/myst/host/utils.h
+++ b/tools/myst/host/utils.h
@@ -4,7 +4,8 @@
 #ifndef _HOST_MYST_UTILS_H
 #define _HOST_MYST_UTILS_H
 
-#include <limits.h>
+#include <myst/defs.h>
+#include <sys/user.h>
 
 // default size used for user app memory
 #define DEFAULT_MMAN_SIZE (64 * 1024 * 1024)
@@ -33,5 +34,10 @@ int cli_getopt(
     const char* argv[],
     const char* opt,
     const char** optarg);
+
+MYST_INLINE uint64_t make_oe_num_heap_pages(off_t rootfs_size)
+{
+    return ((rootfs_size + (50 * 1024 * 1024)) / PAGE_SIZE);
+}
 
 #endif /* _HOST_MYST_UTILS_H */


### PR DESCRIPTION
Calculation of this setting is done via sighing and packaging.
If the unsigned version is used it uses the default enclave setting
which is not always big enough.
This change allows that setting to be updated for unsigned binaries.
This changed also updated algorithm a little as the reserved space was
not enough for a number of scenarios.

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>