### PR TITLE
Fix appbuilder issues

### DIFF
--- a/scripts/appbuilder
+++ b/scripts/appbuilder
@@ -8,21 +8,23 @@
 function print_usage {
     echo "$(basename $0): a useful shell script for converting Docker images into Mystikos cpio archives"
     echo
-    echo "Usage: $(basename $0) [-o file] [-d [file]] [[-i] image]"
+    echo "Usage: $(basename $0) [-o file] [-d [file]] [[-i] image] [-e extras] [-v]"
     echo
     echo "  -d file     Build docker image from the named file"
     echo "              Defaults to './Dockerfile' if no option specified"
     echo "  -i image    Specify an existing Docker image name to build from"
     echo "              If neither -d nor -i are specified, will look for Dockerfile in current dir"
     echo "  -f format   Specify the output format. Options: dir, cpio. Default: 'dir'"
+    echo "  -e extras   Specify the extra options while building the container image"
     echo "  -o      Specify the name of the output file or directory"
     echo "          If not specified, defaults to 'appdir'"
+    echo "  -v      Verbose"
     echo "  -h      Print this help message"
     echo
 }
 
 
-while getopts 'hvd:i:f:o:' OPTION; do
+while getopts 'hvd:i:f:o:e:' OPTION; do
     case "$OPTION" in
         d )
             DOCKER_FILE=${OPTARG:-Dockerfile}
@@ -39,6 +41,9 @@ while getopts 'hvd:i:f:o:' OPTION; do
             ;;
         o )
             OUTPUT_NAME="$OPTARG"
+            ;;
+        e )
+            EXTRA_ARGS="$OPTARG"
             ;;
         v )
             VERBOSE=true;
@@ -71,10 +76,10 @@ set -e
 if [ -z "$IMAGE_NAME" -o "$IMAGE_NAME" == "Dockerfile" ]; then
     USE_DOCKERFILE=true
     if [ -z "$DOCKER_FILE" -a -f 'Dockerfile' ]; then
-        DOCKER_FILE='./'
+        DOCKER_FILE='Dockerfile'
     elif [ ! -f "$DOCKER_FILE" ]; then
-	echo "Could not find specific docker file: $DOCKER_FILE"
-	exit 1
+        echo "Could not find specific docker file: $DOCKER_FILE"
+        exit 1
     fi
 else
     USE_DOCKERFILE=false
@@ -118,7 +123,7 @@ fi
 get_image()
 {
     if $USE_DOCKERFILE; then
-        IMAGE_NAME=$(docker build -q $DOCKER_FILE)
+        IMAGE_NAME=$(docker build -q -f $DOCKER_FILE $EXTRA_ARGS .)
         DELETE_IMAGE=true
     else
         docker pull $IMAGE_NAME
@@ -141,9 +146,13 @@ export_image()
 	docker rmi -f $IMAGE_NAME
     fi
 
-    # finally, create the output cpio object from the docker export
+    # create the 'appdir' from the docker export
     tar xf $TEMP_FILE -C $TEMP_DIR
     rm -rf $OUTPUT_NAME
+
+    # create an explicit name server
+    DNS_SERVER=$(systemd-resolve --status | grep "DNS Servers" | cut -f2 -d:)
+    echo "nameserver $DNS_SERVER" >> $TEMP_DIR/etc/resolv.conf
 
     if [ "$OUTPUT_FORMAT" == "dir" ]; then
         mv $TEMP_DIR $OUTPUT_NAME

--- a/solutions/attested_tls/Makefile
+++ b/solutions/attested_tls/Makefile
@@ -13,8 +13,6 @@ PATH := $(PATH):$(BUILDDIR)/openenclave/bin
 export PKG_CONFIG_PATH := $(BUILDDIR)/openenclave/share/pkgconfig
 export AZDCAP_DEBUG_LOG_LEVEL := 0
 
-DNSSERVER = $(shell systemd-resolve --status | grep "DNS Servers" | cut -f2 -d:)
-
 all: myst app
 	$(MYST) mkcpio $(APPDIR) rootfs
 

--- a/solutions/sql_ae/Makefile
+++ b/solutions/sql_ae/Makefile
@@ -7,8 +7,6 @@ APPDIR = appdir
 CFLAGS = -fPIC
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-DNSSERVER = $(shell systemd-resolve --status | grep "DNS Servers" | cut -f2 -d:)
-
 OPTS = --strace
 
 all: myst app
@@ -26,7 +24,6 @@ app:
 	docker run --rm -v $(CURDIR)/app:/app alpine.build bash -c "gcc -g -fshort-wchar -fPIC -o /app/cksp.so -shared /app/cksp.c -I/opt/microsoft/msodbcsql17/include; gcc -g -o /app/odbc_app -fshort-wchar /app/odbc_app.c /app/odbc_helper.c -lodbc -ldl -I/opt/microsoft/msodbcsql17/include"
 	sudo chown $(USER):$(GROUP) app/odbc_app
 	$(TOP)/scripts/appbuilder Dockerfile
-	echo "nameserver $(DNSSERVER)" >> $(APPDIR)/etc/resolv.conf
 	cp app/odbc_app $(APPDIR)/odbc_app
 	cp app/cksp.so $(APPDIR)/cksp.so
 	# make sure the app we are running is the one we just built.

--- a/tests/curl/Makefile
+++ b/tests/curl/Makefile
@@ -3,7 +3,6 @@ include $(TOP)/defs.mak
 
 APPDIR=$(CURDIR)/appdir
 APPBUILDER=$(TOP)/scripts/appbuilder
-DNSSERVER = $(shell systemd-resolve --status | grep "DNS Servers" | cut -f2 -d:)
 
 ifdef STRACE
 OPTS = --strace
@@ -26,7 +25,6 @@ gdb: all
 
 appdir:
 	$(APPBUILDER) Dockerfile
-	echo "nameserver $(DNSSERVER)" >> $(APPDIR)/etc/resolv.conf
 
 rootfs:
 	$(BINDIR)/myst mkcpio appdir rootfs


### PR DESCRIPTION
1) Interpret "-d" option correctly;
2) Add "-e" option for extra options to the container image build command;
3) Generate name server on appdir and remove the now redundant commands in Makefiles;
4) Produce more meaningful help messages for appbuilder.

Fix #216 #217

Signed-off-by: Xuejun Yang <xuejya@microsoft.com>