### PR TITLE
Separate ramfs based proc filesystem

### DIFF
--- a/include/myst/procfs.h
+++ b/include/myst/procfs.h
@@ -4,6 +4,8 @@
 #ifndef _MYST_PROCFS_H
 #define _MYST_PROCFS_H
 
+#include <fcntl.h>
+
 #include <myst/ramfs.h>
 
 int create_proc_root_entries();
@@ -19,5 +21,8 @@ int create_proc_root_entries();
 int procfs_setup();
 
 int procfs_teardown();
+
+/* Cleanup /proc/[pid] entries */
+int procfs_pid_cleanup(pid_t pid);
 
 #endif /* _MYST_PROCFS_H */

--- a/include/myst/procfs.h
+++ b/include/myst/procfs.h
@@ -18,6 +18,6 @@ int create_proc_root_entries();
 
 int procfs_setup();
 
-int procfs_cleanup();
+int procfs_teardown();
 
 #endif /* _MYST_PROCFS_H */

--- a/include/myst/procfs.h
+++ b/include/myst/procfs.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_PROCFS_H
+#define _MYST_PROCFS_H
+
+#include <myst/ramfs.h>
+
+int create_proc_root_entries();
+
+/*
+**==============================================================================
+**
+** procfs lifetime management
+**
+**==============================================================================
+*/
+
+int procfs_setup();
+
+int procfs_cleanup();
+
+#endif /* _MYST_PROCFS_H */

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -19,6 +19,7 @@ int myst_ramfs_set_buf(
 int myst_create_virtual_file(
     myst_fs_t* fs,
     const char* pathname,
+    mode_t mode,
     int (*vcallback)(myst_buf_t* buf));
 
 #endif /* _MYST_RAMFS_H */

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -5,6 +5,7 @@
 #define _MYST_RAMFS_H
 
 #include <myst/fs.h>
+#include <myst/buf.h>
 #include <stdbool.h>
 
 int myst_init_ramfs(myst_mount_resolve_callback_t resolve_cb, myst_fs_t** fs_out);
@@ -14,5 +15,10 @@ int myst_ramfs_set_buf(
     const char* pathname,
     const void* buf,
     size_t buf_size);
+
+int myst_create_virtual_file(
+    myst_fs_t* fs,
+    const char* pathname,
+    int (*vcallback)(myst_buf_t* buf));
 
 #endif /* _MYST_RAMFS_H */

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -22,4 +22,9 @@ int myst_create_virtual_file(
     mode_t mode,
     int (*vcallback)(myst_buf_t* buf));
 
+int myst_release_tree(
+    myst_fs_t* fs,
+    const char* pathname
+);
+
 #endif /* _MYST_RAMFS_H */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -134,10 +134,7 @@ done:
 
 #ifdef USE_TMPFS
 static myst_fs_t* _tmpfs;
-static myst_fs_t* _procfs;
-#endif
 
-#ifdef USE_TMPFS
 static int _init_tmpfs(const char* target, myst_fs_t** fs_out)
 {
     int ret = 0;
@@ -400,12 +397,6 @@ static int _teardown_tmpfs(void)
     if ((*_tmpfs->fs_release)(_tmpfs) != 0)
     {
         myst_eprintf("failed to release tmpfs\n");
-        return -1;
-    }
-
-    if ((*_procfs->fs_release)(_procfs) != 0)
-    {
-        myst_eprintf("failed to release procfs\n");
         return -1;
     }
 
@@ -788,6 +779,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
 #ifdef USE_TMPFS
     _teardown_tmpfs();
 #endif
+
+    /* Tear down the proc file system */
+    procfs_teardown();
 
     /* Tear down the RAM file system */
     _teardown_ramfs();

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -24,6 +24,7 @@
 #include <myst/panic.h>
 #include <myst/printf.h>
 #include <myst/process.h>
+#include <myst/procfs.h>
 #include <myst/pubkey.h>
 #include <myst/ramfs.h>
 #include <myst/signal.h>
@@ -39,7 +40,6 @@
 #define WANT_TLS_CREDENTIAL "MYST_WANT_TLS_CREDENTIAL"
 
 static myst_fs_t* _fs;
-static myst_fs_t* _procfs;
 
 long myst_tcall(long n, long params[6])
 {
@@ -267,40 +267,11 @@ static int _setup_hostfs(const char* rootfs, char* err, size_t err_size)
     }
 
     _create_standard_directories();
-}
-#endif /* MYST_ENABLE_HOSTFS */
-
-static int _setup_procfs(void)
-{
-    int ret = 0;
-
-    if (myst_init_ramfs(myst_mount_resolve, &_procfs) != 0)
-    {
-        myst_eprintf("failed initialize the proc file system\n");
-        ERAISE(-EINVAL);
-    }
-
-    if (myst_mkdirhier("/proc", 777) != 0)
-    {
-        myst_eprintf("cannot create mount point for procfs\n");
-        ERAISE(-EINVAL);
-    }
-
-    if (myst_mount(_procfs, "/", "/proc") != 0)
-    {
-        myst_eprintf("cannot mount proc file system\n");
-        ERAISE(-EINVAL);
-    }
-
-    if (myst_mkdirhier("/proc/self/fd", 777) != 0)
-    {
-        myst_eprintf("cannot create the /proc/self/fd directory\n");
-        ERAISE(-EINVAL);
-    }
 
 done:
     return ret;
 }
+#endif /* MYST_ENABLE_HOSTFS */
 
 static const char* _getenv(const char** envp, const char* varname)
 {
@@ -596,14 +567,6 @@ done:
     return ret;
 }
 
-static int _meminfo_vcallback(myst_buf_t* vbuf)
-{
-    const char alpha[] = "abcdefghijklmnopqrstuvwxyz";
-    myst_buf_clear(vbuf);
-    myst_buf_append(vbuf, alpha, sizeof(alpha));
-    return 0;
-}
-
 int myst_enter_kernel(myst_kernel_args_t* args)
 {
     int ret = 0;
@@ -688,9 +651,6 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     /* Mount the root file system */
     ECHECK(_mount_rootfs(args, fstype));
 
-    /* Setup virtual proc filesystem */
-    _setup_procfs();
-
     /* Generate TLS credentials if needed */
     want_tls_creds = _getenv(args->envp, WANT_TLS_CREDENTIAL);
     if (want_tls_creds != NULL)
@@ -723,6 +683,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
 
     thread->main.umask = MYST_DEFAULT_UMASK;
 
+    /* Setup virtual proc filesystem */
+    procfs_setup();
+
     if (args->hostname)
         ECHECK(
             myst_syscall_sethostname(args->hostname, strlen(args->hostname)));
@@ -743,8 +706,8 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         ERAISE(-EINVAL);
     }
 
-    /* Create /proc/meminfo */
-    ECHECK(myst_create_virtual_file(_procfs, "/meminfo", _meminfo_vcallback));
+    /* Create top-level proc entries */
+    create_proc_root_entries();
 
     /* Set the 'run-proc' which is called by the target to run new threads */
     ECHECK(myst_tcall_set_run_thread_function(myst_run_thread));

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -581,6 +581,14 @@ done:
     return ret;
 }
 
