### PR TITLE
Error tracing

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -76,6 +76,7 @@ typedef struct myst_kernel_args
     size_t max_threads;
 
     /* Tracing options */
+    bool trace_errors;
     bool trace_syscalls;
     bool have_syscall_instruction;
     bool export_ramfs;

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -10,6 +10,7 @@
 
 typedef struct myst_options
 {
+    bool trace_errors;
     bool trace_syscalls;
     bool have_syscall_instruction;
     bool export_ramfs;

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -34,6 +34,7 @@
 #include <myst/times.h>
 #include <myst/ttydev.h>
 #include <myst/hostfs.h>
+#include <myst/trace.h>
 
 #define WANT_TLS_CREDENTIAL "MYST_WANT_TLS_CREDENTIAL"
 
@@ -588,11 +589,6 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     const char* want_tls_creds;
     myst_fstype_t fstype;
 
-#if 0
-    extern void myst_set_trace(bool flag);
-    myst_set_trace(true);
-#endif
-
     if (!args)
         myst_crash();
 
@@ -603,6 +599,10 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     __options.trace_syscalls = args->trace_syscalls;
     __options.have_syscall_instruction = args->have_syscall_instruction;
     __options.export_ramfs = args->export_ramfs;
+
+    /* enable error tracing if requested */
+    if (args->trace_errors)
+        myst_set_trace(true);
 
     if (__options.have_syscall_instruction)
         myst_set_gsbase(myst_get_fsbase());

--- a/tests/conf/Makefile
+++ b/tests/conf/Makefile
@@ -12,8 +12,8 @@ CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
 LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
 
 LIBS =
-LIBS += $(LIBDIR)/libmysthost.a
 LIBS += $(LIBDIR)/libmystutils.a
+LIBS += $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/tests/cpio/Makefile
+++ b/tests/cpio/Makefile
@@ -13,8 +13,7 @@ CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
 
 LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
 
-LIBS = $(LIBDIR)/libmysthost.a
-LIBS = $(LIBDIR)/libmystutils.a
+LIBS = $(LIBDIR)/libmystutils.a $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/tests/json/print/Makefile
+++ b/tests/json/print/Makefile
@@ -12,9 +12,9 @@ CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
 
 LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
 
-LIBS += $(LIBDIR)/libmysthost.a
 LIBS += $(LIBDIR)/libjson.a
 LIBS += $(LIBDIR)/libmystutils.a
+LIBS += $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/tests/json/test1/Makefile
+++ b/tests/json/test1/Makefile
@@ -11,9 +11,9 @@ CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
 
 LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
 
-LIBS += $(LIBDIR)/libmysthost.a
 LIBS += $(LIBDIR)/libjson.a
 LIBS += $(LIBDIR)/libmystutils.a
+LIBS += $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/tests/json/test2/Makefile
+++ b/tests/json/test2/Makefile
@@ -11,9 +11,9 @@ CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
 
 LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
 
-LIBS += $(LIBDIR)/libmysthost.a
 LIBS += $(LIBDIR)/libjson.a
 LIBS += $(LIBDIR)/libmystutils.a
+LIBS += $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/tests/mman/Makefile
+++ b/tests/mman/Makefile
@@ -13,7 +13,7 @@ CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
 
 LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
 
-LIBS = $(LIBDIR)/libmystutils.a
+LIBS = $(LIBDIR)/libmystutils.a $(LIBDIR)/libmysthost.a
 
 CLEAN = rootfs
 

--- a/tests/strings/Makefile
+++ b/tests/strings/Makefile
@@ -11,8 +11,7 @@ CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
 
 LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
 
-LIBS = $(LIBDIR)/libmysthost.a
-LIBS = $(LIBDIR)/libmystutils.a
+LIBS = $(LIBDIR)/libmystutils.a $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/tests/timeval/Makefile
+++ b/tests/timeval/Makefile
@@ -11,7 +11,7 @@ CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
 
 LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
 
-LIBS = $(LIBDIR)/libmystutils.a
+LIBS = $(LIBDIR)/libmystutils.a $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -196,6 +196,7 @@ int myst_enter_ecall(
     size_t archive_size;
     const void* config_data;
     size_t config_size;
+    bool trace_errors = false;
     bool trace_syscalls = false;
     bool export_ramfs = false;
     const char* rootfs = NULL;
@@ -346,6 +347,7 @@ int myst_enter_ecall(
 
     if (options)
     {
+        trace_errors = options->trace_errors;
         trace_syscalls = options->trace_syscalls;
         export_ramfs = options->export_ramfs;
 
@@ -575,6 +577,7 @@ int myst_enter_ecall(
         kargs.crt_data = (void*)crt_data;
         kargs.crt_size = crt_size;
         kargs.max_threads = _get_num_tcs();
+        kargs.trace_errors = trace_errors;
         kargs.trace_syscalls = trace_syscalls;
         kargs.export_ramfs = export_ramfs;
         kargs.tcall = myst_tcall;

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -263,6 +263,13 @@ int exec_action(int argc, const char* argv[], const char* envp[])
             options.trace_syscalls = true;
         }
 
+        /* Get --trace option */
+        if (cli_getopt(&argc, argv, "--trace-errors", NULL) == 0 ||
+            cli_getopt(&argc, argv, "--etrace", NULL) == 0)
+        {
+            options.trace_errors = true;
+        }
+
         /* Get --export-ramfs option */
         if (cli_getopt(&argc, argv, "--export-ramfs", NULL) == 0)
             options.export_ramfs = true;

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -56,6 +56,7 @@ and <options> are one of:\n\
 
 struct options
 {
+    bool trace_errors;
     bool trace_syscalls;
     bool export_ramfs;
     char rootfs[PATH_MAX];
@@ -87,6 +88,13 @@ static void _get_options(
         cli_getopt(argc, argv, "--strace", NULL) == 0)
     {
         options->trace_syscalls = true;
+    }
+
+    /* Get --trace-errors option */
+    if (cli_getopt(argc, argv, "--trace-errors", NULL) == 0 ||
+        cli_getopt(argc, argv, "--etrace", NULL) == 0)
+    {
+        options->trace_errors = true;
     }
 
     /* Get --export-ramfs option */
@@ -372,6 +380,7 @@ static int _enter_kernel(
     args.crt_data = regions->libmystcrt.image_data;
     args.crt_size = regions->libmystcrt.image_size;
     args.max_threads = LONG_MAX;
+    args.trace_errors = options->trace_errors;
     args.trace_syscalls = options->trace_syscalls;
     args.have_syscall_instruction = true;
     args.export_ramfs = options->export_ramfs;

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -481,6 +481,13 @@ int _exec_package(
         }
     }
 
+    /* Get --trace option */
+    if (cli_getopt(&argc, argv, "--trace-errors", NULL) == 0 ||
+        cli_getopt(&argc, argv, "--etrace", NULL) == 0)
+    {
+        options.trace_errors = true;
+    }
+
     if (!realpath(argv[0], full_app_path))
     {
         fprintf(stderr, "Invalid path %s\n", argv[0]);

--- a/utils/eraise.c
+++ b/utils/eraise.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include <myst/printf.h>
 #include <myst/eraise.h>
 #include <myst/errno.h>
 #include <myst/printf.h>
@@ -16,7 +17,7 @@ void myst_eraise(const char* file, uint32_t line, const char* func, int errnum)
         if (errnum < 0)
             errnum = -errnum;
 
-        printf(
+        myst_eprintf(
             "ERAISE: %s(%u): %s: errno=%d: %s\n",
             file,
             line,


### PR DESCRIPTION
This change adds a **myst** command-line option to enable the error tracing facility, which traces errors arising in **ERAISE** and **ECHECK** macros.

For example:

```
% myst exec-sgx --etrace rootfs /bin/hello
```

Two forms of the option are supported:
```
--trace-errors
--etrace
```

Sample output:

```
ERAISE: ramfs.c(526): _path_to_inode_realpath: errno=2: ENOENT
ERAISE: ramfs.c(554): _path_to_inode: errno=2: ENOENT
ERAISE: ramfs.c(1176): _fs_stat: errno=2: ENOENT
ERAISE: syscall.c(941): myst_syscall_stat: errno=2: ENOENT
```