### PR TITLE
Musl symbols

### DIFF
--- a/crt/Makefile
+++ b/crt/Makefile
@@ -11,6 +11,8 @@ DEFINES = $(MYST_DEFINES)
 
 SOURCES = $(wildcard *.c) $(wildcard $(TOP)/third_party/gcompat/gcompat/libgcompat/*.c)
 
+MUSLSRC=$(TOP)/third_party/musl/crt/musl
+
 ifdef MYST_ENABLE_GCOV
 CFLAGS += -fprofile-arcs -ftest-coverage
 endif
@@ -19,7 +21,7 @@ LDFLAGS1 = -Wl,--sort-section,alignment -Wl,--sort-common -Wl,--gc-sections -Wl,
 
 LDFLAGS1 += -Wl,-emyst_enter_crt
 
-LDFLAGS2 = -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now
+LDFLAGS2 = -shared -Wl,-Bstatic -Wl,--export-dynamic -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,--dynamic-list=$(MUSLSRC)/dynamic.list
 
 ifdef MYST_ENABLE_GCOV
 LDFLAGS2 += -L$(LIBDIR)
@@ -27,8 +29,6 @@ LDFLAGS2 += -lgcov_musl
 endif
 
 LIBCC = -lgcc
-
-MUSLSRC=$(TOP)/third_party/musl/crt/musl
 
 -include $(MUSLSRC)/objects.mak
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -62,6 +62,7 @@ DIRS += tlscert
 DIRS += wake_and_kill
 DIRS += cross_fs_symlinks
 DIRS += ltp
+DIRS += shared_symbols
 
 ifndef MYST_SKIP_LIBCXX_TESTS
 DIRS += libcxx

--- a/tests/shared_symbols/Makefile
+++ b/tests/shared_symbols/Makefile
@@ -1,0 +1,23 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -g
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs: shared_symbols.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/shared_symbols shared_symbols.c
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+tests:
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/shared_symbols -o testarg $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/shared_symbols/shared_symbols.c
+++ b/tests/shared_symbols/shared_symbols.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[])
+{
+    /* Test whether optarg in libc is shared */
+    const struct option longopts[] = {
+        {"option", required_argument, 0, 'o'},
+    };
+
+    int optindex;
+    int c;
+    while ((c = getopt_long(argc, argv, "o:", longopts, &optindex)) != -1)
+    {
+        printf("optarg={%s}\n", optarg);
+        assert(strcmp(optarg, "testarg") == 0);
+    }
+
+    /* Test whether stdin in libc is shared */
+    {
+        char buf[1];
+        size_t n;
+        int fd;
+
+        // make sure fread fails
+        fd = dup(0);
+        close(0);
+
+        n = fread(buf, 1, sizeof buf, stdin);
+        assert(n == 0 && ferror(stdin));
+    }
+
+    printf("\n=== passed test (%s)\n", argv[0]);
+    return 0;
+}


### PR DESCRIPTION
This PR exposes some libc variables, such as `optarg`, as relocatable symbols with type `R_X86_64_GLOB_DAT`. The purpose of the relocation is for applications who use the variables see the same version as libc, rather than a copy. 

This PR produces a relocation section in libmystcrt.so that exposes the libc global variables like the following:
```bash
readelf -r build/lib/libmystcrt.so
Relocation section '.rela.dyn' at offset 0x16898 contains 71 entries:
  Offset          Info           Type           Sym. Value    Sym. Name + Addend
0000002e3bb8  000000000008 R_X86_64_RELATIVE                    188ff
...
0000002e3f70  041600000006 R_X86_64_GLOB_DAT 00000000002e82f8 __daylight + 0
0000002e3f78  055c00000006 R_X86_64_GLOB_DAT 00000000002e3d98 stdout + 0
0000002e3f80  01f000000006 R_X86_64_GLOB_DAT 00000000002e83e0 __stack_chk_guard + 0
0000002e3f88  05d200000006 R_X86_64_GLOB_DAT 00000000002e7f80 __tzname + 0
0000002e3f90  05de00000006 R_X86_64_GLOB_DAT 00000000002e83f0 **optarg** + 0
0000002e3f98  079b00000006 R_X86_64_GLOB_DAT 00000000002e4404 opterr + 0
0000002e3fa0  06ca00000006 R_X86_64_GLOB_DAT 00000000002e8418 getdate_err + 0
0000002e3fa8  001500000006 R_X86_64_GLOB_DAT 00000000002e8020 __environ + 0
0000002e3fb0  05b100000006 R_X86_64_GLOB_DAT 00000000002e8410 h_errno + 0
0000002e3fb8  00aa00000006 R_X86_64_GLOB_DAT 00000000002e4400 optind + 0
0000002e3fc0  072400000006 R_X86_64_GLOB_DAT 00000000002e8048 __progname + 0
0000002e3fc8  02c700000006 R_X86_64_GLOB_DAT 00000000002e8298 __optreset + 0
0000002e3fd0  005f00000006 R_X86_64_GLOB_DAT 00000000002e3d88 stderr + 0
0000002e3fd8  03d200000006 R_X86_64_GLOB_DAT 00000000002e83fc optopt + 0
0000002e3fe0  051f00000006 R_X86_64_GLOB_DAT 00000000002e8294 __signgam + 0
0000002e3fe8  046b00000006 R_X86_64_GLOB_DAT 00000000002e8190 __timezone + 0
0000002e3ff0  016100000006 R_X86_64_GLOB_DAT 00000000002e8050 program_invocation_nam + 0
0000002e3ff8  063300000006 R_X86_64_GLOB_DAT 00000000002e8050 __progname_full + 0
```
 
Without the exposed symbols, and if the application is compiled without `-fPIC`, the synamic loader would relocate the symbols as `R_X86_64_COPY`, effectively creating a copy. If the glibc function `getopt` is called to parse a command line option, the parsed argument is saved in variable `optarg`. But that's useless to the application because the application is reading another copy. 