### PR TITLE
[WIP] Tensorflow Sample based on Ubuntu glibc support

### DIFF
--- a/crt/glibc/__open_2.c
+++ b/crt/glibc/__open_2.c
@@ -7,3 +7,8 @@ int __open_2(const char* file, int oflag)
 {
     return open(file, oflag);
 }
+
+int __open64_2 (const char *file, int oflag)
+{
+    return open(file, oflag);
+}

--- a/crt/glibc/cpuinfo.c
+++ b/crt/glibc/cpuinfo.c
@@ -1,0 +1,12 @@
+#include <sched.h>
+#include <stdlib.h>
+
+void __sched_cpufree (cpu_set_t *set)
+{
+    free (set);
+}
+
+cpu_set_t * __sched_cpualloc (size_t count)
+{
+    return malloc (__CPU_ALLOC_SIZE (count));
+}

--- a/crt/glibc/wchar.c
+++ b/crt/glibc/wchar.c
@@ -1,0 +1,72 @@
+#include <wchar.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+wchar_t * __wcscat_chk(wchar_t *dest, const wchar_t *src, size_t len)
+{
+    wchar_t *tmp1 = dest;
+    const wchar_t *tmp2 = src;
+    wchar_t c;
+
+    /* Move to the end of the dest. Abort if it's too short  */
+    do
+    {
+        if (len-- == 0)
+            abort();
+        c = *tmp1++;
+    }
+    while (c != L'\0');
+
+    /* Append characters in src to the dest. Abort if it's too short  */
+    do
+    {
+        if (len-- == 0)
+            abort();
+        c = *tmp2++;
+        *tmp1++ = c;
+    }
+    while (c != L'\0');
+
+    return dest;
+}
+
+wchar_t * __wcsncpy(wchar_t *dest, const wchar_t *src, size_t len)
+{
+    wchar_t *tmp1 = dest;
+    const wchar_t *tmp2 = src;
+    wchar_t c = *src;
+
+    for (size_t i = 0; i < len; i++)
+    {
+        /* If src has reached the null terminator, don't advance! */
+        c = (c == L'\0') ? c : *tmp2++;
+        *tmp1++ = c;
+    }
+
+    return dest;
+}
+
+wchar_t* __wcsncpy_chk(wchar_t *dest, const wchar_t *src, size_t n1, size_t n2)
+{
+    if (n2 < n1)
+        abort();
+
+    return __wcsncpy(dest, src, n1);
+}
+
+wchar_t * __wcscpy_chk(wchar_t *dest, const wchar_t *src, size_t len)
+{
+    wchar_t *tmp = dest;
+    wchar_t c;
+
+    do
+    {
+        if (len-- == 0)
+            abort();
+        c = *src++;
+        *tmp++ = c;
+    }
+    while (c != L'\0');
+
+    return dest;
+}

