### PR TITLE
Support hostfs as a rootfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,9 @@ third_party/musl/crt/musl/
 tests/msync/tests
 tests/network/appdir/
 third_party/musl/pristine/musl/
+tests/fs/hostfs/
+third_party/musl/crt/musl/
+third_party/musl/crt/musl/
+tests/msync/tests
+tests/network/appdir/
+third_party/musl/pristine/musl/

--- a/defs.mak
+++ b/defs.mak
@@ -183,6 +183,10 @@ ifdef MYST_ENABLE_EXT2FS
 MYST_DEFINES += -DMYST_ENABLE_EXT2FS
 endif
 
+ifdef MYST_DEBUG
+MYST_DEFINES += -DMYST_DEBUG
+endif
+
 ##==============================================================================
 ##
 ## Define $(EXEC) macro in terms of $(TARGET). This macro should be used in

--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -2200,7 +2200,9 @@ static int _remove_dirent(ext2_t* ext2, const char* path)
     ECHECK(_inode_write_data(ext2, ino, &inode, buf.data, buf.size));
 
     /* update the directory inode */
-    inode.i_links_count--;
+    if (ent->file_type == EXT2_FT_DIR)
+        inode.i_links_count--;
+
     ECHECK(_write_inode(ext2, ino, &inode));
 
 done:
@@ -2497,8 +2499,11 @@ static int _add_dirent(
     /* rewrite the directory, one block at a time */
     ECHECK(_inode_write_data(ext2, ino, inode, buf.data, buf.size));
 
+    /* update the number of links if new entry is a directory */
+    if (new_ent->file_type == EXT2_FT_DIR)
+        inode->i_links_count++;
+
     /* update the inode */
-    inode->i_links_count++;
     ECHECK(_write_inode(ext2, ino, inode));
 
 done:

--- a/include/myst/fs.h
+++ b/include/myst/fs.h
@@ -13,6 +13,19 @@
 #include <unistd.h>
 
 #include <myst/fdops.h>
+#include <myst/defs.h>
+
+/* supported file system types */
+typedef enum myst_fstype
+{
+    MYST_FSTYPE_NONE,
+    MYST_FSTYPE_RAMFS,
+    MYST_FSTYPE_EXT2FS,
+    MYST_FSTYPE_HOSTFS,
+}
+myst_fstype_t;
+
+const char* myst_fstype_name(myst_fstype_t fstype);
 
 typedef struct myst_fs myst_fs_t;
 

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -83,6 +83,9 @@ typedef struct myst_kernel_args
     /* The event object for the main thread */
     uint64_t event;
 
+    /* whether this TEE is in debug mode */
+    bool tee_debug_mode;
+
     /* Callback for making target-calls */
     myst_tcall_t tcall;
 } myst_kernel_args_t;

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -17,6 +17,23 @@
 #include <myst/verity.h>
 #include <myst/thread.h>
 
+const char* myst_fstype_name(myst_fstype_t fstype)
+{
+    switch (fstype)
+    {
+        case MYST_FSTYPE_NONE:
+            return "NONE";
+        case MYST_FSTYPE_RAMFS:
+            return "RAMFS";
+        case MYST_FSTYPE_EXT2FS:
+            return "EXT2FS";
+        case MYST_FSTYPE_HOSTFS:
+            return "HOSTFS";
+    }
+
+    return "NONE";
+}
+
 int myst_remove_fd_link(myst_fs_t* fs, myst_file_t* file, int fd)
 {
     int ret = 0;

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -194,7 +194,9 @@ static int _inode_new(
         }
 
         ECHECK(_inode_add_dirent(parent, inode, type, name));
-        parent->nlink++;
+
+        if (type == DT_DIR)
+            parent->nlink++;
     }
 
     if (inode_out)

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -612,6 +612,7 @@ long myst_tcall(long n, long params[6])
         case SYS_readlink:
         case SYS_statfs:
         case SYS_fstatfs:
