### PR TITLE
Thread-processor affinity

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -79,6 +79,9 @@ typedef struct myst_kernel_args
     /* The number of threads that can be created (including the main thread) */
     size_t max_threads;
 
+    /* The tid/pid of the main thread passed from the host */
+    pid_t target_tid;
+
     /* Tracing options */
     bool trace_errors;
     bool trace_syscalls;

--- a/include/myst/tcall.h
+++ b/include/myst/tcall.h
@@ -96,7 +96,8 @@ long myst_tcall_load_symbols(void);
 
 long myst_tcall_unload_symbols(void);
 
-typedef long (*myst_run_thread_t)(uint64_t cookie, uint64_t event);
+typedef long (
+    *myst_run_thread_t)(uint64_t cookie, uint64_t event, pid_t target_tid);
 
 long myst_tcall_set_run_thread_function(myst_run_thread_t function);
 

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -81,6 +81,9 @@ struct myst_thread
     /* unique thread identifier (same as pid for main thread) */
     pid_t tid;
 
+    /* the value returned by gettid() on the target (for this thread) */
+    pid_t target_tid;
+
     /* The exit status passed to SYS_exit */
     int exit_status;
 
@@ -100,7 +103,7 @@ struct myst_thread
     myst_td_t* target_td;
 
     /* called by target to run child theads */
-    long (*run_thread)(uint64_t cookie, uint64_t event);
+    long (*run_thread)(uint64_t cookie, uint64_t event, pid_t target_tid);
 
     /* synchronization event from myst_thread_t.run_thread() */
     uint64_t event;
@@ -285,7 +288,7 @@ MYST_INLINE myst_thread_t* myst_find_process_thread(myst_thread_t* thread)
     return t;
 }
 
-long myst_run_thread(uint64_t cookie, uint64_t event);
+long myst_run_thread(uint64_t cookie, uint64_t event, pid_t target_tid);
 
 pid_t myst_generate_tid(void);
 

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -404,7 +404,10 @@ static int _teardown_tmpfs(void)
 }
 #endif
 
-static int _create_main_thread(uint64_t event, myst_thread_t** thread_out)
+static int _create_main_thread(
+    uint64_t event,
+    pid_t target_tid,
+    myst_thread_t** thread_out)
 {
     int ret = 0;
     myst_thread_t* thread = NULL;
@@ -425,6 +428,7 @@ static int _create_main_thread(uint64_t event, myst_thread_t** thread_out)
     thread->ppid = ppid;
     thread->pid = pid;
     thread->tid = pid;
+    thread->target_tid = target_tid;
     thread->event = event;
     thread->target_td = myst_get_fsbase();
     thread->main.thread_group_lock = MYST_SPINLOCK_INITIALIZER;
@@ -672,7 +676,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     }
 
     /* Create the main thread */
-    ECHECK(_create_main_thread(args->event, &thread));
+    ECHECK(_create_main_thread(args->event, args->target_tid, &thread));
     __myst_main_thread = thread;
 
     thread->main.cwd_lock = MYST_SPINLOCK_INITIALIZER;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2367,6 +2367,22 @@ done:
     return ret;
 }
 
+struct getcpu_cache;
+
+long myst_syscall_getcpu(
+    unsigned* cpu,
+    unsigned* node,
+    struct getcpu_cache* tcache)
+{
+    long ret = 0;
+
+    long params[6] = {(long)cpu, (long)node, (long)tcache};
+    ECHECK((ret = myst_tcall(SYS_getcpu, params)));
+
+done:
+    return ret;
+}
+
 long myst_syscall_ret(long ret)
 {
     if (ret < 0)
@@ -4582,18 +4598,12 @@ long myst_syscall(long n, long params[6])
             unsigned* cpu = (unsigned*)x1;
             unsigned* node = (unsigned*)x2;
             struct getcpu_cache* tcache = (struct getcpu_cache*)x3;
+            long ret;
 
             _strace(n, "cpu=%p node=%p, tcache=%p", cpu, node, tcache);
 
-            // ATTN: report the real NUMA node id and cpu id.
-            // For now, always report id 0 for them.
-            if (cpu)
-                *cpu = 0;
-
-            if (node)
-                *node = 0;
-
-            BREAK(_return(n, 0));
+            ret = myst_syscall_getcpu(cpu, node, tcache);
+            BREAK(_return(n, ret));
         }
         case SYS_process_vm_readv:
             break;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -451,6 +451,7 @@ struct run_thread_arg
     myst_thread_t* thread;
     uint64_t cookie;
     uint64_t event;