--- a/samples/tensorflow-ubuntu/Dockerfile
+++ b/samples/tensorflow-ubuntu/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:18.04 as ubuntu-build-base
+
+# Build Python from source. The packaged Python executable is non-PIE.
+# See issue https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1452115
+RUN apt update && \
+    apt install -y git build-essential libffi-dev zlib1g-dev libssl-dev &&\
+    rm -rf /var/lib/apt/lists/* &&\
+    git clone https://github.com/python/cpython.git --branch 3.6 &&\
+    cd cpython &&\
+    ./configure && make -j 8 && make install &&\
+    cd .. && rm -rf cpython && \
+    apt remove -y git build-essential libffi-dev zlib1g-dev libssl-dev &&\
+    apt -y autoremove &&\
+    python3 --version
+
+
+FROM ubuntu-build-base
+
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
+RUN apt update; apt install curl python3-pip -y
+
+ENV PYTHONUNBUFFERED=1
+
+RUN python3 -m pip --no-cache-dir install --upgrade \
+    "pip<20.3" \
+    setuptools
+
+# Some TF tools expect a "python" binary
+RUN ln -s $(which python3) /usr/local/bin/python
+
+ARG TF_PACKAGE=tensorflow
+ARG TF_PACKAGE_VERSION=
+RUN python3 -m pip install --no-cache-dir tensorflow-cpu
+
+RUN rm -rf /app;mkdir -p /app
+WORKDIR /app
+ADD mnist_convnet.py /app
+
+# CMD ["/usr/local/bin/python3", "/app/mnist_convnet.py"]

--- a/samples/tensorflow-ubuntu/Makefile
+++ b/samples/tensorflow-ubuntu/Makefile
@@ -13,12 +13,16 @@ appdir:
 	$(APPBUILDER) Dockerfile
 
 rootfs:
-	$(MYST) mkcpio appdir rootfs
+	sudo $(MYST) mkext2 appdir rootfs
+	$(MYST) fssig --roothash rootfs > roothash
 
 # run w/ default settings will yield to out of memory error. Must run with config file
 # to allocate larger size of memory
 run:
-	$(MYST_EXEC) $(OPTS) rootfs /usr/local/bin/python3 /app/mnist_convnet.py --app-config-path config.json
+	$(MYST_EXEC) $(OPTS) --roothash=roothash rootfs /usr/local/bin/python3 /app/mnist_convnet.py --user-mem-size 3096m
+
+gdb:
+	$(MYST_GDB) --args $(MYST_EXEC) $(OPTS) --roothash=roothash rootfs /usr/local/bin/python3 /app/mnist_convnet.py --user-mem-size 2048m
 
 clean:
 	rm -rf rootfs appdir

--- a/samples/tensorflow-ubuntu/Makefile
+++ b/samples/tensorflow-ubuntu/Makefile
@@ -1,0 +1,24 @@
+TOP = $(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+all: appdir rootfs
+
+appdir:
+	$(APPBUILDER) Dockerfile
+
+rootfs:
+	$(MYST) mkcpio appdir rootfs
+
+# run w/ default settings will yield to out of memory error. Must run with config file
+# to allocate larger size of memory
+run:
+	$(MYST_EXEC) $(OPTS) rootfs /usr/local/bin/python3 /app/mnist_convnet.py --app-config-path config.json
+
+clean:
+	rm -rf rootfs appdir

--- a/samples/tensorflow-ubuntu/config.json
+++ b/samples/tensorflow-ubuntu/config.json
@@ -1,0 +1,11 @@
+{
+    "Debug": 1,
+    "StackMemSize": "800k",
+    "NumUserThreads": 8,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    "UserMemSize": "512m",
+    "ApplicationPath": "/usr/local/bin/python3",
+    "ApplicationParameters": []
+}

--- a/samples/tensorflow-ubuntu/mnist_convnet.py
+++ b/samples/tensorflow-ubuntu/mnist_convnet.py
@@ -1,0 +1,77 @@
+"""
+Based on https://github.com/keras-team/keras-io/blob/master/examples/vision/mnist_convnet.py
+Title: Simple MNIST convnet
+Description: A simple convnet that achieves ~99% test accuracy on MNIST.
+"""
+
+"""
+## Setup
+"""
+
+import numpy as np
+from tensorflow import keras
+from tensorflow.keras import layers
+
+"""
+## Prepare the data
+"""
+
+# Model / data parameters
+num_classes = 10
+input_shape = (28, 28, 1)
+
+# the data, split between train and test sets
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+
+# Scale images to the [0, 1] range
+x_train = x_train.astype("float32") / 255
+x_test = x_test.astype("float32") / 255
+# Make sure images have shape (28, 28, 1)
+x_train = np.expand_dims(x_train, -1)
+x_test = np.expand_dims(x_test, -1)
+print("x_train shape:", x_train.shape)
+print(x_train.shape[0], "train samples")
+print(x_test.shape[0], "test samples")
+
+
+# convert class vectors to binary class matrices
+y_train = keras.utils.to_categorical(y_train, num_classes)
+y_test = keras.utils.to_categorical(y_test, num_classes)
+
+"""
+## Build the model
+"""
+
+model = keras.Sequential(
+    [
+        keras.Input(shape=input_shape),
+        layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
+        layers.MaxPooling2D(pool_size=(2, 2)),
+        layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
+        layers.MaxPooling2D(pool_size=(2, 2)),
+        layers.Flatten(),
+        layers.Dropout(0.5),
+        layers.Dense(num_classes, activation="softmax"),
+    ]
+)
+
+model.summary()
+
+"""
+## Train the model
+"""
+
+batch_size = 128
+epochs = 15
+
+model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"])
+
+model.fit(x_train, y_train, batch_size=batch_size, epochs=epochs, validation_split=0.1)
+
+"""
+## Evaluate the trained model
+"""
+
+score = model.evaluate(x_test, y_test, verbose=0)
+print("Test loss:", score[0])
+print("Test accuracy:", score[1])

--- a/solutions/python_webserver/Dockerfile
+++ b/solutions/python_webserver/Dockerfile
@@ -1,12 +1,21 @@
 FROM ubuntu:18.04
-RUN apt update && apt install -y git build-essential autotools-dev zlib1g-dev
 
-RUN git clone https://github.com/python/cpython.git --branch 3.6
-WORKDIR /cpython
-RUN ./configure && make -j 4 && make install && which python3
+# Build Python from source. The packaged Python executable is non-PIE.
+# See issue https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1452115
+RUN apt update && \
+    apt install -y git build-essential libffi-dev zlib1g-dev  &&\
+    rm -rf /var/lib/apt/lists/* &&\
+    git clone https://github.com/python/cpython.git --branch 3.6 &&\
+    cd cpython &&\
+    ./configure && make -j 4 && make install &&\
+    cd .. && rm -rf cpython &&\
+    apt remove -y git build-essential libffi-dev zlib1g-dev &&\
+    apt -y autoremove &&\
+    python3 --version
 
 WORKDIR /app
 COPY ./hello_server.py .
 
 ENV PYTHONUNBUFFERED=1
+
 CMD ["python3", "/app/hello_server.py"]

--- a/solutions/python_webserver/Dockerfile
+++ b/solutions/python_webserver/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3-alpine
+FROM ubuntu:18.04
+RUN apt update && apt install -y git build-essential autotools-dev zlib1g-dev
+
+RUN git clone https://github.com/python/cpython.git --branch 3.6
+WORKDIR /cpython
+RUN ./configure && make -j 4 && make install && which python3
 
 WORKDIR /app
 COPY ./hello_server.py .
 
 ENV PYTHONUNBUFFERED=1
-CMD ["python", "hello_server.py"]
+CMD ["python3", "/app/hello_server.py"]

--- a/solutions/python_webserver/Makefile
+++ b/solutions/python_webserver/Makefile
@@ -18,7 +18,7 @@ rootfs:
 run:
 	test -f server.pid && kill -9 `cat server.pid` || true
 	$(MYST_EXEC) $(OPTS) rootfs /usr/local/bin/python3 /app/hello_server.py & echo $$! > server.pid
-	sleep 30
+	sleep 10
 	curl 127.0.0.1:8000
 	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
 

--- a/solutions/python_webserver/Makefile
+++ b/solutions/python_webserver/Makefile
@@ -18,7 +18,7 @@ rootfs:
 run:
 	test -f server.pid && kill -9 `cat server.pid` || true
 	$(MYST_EXEC) $(OPTS) rootfs /usr/local/bin/python3 /app/hello_server.py & echo $$! > server.pid
-	sleep 10
+	sleep 30
 	curl 127.0.0.1:8000
 	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
 

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -179,7 +179,7 @@ index 20d50f2c..c6ad4096 100644
 +    return -ENOTSUP;
 +}
 diff --git a/ldso/dynlink.c b/ldso/dynlink.c
-index afec985a..62f3687f 100644
+index afec985a..4cd45927 100644
 --- a/ldso/dynlink.c
 +++ b/ldso/dynlink.c
 @@ -27,6 +27,13 @@
@@ -196,7 +196,47 @@ index afec985a..62f3687f 100644
  #define MAXP2(a,b) (-(-(a)&-(b)))
  #define ALIGN(x,y) ((x)+(y)-1 & -(y))
  
-@@ -1098,6 +1105,7 @@ static struct dso *load_library(const char *name, struct dso *needed_by)
+@@ -1043,38 +1050,7 @@ static struct dso *load_library(const char *name, struct dso *needed_by)
+ 				fd = path_open(name, p->rpath, buf, sizeof buf);
+ 		}
+ 		if (fd == -1) {
+-			if (!sys_path) {
+-				char *prefix = 0;
+-				size_t prefix_len;
+-				if (ldso.name[0]=='/') {
+-					char *s, *t, *z;
+-					for (s=t=z=ldso.name; *s; s++)
+-						if (*s=='/') z=t, t=s;
+-					prefix_len = z-ldso.name;
+-					if (prefix_len < PATH_MAX)
+-						prefix = ldso.name;
+-				}
+-				if (!prefix) {
+-					prefix = "";
+-					prefix_len = 0;
+-				}
+-				char etc_ldso_path[prefix_len + 1
+-					+ sizeof "/etc/ld-musl-" LDSO_ARCH ".path"];
+-				snprintf(etc_ldso_path, sizeof etc_ldso_path,
+-					"%.*s/etc/ld-musl-" LDSO_ARCH ".path",
+-					(int)prefix_len, prefix);
+-				FILE *f = fopen(etc_ldso_path, "rbe");
+-				if (f) {
+-					if (getdelim(&sys_path, (size_t[1]){0}, 0, f) <= 0) {
+-						free(sys_path);
+-						sys_path = "";
+-					}
+-					fclose(f);
+-				} else if (errno != ENOENT) {
+-					sys_path = "";
+-				}
+-			}
+-			if (!sys_path) sys_path = "/lib:/usr/local/lib:/usr/lib";
++			if (!sys_path) sys_path = "/lib:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu";
+ 			fd = path_open(name, sys_path, buf, sizeof buf);
+ 		}
+ 		pathname = buf;
+@@ -1098,6 +1074,7 @@ static struct dso *load_library(const char *name, struct dso *needed_by)
  	map = noload ? 0 : map_library(fd, &temp_dso);
  	close(fd);
  	if (!map) return 0;
@@ -204,7 +244,7 @@ index afec985a..62f3687f 100644
  
  	/* Avoid the danger of getting two versions of libc mapped into the
  	 * same process when an absolute pathname was used. The symbols
-@@ -1797,6 +1805,7 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1797,6 +1774,7 @@ void __dls3(size_t *sp, size_t *auxv)
  			dprintf(2, "%s: %s: Not a valid dynamic program\n", ldname, argv[0]);
  			_exit(1);
  		}
@@ -212,7 +252,7 @@ index afec985a..62f3687f 100644
  		close(fd);
  		ldso.name = ldname;
  		app.name = argv[0];
-@@ -1936,6 +1945,7 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1936,6 +1914,7 @@ void __dls3(size_t *sp, size_t *auxv)
  	/* Determine if malloc was interposed by a replacement implementation
  	 * so that calloc and the memalign family can harden against the
  	 * possibility of incomplete replacement. */
