### PR TITLE
fix for broken nightly ltp test

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -8,6 +8,7 @@ TEST_FILE=ltp_enabled.txt
 TESTS=$(shell cat $(TEST_FILE))
 
 all:
+	git submodule update --init --progress $(TOP)/third_party/ltp/ltp
 	$(MAKE) myst
 	$(MAKE) rootfs
 


### PR DESCRIPTION
Fix the broken nightly ltp test by checking out the ltp submodule on demand.