+static int _meminfo_vcallback(myst_buf_t* vbuf)
+{
+    const char alpha[] = "abcdefghijklmnopqrstuvwxyz";
+    myst_buf_clear(vbuf);
+    myst_buf_append(vbuf, alpha, sizeof(alpha));
+    return 0;
+}
+
 int myst_enter_kernel(myst_kernel_args_t* args)
 {
     int ret = 0;
@@ -716,6 +724,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         myst_eprintf("failed to unpack root file system\n");
         ERAISE(-EINVAL);
     }
+
+    /* Create /proc/meminfo */
+    ECHECK(myst_create_virtual_file(_fs, "/proc/meminfo", _meminfo_vcallback));
 
     /* Set the 'run-proc' which is called by the target to run new threads */
     ECHECK(myst_tcall_set_run_thread_function(myst_run_thread));

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -774,12 +774,6 @@ static int _setup_exe_link(const char* path)
     snprintf(buf, sizeof(buf), "/proc/%u/exe", pid);
     ECHECK(myst_syscall_symlink(target, buf));
 
-    snprintf(buf, sizeof(buf), "/proc/self/exe");
-
-    /* ATTN-88746EEE: support /proc/self for multiple processes */
-    if (access(buf, R_OK) != 0)
-        ECHECK(myst_syscall_symlink(target, buf));
-
 done:
     return ret;
 }

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -11,6 +11,7 @@
 #include <myst/hex.h>
 #include <myst/kernel.h>
 #include <myst/mount.h>
