### PR TITLE
cpp webserver restbed with test suite 

### DIFF
--- a/samples/webservers/cpp_restbed/Dockerfile
+++ b/samples/webservers/cpp_restbed/Dockerfile
@@ -1,0 +1,27 @@
+# stage 1 build
+FROM alpine:3.12.3 AS base-image
+
+RUN apk add --no-cache bash build-base cmake git openssl-dev linux-headers
+
+
+WORKDIR /src
+
+# clone and build
+RUN git clone --recursive https://github.com/corvusoft/restbed.git restbed
+RUN mkdir -p restbed/build; cd restbed/build; \
+    cmake -DBUILD_SSL=NO ..; make install;
+# filter all test executables and put them to /tests folder
+RUN mkdir -p /tests;cd restbed/build/test;\
+    cp $(find \( ! -name "*.cmake" ! -name "Makefile" \) -maxdepth 2 -type f) /tests
+
+# stage2 get binaries
+FROM alpine:3.12.3
+
+RUN apk add --no-cache zlib-dev libgcc libstdc++
+
+RUN rm -rf /tests;mkdir -p /tests
+
+COPY --from=base-image /tests /tests
+
+WORKDIR /tests
+

--- a/samples/webservers/cpp_restbed/Makefile
+++ b/samples/webservers/cpp_restbed/Makefile
@@ -1,0 +1,30 @@
+.PHONY: all app cpio
+
+TOP=$(abspath ../../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+TESTSDIR_HOST=$(CURDIR)/$(APPDIR)/tests
+TESTSDIR_MYST=/tests
+CFLAGS = -fPIC
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+#OPTS = --strace
+
+all: myst cpio
+
+run:
+	@echo -e "\n------starting cpp restbed test suite------\n"
+	$(foreach test, $(shell ls $(TESTSDIR_HOST)), $(MYST) exec rootfs $(TESTSDIR_MYST)/$(test) $(OPTS) $(NL))
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+app: clean
+	$(TOP)/scripts/appbuilder Dockerfile
+
+cpio: app
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+clean:
+	rm -rf $(APPDIR) rootfs

--- a/samples/webservers/cpp_restbed/Makefile
+++ b/samples/webservers/cpp_restbed/Makefile
@@ -6,8 +6,6 @@ include $(TOP)/defs.mak
 APPDIR = appdir
 TESTSDIR_HOST=$(CURDIR)/$(APPDIR)/tests
 TESTSDIR_MYST=/tests
-CFLAGS = -fPIC
-LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
 #OPTS = --strace
 

--- a/samples/webservers/cpp_restbed/Makefile
+++ b/samples/webservers/cpp_restbed/Makefile
@@ -3,8 +3,10 @@
 TOP=$(abspath ../../..)
 include $(TOP)/defs.mak
 
-APPDIR = appdir
-TESTSDIR_HOST=$(CURDIR)/$(APPDIR)/tests
+
+APPBUILDER    = $(TOP)/scripts/appbuilder
+APPDIR        = appdir
+TESTSDIR_HOST =$(CURDIR)/$(APPDIR)/tests
 TESTSDIR_MYST=/tests
 
 #OPTS = --strace
@@ -15,13 +17,20 @@ run:
 	@echo -e "\n------starting cpp restbed test suite------\n"
 	$(foreach test, $(shell ls $(TESTSDIR_HOST)), $(MYST) exec rootfs $(TESTSDIR_MYST)/$(test) $(OPTS) $(NL))
 
+run-single-test: 
+	@echo -e "\n------running single cpp restbed test suite------\n"
+	$(MYST) exec rootfs $(TESTSDIR_MYST)/signal_handling_feature_test_suite $(OPTS) 
+
+gdb: clean cpio
+	$(MYST_GDB) --args $(MYST_EXEC) rootfs $(TESTSDIR_MYST)/signal_handling_feature_test_suite $(OPTS)
+
 myst:
 	$(MAKE) -C $(TOP)/tools/myst
 
-app: clean
-	$(TOP)/scripts/appbuilder Dockerfile
+$(APPDIR): clean
+	$(APPBUILDER) -v Dockerfile
 
-cpio: app
+cpio: $(APPDIR)
 	$(MYST) mkcpio $(APPDIR) rootfs
 
 clean:


### PR DESCRIPTION
Add open source [C++ Web Server Restbed](https://github.com/Corvusoft/restbed). Mystikos will crash because of not implemented system calls  `SYS_eventfd2` (https://github.com/deislabs/mystikos/issues/142) and `SYS_faccessat` (https://github.com/deislabs/mystikos/issues/144)

Note: another REST sdk, microsoft/cpprestsdk is also blocked by these two issues https://github.com/microsoft/cpprestsdk

Updates:
---
All syscall blocking issue have been solved.
In all 115 test suites(around 1000 test cases), only one test suite failed. Failure can be reproduced through `run-single-test` or `gdb` recipe.
https://github.com/Corvusoft/restbed/blob/55009b43618c2d3a0e2afad5fd845eddd964816b/test/feature/source/signal_handling/feature.cpp#L65

Blocked by #394 