### PR TITLE
Support parallel libcxx tests

### DIFF
--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -49,7 +49,7 @@ jobs:
 
       # run all tests
       - script: |
-          make tests ALLTESTS=1 VERBOSE=1
+          make -j tests ALLTESTS=1 VERBOSE=1
         displayName: 'run all tests'
         continueOnError: true
         enabled: true

--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -43,7 +43,7 @@ jobs:
 
       # build all source files
       - script: |
-          make clean && make
+          make clean && make -j
         displayName: 'build repo source'
         workingDirectory: $(Build.SourcesDirectory)
 

--- a/tests/libcxx/Makefile
+++ b/tests/libcxx/Makefile
@@ -91,10 +91,21 @@ $(ROOTHASH): run.c
 OPTS += --roothash=$(ROOTHASH)
 
 tests:
-	$(RUNTEST) $(MYST_EXEC) --user-mem-size 1024m $(OPTS) $(ROOTFS) /bin/run $(STATUS) $(TEST_FILE1)
+	$(RUNTEST) $(MAKE) __tests
+
+__tests: test1 test2 test3
+
+test1:
+	$(MYST_EXEC) --user-mem-size 1024m $(OPTS) $(ROOTFS) /bin/run $(STATUS) $(TEST_FILE1)
+
+test2:
 ifndef FAILED
-	$(RUNTEST) $(MYST_EXEC) --user-mem-size 1024m $(OPTS) $(ROOTFS) /bin/run $(STATUS) $(TEST_FILE2)
-	$(RUNTEST) $(MYST_EXEC) --user-mem-size 1024m $(OPTS) $(ROOTFS) /bin/run $(STATUS) $(TEST_FILE3)
+	$(MYST_EXEC) --user-mem-size 1024m $(OPTS) $(ROOTFS) /bin/run $(STATUS) $(TEST_FILE2)
+endif
+
+test3:
+ifndef FAILED
+	$(MYST_EXEC) --user-mem-size 1024m $(OPTS) $(ROOTFS) /bin/run $(STATUS) $(TEST_FILE3)
 endif
 
 myst:


### PR DESCRIPTION
This change allows the three libcxx batch tests to run in parallel (when running tests with make -j).

The parallel tests run twice as fast as the non-parallel tests.