+        case SYS_lseek:
         {
             return _forward_syscall(n, x1, x2, x3, x4, x5, x6);
         }

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -691,6 +691,7 @@ long myst_tcall(long n, long params[6])
         case SYS_readlink:
         case SYS_statfs:
         case SYS_fstatfs:
+        case SYS_lseek:
         {
             extern long myst_handle_tcall(long n, long params[6]);
             return myst_handle_tcall(n, params);
@@ -857,6 +858,7 @@ long myst_tcall(long n, long params[6])
         }
         default:
         {
+            printf("error: tcall=%ld\n", n);
             ERAISE(-EINVAL);
         }
     }

--- a/tests/fs/Makefile
+++ b/tests/fs/Makefile
@@ -16,19 +16,28 @@ ifdef STRACE
 OPTS = --strace
 endif
 
-CLEAN = appdir rootfs ext2rootfs ramfs
+HOSTFS = $(CURDIR)/hostfs
+
+CLEAN = appdir rootfs ext2rootfs ramfs $(HOSTFS)
 
 include $(TOP)/rules.mak
 
-tests: program test1 test2
+tests: program test1 test2 test3
 
 test1: rootfs
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/fs
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/fs ramfs
 
 test2: ext2rootfs
 ifdef MYST_ENABLE_EXT2FS
 	$(MYST) fssig --roothash ext2rootfs > $(ROOTHASH)
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) ext2rootfs --roothash=$(ROOTHASH) /bin/fs
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) ext2rootfs --roothash=$(ROOTHASH) /bin/fs ext2fs
+endif
+
+test3: rootfs
+ifdef MYST_ENABLE_HOSTFS
+	rm -rf $(HOSTFS)
+	cp -r appdir $(HOSTFS)
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(HOSTFS) /bin/fs hostfs
 endif
 
 rootfs: appdir

--- a/tests/ltp/ltp_enabled.txt
+++ b/tests/ltp/ltp_enabled.txt
@@ -1,3 +1,6 @@
+/ltp/testcases/kernel/syscalls/open/open03
+/ltp/testcases/kernel/syscalls/open/open07
+/ltp/testcases/kernel/syscalls/open/open09
 /ltp/testcases/kernel/syscalls/chdir/chdir02
 /ltp/testcases/kernel/syscalls/chmod/chmod02
 /ltp/testcases/kernel/syscalls/chown/chown01

--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -1336,6 +1336,25 @@ done:
 }
 #endif
 
+#ifdef MYST_ENABLE_HOSTFS
+static off_t _lseek(int fd, off_t offset, int whence)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_lseek_ocall(&retval, fd, offset, whence) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+#endif
+
 long myst_handle_tcall(long n, long params[6])
 {
     const long a = params[0];
@@ -1543,6 +1562,10 @@ long myst_handle_tcall(long n, long params[6])
         case SYS_fstatfs:
         {
             return _fstatfs((int)a, (struct myst_statfs*)b);
+        }
+        case SYS_lseek:
+        {
+            return _lseek((int)a, b, (int)c);
         }
 #endif
         default:

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -376,6 +376,7 @@ static int _enter_kernel(
     args.have_syscall_instruction = true;
     args.export_ramfs = options->export_ramfs;
     args.event = (uint64_t)&_thread_event;
+    args.tee_debug_mode = true;
     args.tcall = tcall;
 
     if (options->rootfs)

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -339,3 +339,8 @@ long myst_fstatfs_ocall(int fd, struct myst_statfs* buf)
 {
     RETURN(fstatfs(fd, (struct statfs*)buf));
 }
+
+long myst_lseek_ocall(int fd, off_t offset, int whence)
+{
+    RETURN(lseek(fd, offset, whence));
+}

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -339,6 +339,8 @@ enclave
             int fd,
             [out] struct myst_statfs* buf);
 
+        long myst_lseek_ocall(int fd, off_t offset, int whence);
+
         /*
         **======================================================================
         **


### PR DESCRIPTION
This change allows a hostfs to be mounted as a rootfs and extends the fs test to cover ramfs, ext2fs, and hostfs. Accordingly, it fixes buts in all three implementations.

Hostfs-rootfs support only applied to debug builds and is intended for running file system tests.