+    pid_t target_tid;
 };
 
 /* The target calls this from the new thread */
@@ -468,6 +469,8 @@ static long _run_thread(void* arg_)
         myst_set_gsbase(target_td);
 
     myst_assume(myst_valid_thread(thread));
+
+    thread->target_tid = arg->target_tid;
 
     is_child_thread = thread->crt_td ? true : false;
 
@@ -617,7 +620,7 @@ static long _run_thread(void* arg_)
     return 0;
 }
 
-long myst_run_thread(uint64_t cookie, uint64_t event)
+long myst_run_thread(uint64_t cookie, uint64_t event, pid_t target_tid)
 {
     long ret = 0;
     myst_thread_t* thread;
@@ -642,7 +645,7 @@ long myst_run_thread(uint64_t cookie, uint64_t event)
         ERAISE(-ENOMEM);
 
     /* run the thread on the transient stack */
-    struct run_thread_arg arg = {thread, cookie, event};
+    struct run_thread_arg arg = {thread, cookie, event, target_tid};
     ECHECK(myst_call_on_stack(stack + stack_size, _run_thread, &arg));
 
 done:

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -527,6 +527,8 @@ long myst_tcall(long n, long params[6])
         case SYS_fstatfs:
         case SYS_lseek:
         case SYS_utimensat:
+        case SYS_sched_setaffinity:
+        case SYS_sched_getaffinity:
         {
             return _forward_syscall(n, x1, x2, x3, x4, x5, x6);
         }

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -529,6 +529,7 @@ long myst_tcall(long n, long params[6])
         case SYS_utimensat:
         case SYS_sched_setaffinity:
         case SYS_sched_getaffinity:
+        case SYS_getcpu:
         {
             return _forward_syscall(n, x1, x2, x3, x4, x5, x6);
         }

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -608,6 +608,7 @@ long myst_tcall(long n, long params[6])
         case SYS_utimensat:
         case SYS_sched_setaffinity:
         case SYS_sched_getaffinity:
+        case SYS_getcpu:
         {
             extern long myst_handle_tcall(long n, long params[6]);
             return myst_handle_tcall(n, params);

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -606,6 +606,8 @@ long myst_tcall(long n, long params[6])
         case SYS_fstatfs:
         case SYS_lseek:
         case SYS_utimensat:
+        case SYS_sched_setaffinity:
+        case SYS_sched_getaffinity:
         {
             extern long myst_handle_tcall(long n, long params[6]);
             return myst_handle_tcall(n, params);

--- a/target/shared/runthread.c
+++ b/target/shared/runthread.c
@@ -5,7 +5,7 @@
 
 extern myst_run_thread_t __myst_run_thread;
 
-long myst_run_thread(uint64_t cookie, uint64_t event)
+long myst_run_thread(uint64_t cookie, uint64_t event, pid_t target_tid)
 {
-    return (*__myst_run_thread)(cookie, event);
+    return (*__myst_run_thread)(cookie, event, target_tid);
 }

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -165,6 +165,3 @@ one:
 	$(MYST) mkcpio ramfs.appdir ramfs
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) $(TEST) $(NL)
 endif
-
-t:
-	make one TEST=/ltp/testcases/kernel/syscalls/link/link05 FS=ramfs #ETRACE=1 STRACE=1

--- a/tests/pthread/pthread.c
+++ b/tests/pthread/pthread.c
@@ -764,7 +764,6 @@ int main(int argc, const char* argv[])
     {
         printf("=== pass %zu\n", i);
         test_affinity();
-#if 0
         test_create_thread();
         test_mutexes(PTHREAD_MUTEX_NORMAL);
         test_mutexes(PTHREAD_MUTEX_RECURSIVE);
@@ -773,7 +772,6 @@ int main(int argc, const char* argv[])
         test_cond_broadcast();
         if (_get_max_threads() != LONG_MAX)
             test_exhaust_threads();
-#endif
     }
 
     struct tms tms;

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -242,6 +242,7 @@ static long _enter(void* arg_)
     const void* envp_data = arg->envp_data;
     size_t envp_size = arg->envp_size;
     uint64_t event = arg->event;
+    pid_t target_tid = arg->target_tid;
     bool trace_errors = false;
     bool trace_syscalls = false;
     bool export_ramfs = false;
@@ -419,7 +420,6 @@ static long _enter(void* arg_)
     {
         myst_kernel_args_t kargs;
         myst_kernel_entry_t entry;
-<<<<<<< HEAD
         extern const void* __oe_get_heap_base(void);
         const void* regions_end = __oe_get_heap_base();
         const bool tee_debug_mode = _test_oe_debug_mode() == 0;
@@ -444,64 +444,13 @@ static long _enter(void* arg_)
             false, /* have_syscall_instruction */
             tee_debug_mode,
             event, /* thread_event */
+            target_tid,
             myst_tcall,
             rootfs,
             err,
             sizeof(err));
 
         /* set ehdr and verify that the kernel is an ELF image */
-=======
-
-        memset(&kargs, 0, sizeof(kargs));
-        kargs.image_data = enclave_base;
-        kargs.image_size = enclave_size;
-        kargs.kernel_data = kernel_data;
-        kargs.kernel_size = kernel_size;
-        kargs.reloc_data = kernel_reloc_data;
-        kargs.reloc_size = kernel_reloc_size;
-        kargs.crt_reloc_data = crt_reloc_data;
-        kargs.crt_reloc_size = crt_reloc_size;
-        kargs.symtab_data = kernel_symtab_data;
-        kargs.symtab_size = kernel_symtab_size;
-        kargs.dynsym_data = kernel_dynsym_data;
-        kargs.dynsym_size = kernel_dynsym_size;
-        kargs.strtab_data = kernel_strtab_data;
-        kargs.strtab_size = kernel_strtab_size;
-        kargs.dynstr_data = kernel_dynstr_data;
-        kargs.dynstr_size = kernel_dynstr_size;
-        kargs.argc = args.size;
-        kargs.argv = args.data;
-        kargs.envc = env.size;
-        kargs.envp = env.data;
-        kargs.cwd = cwd;
-        kargs.hostname = hostname;
-        kargs.mman_data = mman_data;
-        kargs.mman_size = mman_size;
-        kargs.rootfs_data = (void*)rootfs_data;
-        kargs.rootfs_size = rootfs_size;
-        kargs.archive_data = (void*)archive_data;
-        kargs.archive_size = archive_size;
-        kargs.crt_data = (void*)crt_data;
-        kargs.crt_size = crt_size;
-        kargs.max_threads = _get_num_tcs();
-        kargs.trace_errors = trace_errors;
-        kargs.trace_syscalls = trace_syscalls;
-        kargs.export_ramfs = export_ramfs;
-        kargs.tcall = myst_tcall;
-        kargs.event = event;
-        kargs.target_tid = target_tid;
-
-        /* determine whether in SGX debug mode */
-        if (_test_oe_debug_mode() == 0)
-            kargs.tee_debug_mode = true;
-        else
-            kargs.tee_debug_mode = false;
-
-        if (rootfs)
-            myst_strlcpy(kargs.rootfs, rootfs, sizeof(kargs.rootfs));
-
-        /* Verify that the kernel is an ELF image */
->>>>>>> add SYS_sched_getaffinity & SYS_sched_setaffinity
         {
             ehdr = (const Elf64_Ehdr*)kargs.kernel_data;
             const uint8_t ident[] = {0x7f, 'E', 'L', 'F'};

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -399,7 +399,7 @@ static void* _thread_func(void* arg)
     uint64_t cookie = (uint64_t)arg;
     uint64_t event = (uint64_t)&_thread_event;
 
-    if (myst_run_thread(cookie, event) != 0)
+    if (myst_run_thread(cookie, event, (pid_t)syscall(SYS_gettid)) != 0)
     {
         fprintf(stderr, "myst_run_thread() failed\n");
         exit(1);

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -225,6 +225,7 @@ static int _enter_kernel(
                 have_syscall_instruction,
                 tee_debug_mode,
                 (uint64_t)&_thread_event,
+                (pid_t)syscall(SYS_gettid),
                 tcall,
                 options->rootfs,
                 terr,

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -378,3 +378,11 @@ long myst_sched_getaffinity_ocall(
 {
     RETURN(syscall(SYS_sched_getaffinity, pid, cpusetsize, mask));
 }
+
+long myst_getcpu_ocall(
+    unsigned* cpu,
+    unsigned* node,
+    struct myst_getcpu_cache* tcache)
+{
+    RETURN(syscall(SYS_getcpu, cpu, node, tcache));
+}

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
+#include <sched.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
@@ -358,4 +359,22 @@ long myst_utimensat_ocall(
 {
     /* bypass the glibc wrapper (it raises EINVAL when pathname is null */
     RETURN(syscall(SYS_utimensat, dirfd, pathname, times, flags));
+}
+
+long myst_sched_setaffinity_ocall(
+    pid_t pid,
+    size_t cpusetsize,
+    const struct myst_cpu_set* mask)
+{
+    RETURN(syscall(SYS_sched_setaffinity, pid, cpusetsize, mask));
+}
+
+MYST_STATIC_ASSERT(sizeof(struct myst_cpu_set) == sizeof(cpu_set_t));
+
+long myst_sched_getaffinity_ocall(
+    pid_t pid,
+    size_t cpusetsize,
+    struct myst_cpu_set* mask)
+{
+    RETURN(syscall(SYS_sched_getaffinity, pid, cpusetsize, mask));
 }

--- a/tools/myst/kargs.c
+++ b/tools/myst/kargs.c
@@ -55,6 +55,7 @@ int init_kernel_args(
     bool have_syscall_instruction,
     bool tee_debug_mode,
     uint64_t thread_event,
+    pid_t target_tid,
     long (*tcall)(long n, long params[6]),
     const char* rootfs,
     char* err,
@@ -251,6 +252,7 @@ int init_kernel_args(
     args->have_syscall_instruction = have_syscall_instruction;
     args->export_ramfs = export_ramfs;
     args->event = thread_event;
+    args->target_tid = target_tid;
     args->tee_debug_mode = tee_debug_mode;
     args->tcall = tcall;
 

--- a/tools/myst/kargs.h
+++ b/tools/myst/kargs.h
@@ -22,6 +22,7 @@ int init_kernel_args(
     bool have_syscall_instruction,
     bool tee_debug_mode,
     uint64_t thread_event,
+    pid_t target_tid,
     long (*tcall)(long n, long params[6]),
     const char* rootfs,
     char* err,

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -20,11 +20,6 @@ enclave
        long tv_nsec;
     };
 
-    struct myst_cpu_set
-    {
-        uint64_t buf[16];
-    };
-
     struct myst_stat
     {
         unsigned long st_dev;
@@ -70,6 +65,16 @@ enclave
         unsigned short d_reclen;
         unsigned char d_type;
         char d_name[1];
+    };
+
+    struct myst_cpu_set
+    {
+        uint64_t buf[16];
+    };
+
+    struct myst_getcpu_cache
+    {
+        uint64_t blob[16];
     };
 
     trusted
@@ -399,6 +404,11 @@ enclave
         **
         **======================================================================
         */
+
+        long myst_getcpu_ocall(
+            [out] unsigned* cpu,
+            [out] unsigned* node,
+            [out] struct myst_getcpu_cache* tcache);
 
         long myst_sched_setaffinity_ocall(
             pid_t pid,

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -20,6 +20,10 @@ enclave
        long tv_nsec;
     };
 
+    struct myst_cpu_set
+    {
+        uint64_t buf[16];
+    };
 
     struct myst_stat
     {
@@ -77,9 +81,13 @@ enclave
             size_t args_size,
             [in, size=env_size] const void* env,
             size_t env_size,
-            uint64_t event);
+            uint64_t event,
+            pid_t target_tid);
 
-        public long myst_run_thread_ecall(uint64_t cookie, uint64_t event);
+        public long myst_run_thread_ecall(
+            uint64_t cookie,
+            uint64_t event,
+            pid_t target_id);
     };
 
     untrusted
@@ -383,5 +391,23 @@ enclave
         int myst_load_fssig_ocall(
             [in, string] const char* path,
             [out] myst_fssig_t* fssig);
+
+        /*
+        **======================================================================
+        **
+        ** processor
+        **
+        **======================================================================
+        */
+
+        long myst_sched_setaffinity_ocall(
+            pid_t pid,
+            size_t cpusetsize,
+            [in] const struct myst_cpu_set* mask);
+
+        long myst_sched_getaffinity_ocall(
+            pid_t pid,
+            size_t cpusetsize,
+            [out] struct myst_cpu_set* mask);
     };
 };


### PR DESCRIPTION
This change support ``SYS_sched_getaffinity`` and ``SYS_sched_setaffinity`` by forwarding these to the the target (via an OCALL). It also adds a way to map from a kernel thread TID to a target thread TID**.

**Caution:** This change causes Python to attempt the ``SYS_bind`` syscall, which is needed before this change is complete.