### PR TITLE
Fixes for open tests

### DIFF
--- a/include/myst/process.h
+++ b/include/myst/process.h
@@ -8,6 +8,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#define MYST_DEFAULT_UMASK (S_IWGRP | S_IWOTH)
+
 MYST_INLINE pid_t myst_getsid(void)
 {
     return myst_thread_self()->sid;

--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -253,4 +253,6 @@ long myst_syscall_sendfile(int out_fd, int in_fd, off_t* offset, size_t count);
 
 long myst_syscall_sethostname(const char* hostname, size_t len);
 
+long myst_syscall_umask(mode_t mask);
+
 #endif /* _MYST_SYSCALL_H */

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -146,6 +146,10 @@ struct myst_thread
         char* cwd;
         myst_spinlock_t cwd_lock;
 
+        /* The current umask this process */
+        mode_t umask;
+        myst_spinlock_t umask_lock;
+
     } main;
 
     volatile _Atomic enum myst_thread_status status;

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -481,6 +481,8 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     if (thread->main.cwd == NULL)
         ERAISE(-ENOMEM);
 
+    thread->main.umask = MYST_DEFAULT_UMASK;
+
     if (args->hostname)
         ECHECK(
             myst_syscall_sethostname(args->hostname, strlen(args->hostname)));

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -746,6 +746,10 @@ static ssize_t _fs_read(
     if (!buf && count)
         ERAISE(-EINVAL);
 
+    /* fail if file has been opened for write only */
+    if (file->access == O_WRONLY)
+        ERAISE(-EBADF);
+
     /* reading zero bytes is okay */
     if (!count)
         goto done;
@@ -796,6 +800,10 @@ static ssize_t _fs_write(
     /* writing zero bytes is okay */
     if (!count)
         goto done;
+
+    /* fail if file has been opened for read only */
+    if (file->access == O_RDONLY)
+        ERAISE(-EBADF);
 
     /* Verify that the offset is in bounds */
     if (file->offset > _file_size(file))

--- a/kernel/realpath.c
+++ b/kernel/realpath.c
@@ -68,13 +68,21 @@ int myst_realpath(const char* path, myst_path_t* resolved_path)
         {
             v->in[nin++] = p;
         }
+
+        /* if the path ends in '/' and not root then add '.' */
+        {
+            size_t len = strlen(path);
+
+            if (len > 1 && path[len-1] == '/')
+                v->in[nin++] = ".";
+        }
     }
 
     /* Normalize the path. */
     for (size_t i = 0; i < nin; i++)
     {
         /* Skip "." elements. */
-        if (strcmp(v->in[i], ".") == 0)
+        if (i + 1 != nin && strcmp(v->in[i], ".") == 0)
             continue;
 
         /* If "..", remove previous element. */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -672,6 +672,9 @@ static long _syscall_clone_vfork(
         if (child->main.cwd == NULL)
             ERAISE(-ENOMEM);
 
+        /* inherit the umask from the parent process */
+        child->main.umask = parent->main.umask;
+
         if (myst_fdtable_clone(parent->fdtable, &child->fdtable) != 0)
             ERAISE(-ENOMEM);
 

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -19,7 +19,7 @@ $(APPDIR): buildltp.sh
 	$(APPBUILDER) Dockerfile
 
 rootfs: $(APPDIR)
-	$(MYST) mkext2 $(APPDIR) "$@"
+	sudo $(MYST) mkext2 $(APPDIR) "$@"
 	truncate --size=-4096 "$@"
 
 ifdef STRACE

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -19,8 +19,9 @@ $(APPDIR): buildltp.sh
 	$(APPBUILDER) Dockerfile
 
 rootfs: $(APPDIR)
-	sudo $(MYST) mkext2 $(APPDIR) "$@"
-	truncate --size=-4096 "$@"
+	sudo $(MYST) mkext2 $(APPDIR) $@
+	sudo chown $(USER).$(USER) $@
+	truncate --size=-4096 $@
 
 ifdef STRACE
 OPTS = --strace

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -8,20 +8,26 @@ TEST_FILE=ltp_enabled.txt
 TESTS=$(shell cat $(TEST_FILE))
 
 all:
+	git submodule update --init --progress $(TOP)/third_party/ltp/ltp
 	$(MAKE) myst
 	$(MAKE) rootfs
 
 $(APPDIR): buildltp.sh
 	@ rm -fr ltp
 	@ mkdir ltp
-	@ cp -R ../../third_party/ltp/ltp/* ltp/ 
+	@ cp -R ../../third_party/ltp/ltp/* ltp/
 	$(APPBUILDER) Dockerfile
 
 rootfs: $(APPDIR)
-	$(MYST) mkcpio $(APPDIR) "$@"
+	$(MYST) mkext2 $(APPDIR) "$@"
+	truncate --size=-4096 "$@"
+
+ifdef STRACE
+OPTS = --strace
+endif
 
 tests:
-	@ $(foreach i, $(TESTS), $(RUNTEST) $(MYST_EXEC) rootfs $(i) $(OPTS) $(NL) )
+	@ $(foreach i, $(TESTS), $(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs $(i) $(OPTS) $(NL) )
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/ltp/ltp_enabled.txt
+++ b/tests/ltp/ltp_enabled.txt
@@ -1,3 +1,6 @@
+/ltp/testcases/kernel/syscalls/open/open03
+/ltp/testcases/kernel/syscalls/open/open07
+/ltp/testcases/kernel/syscalls/open/open09
 /ltp/testcases/kernel/syscalls/chdir/chdir02
 /ltp/testcases/kernel/syscalls/epoll/epoll-ltp
 /ltp/testcases/kernel/syscalls/futex/futex_wait01


### PR DESCRIPTION
Add fixes so that the following ltp open tests will pass.

```
/ltp/testcases/kernel/syscalls/open/open03
/ltp/testcases/kernel/syscalls/open/open07
/ltp/testcases/kernel/syscalls/open/open09
```

This involved the following changes:
- access checks in read and write functions (O_RDONLY/O_WRONLY)
- add umask syscall
- add chown syscall as no-op
- add setpgid syscall
- update ltp tests to use ext2 (instead of ramfs)
- fix handling of filenames ending in slash (denoting /.)