### PR TITLE
Add simple installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,24 @@ kernel while others are delegated to the target.
 You can download the latest binary release [from our builds
 page](https://github.com/deislabs/mystikos/releases)
 
-**TODO**: Include installation instructions. 
+```
+# change this to match the latest version
+LATEST='0.1.2'
+RELEASE="mystikos-${LATEST}-x86_64"
+
+# this will create the "mystikos" directory within your current working directory
+curl -sSL --ssl https://github.com/deislabs/mystikos/releases/download/v${LATEST}/${RELEASE}.tar.gz | tar -xzf -
+
+# you can use mystikos from your home directory
+export PATH="$PATH:$(pwd)/mystikos/bin"
+
+# or you can move it to a system-wide location
+sudo mv mystikos /opt/
+sudo chown -R root:root /opt/mystikos
+sudo chmod -R o-rw /opt/mystikos
+export PATH="$PATH:/opt/mystikos/bin"
+```
+
 
 ## From Source
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,42 @@ kernel while others are delegated to the target.
 
 # Installation Guide
 
-## From Binaries
+## Verify the Intel SGX DCAP Driver is Installed
 
-You can download the latest binary release [from our builds
-page](https://github.com/deislabs/mystikos/releases)
+Some distributions come with the SGX driver already installed; if it is,
+you don't need to re-install it. You can verify this by running:
+
+```bash
+dmesg | grep -i sgx
+```
+
+If the output is blank, install the driver manually by downloading it from Intel.
+
+> NOTE: The script below may not refer to the latest Intel SGX DCAP driver.
+> Check [Intel's SGX Downloads page](https://01.org/intel-software-guard-extensions/downloads)
+> to see if a more recent SGX DCAP driver exists.
+
+```bash
+sudo apt -y install dkms
+wget https://download.01.org/intel-sgx/sgx-dcap/1.7/linux/distro/ubuntu18.04-server/sgx_linux_x64_driver_1.35.bin -O sgx_linux_x64_driver.bin
+chmod +x sgx_linux_x64_driver.bin
+sudo ./sgx_linux_x64_driver.bin
+```
+## Add Intel's repository & install the sgx libraries
+
+```bash
+echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+
+sudo apt update
+
+sudo apt -y install libsgx-enclave-common libsgx-dcap-ql libsgx-dcap-ql-dev
+```
+
+## Download Mystikos
+
+You can [download the latest build here](https://github.com/deislabs/mystikos/releases)
+then simply decompress it, add it to your path, and run it.
 
 ```
 # change this to match the latest version
@@ -59,18 +91,11 @@ RELEASE="mystikos-${LATEST}-x86_64"
 # this will create the "mystikos" directory within your current working directory
 curl -sSL --ssl https://github.com/deislabs/mystikos/releases/download/v${LATEST}/${RELEASE}.tar.gz | tar -xzf -
 
-# you can use mystikos from your home directory
+# you can use mystikos from your home directory, or any path
 export PATH="$PATH:$(pwd)/mystikos/bin"
-
-# or you can move it to a system-wide location
-sudo mv mystikos /opt/
-sudo chown -R root:root /opt/mystikos
-sudo chmod -R o-rw /opt/mystikos
-export PATH="$PATH:/opt/mystikos/bin"
 ```
 
-
-## From Source
+## Install From Source
 
 You may also [build Mystikos from source](BUILDING.md). In our experience, this
 takes about 20 minutes. 


### PR DESCRIPTION
This commit adds simple bash installation instructions to the README file.

Closes #152