### PR TITLE
msync syscall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,10 @@ tests/hostfs/appdir/
 tests/ext2/crypt/appdir/
 tests/ext2/verity/appdir/
 tests/myst/exec-package-ext2/myst/
-tests/libcxx/appdir/
+tests/msync/appdir/
 tests/tlscert/appdir/
 tests/wake_and_kill/appdir/
+third_party/musl/crt/musl/
+tests/msync/tests
+tests/network/appdir/
+third_party/musl/pristine/musl/

--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -38,4 +38,8 @@ int myst_register_process_mapping(pid_t pid, void* addr, size_t size);
 
 int myst_release_process_mappings(pid_t pid);
 
+int myst_msync(void* addr, size_t length, int flags);
+
+void myst_mman_close_notify(int fd);
+
 #endif /* _MYST_MMANUTILS_H */

--- a/kernel/libc.c
+++ b/kernel/libc.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include <myst/backtrace.h>
+#include <myst/syscall.h>
 #include <myst/defs.h>
 #include <myst/eraise.h>
 #include <myst/kernel.h>
@@ -720,7 +721,7 @@ ssize_t pread(int fd, void* buf, size_t count, off_t offset)
     return myst_syscall_ret(myst_syscall_pread(fd, buf, count, offset));
 }
 
-ssize_t myst_pwrite(int fd, const void* buf, size_t count, off_t offset)
+ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset)
 {
     return myst_syscall_ret(myst_syscall_pwrite(fd, buf, count, offset));
 }
@@ -798,6 +799,15 @@ ssize_t readlink(const char* pathname, char* buf, size_t bufsiz)
 int symlink(const char* target, const char* linkpath)
 {
     return (int)myst_syscall_ret(myst_syscall_symlink(target, linkpath));
+}
+
+int fcntl(int fd, int cmd, ...)
+{
+    va_list ap;
+    va_start(ap, cmd);
+    long arg = va_arg(ap, long);
+    va_end(ap);
+    return (int)myst_syscall_ret(myst_syscall_fcntl(fd, cmd, arg));
 }
 
 /*

--- a/kernel/libc.c
+++ b/kernel/libc.c
@@ -801,15 +801,6 @@ int symlink(const char* target, const char* linkpath)
     return (int)myst_syscall_ret(myst_syscall_symlink(target, linkpath));
 }
 
-int fcntl(int fd, int cmd, ...)
-{
-    va_list ap;
-    va_start(ap, cmd);
-    long arg = va_arg(ap, long);
-    va_end(ap);
-    return (int)myst_syscall_ret(myst_syscall_fcntl(fd, cmd, arg));
-}
-
 /*
 **==============================================================================
 **

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -15,6 +15,7 @@
 #include <myst/mmanutils.h>
 #include <myst/process.h>
 #include <myst/strings.h>
+#include <myst/round.h>
 
 #define SCRUB
 
@@ -335,7 +336,7 @@ static int _release_msync_mappings(void* addr, size_t length)
 
                     /* update the left mapping length */
                     p->length = llength;
-                    prev = p;
+                    prev = rm;
                 }
                 else if (llength)
                 {
@@ -385,12 +386,11 @@ int myst_munmap(void* addr, size_t length)
     int ret = 0;
 
     /* address cannot be null and must be aligned on a page boundary */
-    if (!addr || ((uint64_t)addr % PAGE_SIZE))
+    if (!addr || ((uint64_t)addr % PAGE_SIZE) || !length)
         ERAISE(-EINVAL);
 
-    /* length cannot be 0 and must be aligned on a page boundary */
-    if (!length || (length % PAGE_SIZE))
-        ERAISE(-EINVAL);
+    /* align length to a page boundary */
+    ECHECK(myst_round_up(length, PAGE_SIZE, &length));
 
     ECHECK(myst_mman_munmap(&_mman, addr, length));
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -732,6 +732,7 @@ long myst_syscall_close(int fd)
         myst_remove_fd_link(device, object, fd);
     }
 
+    myst_mman_close_notify(fd);
     ECHECK((*fdops->fd_close)(device, object));
     ECHECK(myst_fdtable_remove(fdtable, fd));
 
@@ -2717,8 +2718,7 @@ long myst_syscall(long n, long params[6])
 
             _strace(n, "addr=%p length=%zu flags=%d ", addr, length, flags);
 
-            /* ATTN: hook up implementation */
-            BREAK(_return(n, 0));
+            BREAK(_return(n, myst_msync(addr, length, flags)));
         }
         case SYS_mincore:
             /* ATTN: hook up implementation */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -85,6 +85,8 @@ ifeq ($(MYST_ENABLE_HOSTFS),1)
 DIRS += hostfs
 endif
 
+DIRS += msync
+
 __tests:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) tests $(NL) )
 