@@ -220,7 +260,7 @@ index afec985a..62f3687f 100644
  	if (find_sym(head, "malloc", 1).dso != &ldso)
  		__malloc_replaced = 1;
  
-@@ -1955,7 +1965,11 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1955,7 +1934,11 @@ void __dls3(size_t *sp, size_t *auxv)
  
  	errno = 0;
  
@@ -232,7 +272,7 @@ index afec985a..62f3687f 100644
  	for(;;);
  }
  
-@@ -2100,6 +2114,7 @@ end:
+@@ -2100,6 +2083,7 @@ end:
  		free(ctor_queue);
  	}
  	pthread_setcancelstate(cs, 0);


### PR DESCRIPTION
This is an tensorflow sample based on  [glibc support PR #167](https://github.com/deislabs/mystikos/pull/167). 
The sample will download and install the latest version of tensorflow(2.4.x) with python version 3.6 build from src. The sample will run a MNIST sample with 15 epochs. 

The sample will  fail at `ramfs.c:249` with following error message:

https://github.com/jxyang/mystikos/blob/c98af1183207cf85275f6b929be672dbab766935/kernel/ramfs.c#L249

```
Assertion failed: _inode_valid(child) (ramfs.c: _inode_release_all: 249)
2021-03-09T03:12:34+0000.031846Z [(H)ERROR] tid(0x7fd3db76bb80) | :OE_ENCLAVE_ABORTING [/home/wyh/workspaces/app/mystikos/third_party/openenclave/openenclave/host/calls.c:_call_enclave_function_impl:56]
```