### PR TITLE
Support absolute symlinks across file systems

### DIFF
--- a/hostfs/hostfs.c
+++ b/hostfs/hostfs.c
@@ -150,6 +150,7 @@ static int _fs_open(
     const char* pathname,
     int flags,
     mode_t mode,
+    myst_fs_t** fs_out,
     myst_file_t** file_out)
 {
     int ret = 0;
@@ -179,6 +180,8 @@ static int _fs_open(
 
     *file_out = file;
     file = NULL;
+    /* hostfs does not delegate the open operation */
+    *fs_out = fs;
 
 done:
 
@@ -192,9 +195,10 @@ static int _fs_creat(
     myst_fs_t* fs,
     const char* pathname,
     mode_t mode,
+    myst_fs_t** fs_out,
     myst_file_t** file)
 {
-    return _fs_open(fs, pathname, O_CREAT | O_WRONLY | O_TRUNC, mode, file);
+    return _fs_open(fs, pathname, O_CREAT | O_WRONLY | O_TRUNC, mode, fs_out, file);
 }
 
 static off_t _fs_lseek(

--- a/include/myst/ext2.h
+++ b/include/myst/ext2.h
@@ -200,6 +200,7 @@ struct ext2
     ext2_group_desc_t* groups;
     ext2_inode_t root_inode;
     char target[EXT2_PATH_MAX];
+    myst_mount_resolve_callback_t resolve;
 };
 
 /*
@@ -210,7 +211,7 @@ struct ext2
 **==============================================================================
 */
 
-int ext2_create(myst_blkdev_t* dev, myst_fs_t** fs);
+int ext2_create(myst_blkdev_t* dev, myst_fs_t** fs, myst_mount_resolve_callback_t resolve_cb);
 
 int ext2_release(myst_fs_t* fs);
 
@@ -257,6 +258,7 @@ int ext2_open(
     const char* path,
     int flags,
     mode_t mode,
+    myst_fs_t** fs_out,
     myst_file_t** file);
 
 int64_t ext2_read(myst_fs_t* fs, myst_file_t* file, void* data, uint64_t size);

--- a/include/myst/fs.h
+++ b/include/myst/fs.h
@@ -5,6 +5,7 @@
 #define _MYST_FS_H
 
 #include <dirent.h>
+#include <limits.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
@@ -30,6 +31,11 @@ const char* myst_fstype_name(myst_fstype_t fstype);
 typedef struct myst_fs myst_fs_t;
 
 typedef struct myst_file myst_file_t;
+
+typedef int (*myst_mount_resolve_callback_t)(
+    const char* path,
+    char suffix[PATH_MAX],
+    myst_fs_t** fs);
 
 struct myst_fs
 {

--- a/include/myst/fs.h
+++ b/include/myst/fs.h
@@ -49,6 +49,7 @@ struct myst_fs
         myst_fs_t* fs,
         const char* pathname,
         mode_t mode,
+        myst_fs_t** fs_out,
         myst_file_t** file);
 
     int (*fs_open)(
@@ -56,6 +57,7 @@ struct myst_fs
         const char* pathname,
         int flags,
         mode_t mode,
+        myst_fs_t** fs_out,
         myst_file_t** file);
 
     off_t (
@@ -161,6 +163,6 @@ struct myst_fs
 
 int myst_remove_fd_link(myst_fs_t* fs, myst_file_t* file, int fd);
 
-int myst_load_fs(const char* source, const char* key, myst_fs_t** fs_out);
+int myst_load_fs(myst_mount_resolve_callback_t resolve_cb, const char* source, const char* key, myst_fs_t** fs_out);
 
 #endif /* _MYST_FS_H */

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -7,7 +7,7 @@
 #include <myst/fs.h>
 #include <stdbool.h>
 
-int myst_init_ramfs(myst_fs_t** fs_out);
+int myst_init_ramfs(myst_mount_resolve_callback_t resolve, myst_fs_t** fs_out);
 
 int myst_ramfs_set_buf(
     myst_fs_t* fs,

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -7,7 +7,7 @@
 #include <myst/fs.h>
 #include <stdbool.h>
 
-int myst_init_ramfs(myst_mount_resolve_callback_t resolve, myst_fs_t** fs_out);
+int myst_init_ramfs(myst_mount_resolve_callback_t resolve_cb, myst_fs_t** fs_out);
 
 int myst_ramfs_set_buf(
     myst_fs_t* fs,

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -188,7 +188,7 @@ static int _setup_ext2(const char* rootfs, char* err, size_t err_size)
 
     *err = '\0';
 
-    if (myst_load_fs(rootfs, key, &_fs) != 0)
+    if (myst_load_fs(myst_mount_resolve, rootfs, key, &_fs) != 0)
     {
         snprintf(err, err_size, "cannot load or verify EXT2 image: %s", rootfs);
         ERAISE(-EINVAL);
@@ -271,13 +271,13 @@ static int _create_tls_credentials()
     ECHECK(myst_tcall(MYST_TCALL_GEN_CREDS, params));
 
     // Save the certificate
-    ECHECK((_fs->fs_open)(_fs, MYST_CERTIFICATE_PATH, flags, 0444, &file));
+    ECHECK((_fs->fs_open)(_fs, MYST_CERTIFICATE_PATH, flags, 0444, NULL, &file));
     ECHECK((_fs->fs_write)(_fs, file, cert, cert_size) == (int64_t)cert_size);
     ECHECK((_fs->fs_close)(_fs, file));
     file = NULL;
 
     // Save the private key
-    ECHECK((_fs->fs_open)(_fs, MYST_PRIVATE_KEY_PATH, flags, 0444, &file));
+    ECHECK((_fs->fs_open)(_fs, MYST_PRIVATE_KEY_PATH, flags, 0444, NULL, &file));
     ECHECK((_fs->fs_write)(_fs, file, pkey, pkey_size) == (int64_t)pkey_size);
     ECHECK((_fs->fs_close)(_fs, file));
     file = NULL;

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -162,7 +162,7 @@ static int _setup_ramfs(void)
 {
     int ret = 0;
 
-    if (myst_init_ramfs(&_fs) != 0)
+    if (myst_init_ramfs(myst_mount_resolve, &_fs) != 0)
     {
         myst_eprintf("failed initialize the RAM files system\n");
         ERAISE(-EINVAL);

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -64,7 +64,7 @@ done:
 }
 
 #ifdef MYST_ENABLE_EXT2FS
-int myst_load_fs(const char* source, const char* key, myst_fs_t** fs_out)
+int myst_load_fs(myst_mount_resolve_callback_t resolve_cb, const char* source, const char* key, myst_fs_t** fs_out)
 {
     int ret = 0;
     myst_blkdev_t* blkdev = NULL;
@@ -133,7 +133,7 @@ int myst_load_fs(const char* source, const char* key, myst_fs_t** fs_out)
         blkdev = tmp;
     }
 
-    ECHECK(ext2_create(blkdev, &fs));
+    ECHECK(ext2_create(blkdev, &fs, resolve_cb));
     blkdev = NULL;
 
     *fs_out = fs;

--- a/kernel/mount.c
+++ b/kernel/mount.c
@@ -324,7 +324,7 @@ long myst_syscall_mount(
 
         key = _find_arg(args, "key");
 
-        ECHECK(myst_load_fs(source, key, &fs));
+        ECHECK(myst_load_fs(myst_mount_resolve, source, key, &fs));
 
         /* perform the mount */
         ECHECK(myst_mount(fs, source, target));

--- a/kernel/mount.c
+++ b/kernel/mount.c
@@ -289,7 +289,7 @@ long myst_syscall_mount(
             ERAISE(-EINVAL);
 
         /* create a new ramfs instance */
-        ECHECK(myst_init_ramfs(&fs));
+        ECHECK(myst_init_ramfs(myst_mount_resolve, &fs));
 
         /* perform the mount */
         ECHECK(myst_mount(fs, source, target));

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -597,25 +597,25 @@ long myst_syscall_creat(const char* pathname, mode_t mode)
     long ret = 0;
     int fd;
     char suffix[PATH_MAX];
-    myst_fs_t* fs;
+    myst_fs_t *fs, *fs_out;
     myst_file_t* file;
     myst_fdtable_t* fdtable = myst_fdtable_current();
     const myst_fdtable_type_t fdtype = MYST_FDTABLE_TYPE_FILE;
     long r;
 
     ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_creat)(fs, suffix, mode, &file));
+    ECHECK((*fs->fs_creat)(fs, suffix, mode, &fs_out, &file));
 
-    if ((fd = myst_fdtable_assign(fdtable, fdtype, fs, file)) < 0)
+    if ((fd = myst_fdtable_assign(fdtable, fdtype, fs_out, file)) < 0)
     {
-        (*fs->fs_close)(fs, file);
+        (*fs_out->fs_close)(fs_out, file);
         ERAISE(fd);
     }
 
-    if ((r = _add_fd_link(fs, file, fd)) != 0)
+    if ((r = _add_fd_link(fs_out, file, fd)) != 0)
     {
         myst_fdtable_remove(fdtable, fd);
-        (*fs->fs_close)(fs, file);
+        (*fs_out->fs_close)(fs_out, file);
         ERAISE(r);
     }
 
@@ -630,7 +630,7 @@ long myst_syscall_open(const char* pathname, int flags, mode_t mode)
 {
     long ret = 0;
     char suffix[PATH_MAX];
-    myst_fs_t* fs;
+    myst_fs_t *fs, *fs_out;
     myst_file_t* file;
     myst_fdtable_t* fdtable = myst_fdtable_current();
     const myst_fdtable_type_t fdtype = MYST_FDTABLE_TYPE_FILE;
@@ -645,18 +645,18 @@ long myst_syscall_open(const char* pathname, int flags, mode_t mode)
     }
 
     ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_open)(fs, suffix, flags, mode, &file));
+    ECHECK((*fs->fs_open)(fs, suffix, flags, mode, &fs_out, &file));
 
-    if ((fd = myst_fdtable_assign(fdtable, fdtype, fs, file)) < 0)
+    if ((fd = myst_fdtable_assign(fdtable, fdtype, fs_out, file)) < 0)
     {
-        (*fs->fs_close)(fs, file);
+        (*fs_out->fs_close)(fs_out, file);
         ERAISE(fd);
     }
 
-    if ((r = _add_fd_link(fs, file, fd)) != 0)
+    if ((r = _add_fd_link(fs_out, file, fd)) != 0)
     {
         myst_fdtable_remove(fdtable, fd);
-        (*fs->fs_close)(fs, file);
+        (*fs_out->fs_close)(fs_out, file);
         ERAISE(r);
     }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -60,6 +60,7 @@ DIRS += round
 DIRS += signal
 DIRS += tlscert
 DIRS += wake_and_kill
+DIRS += cross_fs_symlinks
 
 ifndef MYST_SKIP_LIBCXX_TESTS
 DIRS += libcxx

--- a/tests/cross_fs_symlinks/Makefile
+++ b/tests/cross_fs_symlinks/Makefile
@@ -1,0 +1,41 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+PROG=cross_fs_symlinks
+APPDIR = appdir
+CFLAGS = -fPIC
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+ROOTHASH=roothash
+ifdef STRACE
+OPTS = --strace
+endif
+
+all:
+	$(MAKE) $(APPDIR)
+
+tests: test_ramfs_rootfs test_ext2_rootfs
+
+test_ramfs_rootfs: rootfs
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/$(PROG) ramfs
+
+test_ext2_rootfs: ext2rootfs
+ifdef MYST_ENABLE_EXT2FS
+	$(MYST) fssig --roothash ext2rootfs > $(ROOTHASH)
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) \
+	ext2rootfs --roothash=$(ROOTHASH) /bin/$(PROG) ext2
+endif
+
+$(APPDIR):
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -g -o $(APPDIR)/bin/cross_fs_symlinks cross_fs_symlinks.c $(LDFLAGS)
+	# Create CPIO in appdir, which will be mounted later by the program 
+	mkdir cpio_image && $(MYST) mkcpio cpio_image $(APPDIR)/cpio_image
+
+rootfs: $(APPDIR)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+ext2rootfs: $(APPDIR)
+	sudo $(MYST) mkext2 --force $(APPDIR) ext2rootfs
+
+clean:
+	rm -rf $(APPDIR) rootfs ramfs cpio_image ext2rootfs roothash

--- a/tests/cross_fs_symlinks/cross_fs_symlinks.c
+++ b/tests/cross_fs_symlinks/cross_fs_symlinks.c
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <sys/types.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#define EXT2_S_MAGIC 0xEF53
+#define RAMFS_MAGIC 0x858458f6
+
+void setup_mount()
+{
+    assert(mkdir("/mnt", 0777) == 0);
+    assert(mount("/cpio_image", "/mnt", "ramfs", 0, NULL) == 0);
+
+    {
+        struct statfs buf;
+        assert(statfs("/mnt/", &buf) == 0);
+        assert(buf.f_type == RAMFS_MAGIC);
+    }
+    
+    assert(mkdir("/datadir", 0777) == 0);
+}
+
+void test_dir_target(const char* rootfs_type)
+{
+    assert(symlink("/datadir", "/mnt/datadir-slink") == 0);
+    assert(mkdir("/mnt/datadir-slink/subdir", 0777) == 0);
+
+    // create regular file - "file1", under /datadir/subdir via the symlink
+    {
+        int fd;
+        const char alpha[] = "abcdefghijklmnopqrstuvwxyz";
+        char buf[BUFSIZ];
+        mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+        assert((fd = open("/mnt/datadir-slink/subdir/file1", O_CREAT|O_RDWR|O_TRUNC, mode)) > 0);
+        assert(write(fd, alpha, sizeof(alpha)) > 0);
+        assert(lseek(fd, 0L, 0) == 0);
+        assert(read(fd, buf, BUFSIZ) > 0);
+        assert(close(fd) == 0); 
+    }
+
+    {
+        assert(truncate("/mnt/datadir-slink/subdir/file1", 0) == 0);
+        struct stat statbuf;
+        assert(stat("/mnt/datadir-slink/subdir/file1", &statbuf) == 0);
+        assert(statbuf.st_size == 0);
+    }
+
+    {
+        struct statfs buf;
+        assert(statfs("/mnt/datadir-slink/subdir/file1", &buf) == 0);
+        if (strcmp(rootfs_type, "ramfs") == 0)
+            assert(buf.f_type == RAMFS_MAGIC);
+        else if (strcmp(rootfs_type, "ext2") == 0)
+            assert(buf.f_type == EXT2_S_MAGIC);
+    }
+
+
+    // create symlink to file1 via the directory symlink
+    {
+        assert(symlink("/mnt/datadir-slink/subdir/file1", "/mnt/datadir-slink/subdir/file1-slink") == 0);
+        int ret;
+        char buf[128];
+        assert((ret = readlink("/mnt/datadir-slink/subdir/file1-slink", buf, sizeof(buf))) > 0);
+        printf("buf{%.*s}\n", ret, buf);
+
+
+        FILE *f = fopen("/mnt/datadir-slink/subdir/file1-slink", "r");
+        assert(f);
+        fgets(buf, sizeof(buf), f);
+        printf("%s\n", buf);
+    }
+
+    // cleanup
+    {
+        assert(unlink("/mnt/datadir-slink/subdir/file1") == 0);
+        assert(unlink("/mnt/datadir-slink/subdir/file1-slink") == 0);
+        struct stat statbuf;
+        assert(stat("/mnt/datadir-slink/subdir/file1", &statbuf) == -1);
+        assert(errno == ENOENT);
+        assert(rmdir("/mnt/datadir-slink/subdir") == 0);
+    }
+  
+}
+
+void test_file_target()
+{
+    {
+        int fd;
+        const char alpha[] = "abcdefghijklmnopqrstuvwxyz";
+        mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+        assert((fd = open("/datadir/file2", O_CREAT|O_RDWR|O_TRUNC, mode)) > 0);
+        assert(write(fd, alpha, sizeof(alpha)) > 0);
+        assert(close(fd) == 0); 
+    }
+    
+    struct stat statbuf;
+
+    assert(symlink("/datadir/file2", "/mnt/file2-slink") == 0);
+    assert(lstat("/datadir/file2", &statbuf) == 0);
+
+    {
+        int ret;
+        char buf[128];
+        assert((ret = readlink("/mnt/file2-slink", buf, sizeof(buf))) > 0);
+        assert(ret == strlen("/datadir/file2"));
+        assert(strncmp(buf, "/datadir/file2", ret) == 0);
+
+        FILE *f = fopen("/mnt/file2-slink", "r");
+        assert(f);
+        fgets(buf, sizeof(buf), f);
+        printf("%s\n", buf);
+    }
+}
+
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 2 && 
+            (!strcmp(argv[1], "ramfs") || !strcmp(argv[1], "ext2")))
+    {
+        exit(1);
+    }
+
+    setup_mount();
+
+    test_dir_target(argv[1]);
+    test_file_target();
+
+    printf("=== passed test (%s)\n", argv[0]);
+    return 0;
+}


### PR DESCRIPTION
### Summary
This affects file operations which deal with pathnames.
During path to inode lookup, if an absolute symlink is encountered on an
intermediate path component; path lookup is terminated early.

The unresolved path is then resolved with the mount resolve callback,
which the filesystems receive during initial setup.

With the target filesytem and the unresolved path in hand, the file
operation is then delegated to the target filesystem.

Limitations:
- Only absolute symlinks can cross filesystem boundary.
- Symlinks into hostfs are supported, but not the other way. This is
because hostfs file operations are carried by the host OS, and we can't
supplement it with the mount point information within mystikos.