--- a/tests/msync/Makefile
+++ b/tests/msync/Makefile
@@ -1,0 +1,35 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+TARGET2=$(SUBOBJDIR)/msync
+
+all:
+	$(MAKE) myst
+	$(MAKE) $(TARGET2)
+	$(MAKE) rootfs
+
+rootfs: msync.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/msync msync.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+$(TARGET2): msync.c
+	mkdir -p $(SUBOBJDIR)
+	$(CC) $(CFLAGS) msync.c -o $(TARGET2)
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+tests:
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/msync $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs $(TARGET2)

--- a/tests/msync/msync.c
+++ b/tests/msync/msync.c
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 4096
+#endif
+
+static int _writen(int fd, const void* data, size_t size)
+{
+    ssize_t ret = -1;
+    const uint8_t* p = (const uint8_t*)data;
+    size_t r = size;
+
+    while (r > 0)
+    {
+        ssize_t n = write(fd, p, r);
+
+        if (n == 0)
+            break;
+        else if (n < 0)
+            goto done;
+
+        p += n;
+        r -= (size_t)n;
+    }
+
+    ret = 0;
+
+done:
+
+    return ret;
+}
+
+static int _readn(int fd, void* data, size_t size)
+{
+    ssize_t ret = -1;
+    uint8_t* p = (uint8_t*)data;
+    size_t r = size;
+
+    while (r > 0)
+    {
+        ssize_t n = read(fd, p, r);
+
+        if (n <= 0)
+            goto done;
+
+        p += n;
+        r -= (size_t)n;
+    }
+
+    ret = 0;
+
+done:
+
+    return ret;
+}
+
+static bool _check_page(uint8_t page[PAGE_SIZE], uint8_t byte)
+{
+    for (size_t i = 0; i < PAGE_SIZE; i++)
+    {
+        if (page[i] != byte)
+            return false;
+    }
+
+    return true;
+}
+
+int main(int argc, const char* argv[])
+{
+    const size_t num_pages = 8;
+    uint8_t page[PAGE_SIZE];
+    int fd;
+    struct stat st;
+
+    /* create a new file */
+    assert((fd = open("/msync", O_CREAT | O_TRUNC | O_RDWR, 0666)) >= 0);
+
+    /* create a file where each page is filled with a specific byte value */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        const uint8_t byte = (uint8_t)i;
+        memset(page, byte, sizeof(page));
+        assert(_writen(fd, page, sizeof(page)) == 0);
+    }
+
+    /* check the size of the file */
+    assert(fstat(fd, &st) == 0);
+    assert(st.st_size == num_pages * sizeof(page));
+
+    /* map the file onto memory */
+    const size_t length = st.st_size;
+    const int prot = PROT_READ | PROT_WRITE;
+    const int flags = MAP_PRIVATE | MAP_SHARED;
+    uint8_t* addr = mmap(NULL, length, prot, flags, fd, 0);
+    assert(addr != MAP_FAILED);
+
+    /* check that the memory mapped image matches the file */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        /* check that the current page consists of the given byte */
+        uint8_t* p = addr + (i * PAGE_SIZE);
+        const uint8_t byte = (uint8_t)i;
+        assert(_check_page(p, byte) == true);
+    }
+
+    /* update the memory mapped image by changing the page byte values */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        uint8_t* p = addr + (i * PAGE_SIZE);
+        const uint8_t byte = (uint8_t)(i + 1);
+        memset(p, byte, PAGE_SIZE);
+    }
+
+    /* sync the pages back to disk one page at a time */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        uint8_t* p = addr + (i * PAGE_SIZE);
+        assert(msync(p, PAGE_SIZE, MS_SYNC) == 0);
+    }
+
+    // remove the memory mappings in an irregular order to this has many
+    // cases in the mman implementation as possible.
+    {
+#if 1
+        size_t indices[] =
+        {
+            0,
+            3,
+            5,
+            7,
+            2,
+            4,
+            6,
+            1,
+        };
+        assert(sizeof(indices) / sizeof(indices[0]) == num_pages);
+
+        for (size_t i = 0; i < num_pages; i++)
+        {
+            size_t index = indices[i];
+            uint8_t* p = addr + index * PAGE_SIZE;
+            assert(munmap(p, PAGE_SIZE) == 0);
+        }
+#else
+        assert(munmap(addr, length) == 0);
+#endif
+    }
+
+    /* close the file (which implicitly removes the file mapping) */
+    assert(close(fd) == 0);
+
+    /* reopen the file and check that it has actually changed */
+    {
+        assert((fd = open("/msync", O_RDONLY)) >= 0);
+
+        for (size_t i = 0; i < num_pages; i++)
+        {
+            const uint8_t byte = (uint8_t)(i + 1);
+            memset(page, 0, sizeof(page));
+            assert(_readn(fd, page, PAGE_SIZE) == 0);
+            assert(_check_page(page, byte) == true);
+        }
+
+        assert(close(fd) == 0);
+    }
+
+    printf("=== passed test (%s)\n", argv[0]);
+
+    return 0;
+}


### PR DESCRIPTION
Add support for msync syscall. Add msync mapping structures that
are created by mmap(), syncrhoized by msync(), and removed by
munmap().