+#include <myst/process.h>
 #include <myst/pubkey.h>
 #include <myst/roothash.h>
 #include <myst/tcall.h>
@@ -38,11 +39,10 @@ const char* myst_fstype_name(myst_fstype_t fstype)
 int myst_remove_fd_link(int fd)
 {
     int ret = 0;
-
     char path[PATH_MAX];
     const size_t n = sizeof(path);
 
-    if (snprintf(path, n, "/proc/self/fd/%d", fd) >= (int)n)
+    if (snprintf(path, n, "/proc/%d/fd/%d", myst_getpid(), fd) >= (int)n)
         ERAISE(-ENAMETOOLONG);
 
     ECHECK(myst_syscall_unlink(path));

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -65,17 +65,13 @@ int procfs_teardown()
 int procfs_pid_cleanup(pid_t pid)
 {
     int ret = 0;
-    char pid_exe_path[PATH_MAX];
     char pid_dir_path[PATH_MAX];
 
     if (!pid)
         ERAISE(-EINVAL);
 
-    snprintf(pid_exe_path, sizeof(pid_exe_path), "/proc/%d/exe", pid);
-    ECHECK(_procfs->fs_unlink(_procfs, pid_exe_path));
-
-    snprintf(pid_dir_path, sizeof(pid_dir_path), "/proc/%d", pid);
-    ECHECK(_procfs->fs_rmdir(_procfs, pid_exe_path));
+    snprintf(pid_dir_path, sizeof(pid_dir_path), "/%d", pid);
+    ECHECK(myst_release_tree(_procfs, pid_dir_path));
 
 done:
     return ret;

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include <string.h>
+#include <sys/stat.h>
+
+#include <myst/eraise.h>
+#include <myst/file.h>
+#include <myst/fs.h>
+#include <myst/kernel.h>
+#include <myst/mmanutils.h>
+#include <myst/mount.h>
+#include <myst/printf.h>
+#include <myst/process.h>
+#include <myst/procfs.h>
+
+static myst_fs_t* _procfs;
+
+int procfs_setup()
+{
+    int ret = 0;
+
+    if (myst_init_ramfs(myst_mount_resolve, &_procfs) != 0)
+    {
+        myst_eprintf("failed initialize the proc file system\n");
+        ERAISE(-EINVAL);
+    }
+
+    if (myst_mkdirhier("/proc", 777) != 0)
+    {
+        myst_eprintf("cannot create mount point for procfs\n");
+        ERAISE(-EINVAL);
+    }
+
+    if (myst_mount(_procfs, "/", "/proc") != 0)
+    {
+        myst_eprintf("cannot mount proc file system\n");
+        ERAISE(-EINVAL);
+    }
+
+    /* Create /proc/[pid]/fd directory for main thread */
+    char fdpath[PATH_MAX];
+    const size_t n = sizeof(fdpath);
+    snprintf(fdpath, n, "/proc/%d/fd", myst_getpid());
+    if (myst_mkdirhier(fdpath, 777) != 0)
+    {
+        myst_eprintf("cannot create the /proc/[pid]/fd directory\n");
+        ERAISE(-EINVAL);
+    }
+
+done:
+    return ret;
+}
+
+static int _meminfo_vcallback(myst_buf_t* vbuf)
+{
+    int ret = 0;
+    size_t totalram;
+    size_t freeram;
+    
+    ECHECK(myst_get_total_ram(&totalram));
+    ECHECK(myst_get_free_ram(&freeram));
+
+    myst_buf_clear(vbuf);
+    char tmp[128];
+    const size_t n = sizeof(tmp);
+    snprintf(tmp, n, "MemTotal:       %lu\n", totalram);
+    myst_buf_append(vbuf, tmp, strlen(tmp));
+    snprintf(tmp, n, "MemFree:        %lu\n", freeram);
+    myst_buf_append(vbuf, tmp, strlen(tmp));
+
+done:
+    return ret;
+}
+
+static int _self_vcallback(myst_buf_t* vbuf)
+{
+    char linkpath[PATH_MAX];
+    const size_t n = sizeof(linkpath);
+    snprintf(linkpath, n, "/proc/%d", myst_getpid());
+    myst_buf_clear(vbuf);
+    myst_buf_append(vbuf, linkpath, sizeof(linkpath));
+    return 0;
+}
+
+int create_proc_root_entries()
+{
+    int ret;
+
+    /* Create /proc/meminfo */
+    ECHECK(myst_create_virtual_file(_procfs, "/meminfo", S_IFREG, _meminfo_vcallback));
+
+    /* Create /proc/self */
+    ECHECK(myst_create_virtual_file(_procfs, "/self", S_IFLNK, _self_vcallback));
+
+done:
+    return ret;
+}

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -62,6 +62,25 @@ int procfs_teardown()
     return 0;
 }
 
+int procfs_pid_cleanup(pid_t pid)
+{
+    int ret = 0;
+    char pid_exe_path[PATH_MAX];
+    char pid_dir_path[PATH_MAX];
+
+    if (!pid)
+        ERAISE(-EINVAL);
+
+    snprintf(pid_exe_path, sizeof(pid_exe_path), "/proc/%d/exe", pid);
+    ECHECK(_procfs->fs_unlink(_procfs, pid_exe_path));
+
+    snprintf(pid_dir_path, sizeof(pid_dir_path), "/proc/%d", pid);
+    ECHECK(_procfs->fs_rmdir(_procfs, pid_exe_path));
+
+done:
+    return ret;
+}
+
 static int _meminfo_vcallback(myst_buf_t* vbuf)
 {
     int ret = 0;

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -51,6 +51,17 @@ done:
     return ret;
 }
 
+int procfs_teardown()
+{
+    if ((*_procfs->fs_release)(_procfs) != 0)
+    {
+        myst_eprintf("failed to release procfs\n");
+        return -1;
+    }
+    
+    return 0;
+}
+
 static int _meminfo_vcallback(myst_buf_t* vbuf)
 {
     int ret = 0;

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -735,7 +735,7 @@ static int _fs_open(
         if ((flags & O_CREAT) && (flags & O_EXCL))
             ERAISE(-EEXIST);
 
-#if 0
+        /* Check file access permissions */
         {
             const int access = flags & 0x03;
 
@@ -751,7 +751,6 @@ static int _fs_open(
             if (access == O_RDWR && !(inode->mode & S_IWUSR))
                 ERAISE(-EPERM);
         }
-#endif
 
         if ((flags & O_DIRECTORY) && !S_ISDIR(inode->mode))
             ERAISE(-ENOTDIR);
@@ -2160,7 +2159,7 @@ int myst_create_virtual_file(
     if (S_ISREG(mode))
     {
         myst_file_t* file = NULL;
-        ECHECK(fs->fs_open(fs, pathname, O_RDONLY | O_CREAT, S_IFREG, NULL, &file));
+        ECHECK(fs->fs_open(fs, pathname, O_RDONLY | O_CREAT, S_IFREG | S_IRUSR, NULL, &file));
         ECHECK(fs->fs_close(fs, file));
     }
     else if (S_ISLNK(mode))

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -610,7 +610,7 @@ static int _add_fd_link(myst_fs_t* fs, myst_file_t* file, int fd)
 
     ECHECK((*fs->fs_realpath)(fs, file, realpath, sizeof(realpath)));
 
-    if (snprintf(linkpath, n, "/proc/self/fd/%d", fd) >= (int)n)
+    if (snprintf(linkpath, n, "/proc/%d/fd/%d", myst_getpid(), fd) >= (int)n)
         ERAISE(-ENAMETOOLONG);
 
     ECHECK(symlink(realpath, linkpath));

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -23,6 +23,7 @@
 #include <myst/options.h>
 #include <myst/panic.h>
 #include <myst/printf.h>
+#include <myst/procfs.h>
 #include <myst/setjmp.h>
 #include <myst/signal.h>
 #include <myst/spinlock.h>
@@ -519,6 +520,8 @@ long myst_run_thread(uint64_t cookie, uint64_t event)
 
             free(thread->main.cwd);
             thread->main.cwd = NULL;
+
+            procfs_pid_cleanup(thread->pid);
         }
 
         myst_zombify_thread(thread);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -14,6 +14,7 @@
 #include <myst/cond.h>
 #include <myst/eraise.h>
 #include <myst/fdtable.h>
+#include <myst/file.h>
 #include <myst/fsgs.h>
 #include <myst/futex.h>
 #include <myst/kernel.h>
@@ -718,6 +719,18 @@ static long _syscall_clone_vfork(
         child->main.prev_process_thread = parent_main_thread;
         parent_main_thread->main.next_process_thread = child;
         myst_spin_unlock(&myst_process_list_lock);
+
+        /* Create /proc/[pid]/fd directory for new thread */
+        {
+            char fdpath[PATH_MAX];
+            const size_t n = sizeof(fdpath);
+            snprintf(fdpath, n, "/proc/%d/fd", child->pid);
+            if (myst_mkdirhier(fdpath, 777) != 0)
+            {
+                myst_eprintf("cannot create the /proc/[pid]/fd directory\n");
+                ERAISE(-EINVAL);
+            }
+        }
     }
 
     cookie = _get_cookie(child);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -723,7 +723,7 @@ static long _syscall_clone_vfork(
         parent_main_thread->main.next_process_thread = child;
         myst_spin_unlock(&myst_process_list_lock);
 
-        /* Create /proc/[pid]/fd directory for new thread */
+        /* Create /proc/[pid]/fd directory for new process thread */
         {
             char fdpath[PATH_MAX];
             const size_t n = sizeof(fdpath);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -66,9 +66,6 @@ ifndef MYST_SKIP_LIBCXX_TESTS
 DIRS += libcxx
 endif
 
-DIRS += tlscert
-DIRS += wake_and_kill
-
 ifndef MYST_USE_OECACHE
 DIRS += curl
 endif
@@ -83,6 +80,7 @@ include $(TOP)/rules.mak
 
 DIRS += epoll
 DIRS += oe
+DIRS += procfs
 
 ifeq ($(MYST_ENABLE_HOSTFS),1)
 DIRS += hostfs

--- a/tests/procfs/Makefile
+++ b/tests/procfs/Makefile
@@ -1,0 +1,26 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC -g
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+all: myst rootfs
+
+rootfs: procfs.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/procfs procfs.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+tests:
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/procfs $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/procfs/procfs.c
+++ b/tests/procfs/procfs.c
@@ -9,6 +9,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <errno.h>
 
 int test_meminfo()
 {
@@ -65,10 +66,19 @@ int test_self_links(const char* pn)
     test_self_fd();
 }
 
+int test_readonly()
+{
+    int fd;
+    fd = open("/proc/meminfo", O_RDWR);
+    assert(fd == -1);
+    assert(errno == EPERM);
+}
+
 int main(int argc, const char* argv[])
 {
     test_meminfo();
     test_self_links(argv[0]);
+    test_readonly();
 
     printf("\n=== passed test (%s)\n", argv[0]);
     return 0;

--- a/tests/procfs/procfs.c
+++ b/tests/procfs/procfs.c
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int test_meminfo()
+{
+    int fd;
+    char buf[1024];
+    
+    fd = open("/proc/meminfo", O_RDONLY);
+    assert(fd > 0);   
+    assert(read(fd, buf, sizeof(buf)));
+    
+    printf("%s\n", buf);
+}
+
+int test_self_exe(const char* pn)
+{
+    int ret;
+    char target[PATH_MAX];
+    ret = readlink("/proc/self/exe", target, sizeof(target));
+    assert(ret > 0);
+    assert(!strcmp(pn,target));
+}
+
+int test_self_fd()
+{
+
+}
+
+int test_self_links(const char* pn)
+{
+    char target[PATH_MAX];
+    readlink("/proc/self", target, sizeof(target));
+    printf("%s\n", target);
+
+    test_self_exe(pn);
+    test_self_fd();
+}
+
+int main(int argc, const char* argv[])
+{
+    test_meminfo();
+    test_self_links(argv[0]);
+
+    printf("\n=== passed test (%s)\n", argv[0]);
+    return 0;
+}


### PR DESCRIPTION
### Summary
- Mounts procfs, a ramfs based filesystem, at /proc. 
- Added pid specific link entries: /proc/[pid]/fd and /proc/[pid]/exe
- /proc/self will resolve to the current pid.
- Initial implementation of /proc/meminfo.
