### PR TITLE
Debug malloc feature

### DIFF
--- a/include/myst/debugmalloc.h
+++ b/include/myst/debugmalloc.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_DEBUGMALLOC_H
+#define _MYST_DEBUGMALLOC_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+void* myst_debug_malloc(size_t size);
+
+void myst_debug_free(void* ptr);
+
+void* myst_debug_calloc(size_t nmemb, size_t size);
+
+void* myst_debug_realloc(void* ptr, size_t size);
+
+int myst_debug_posix_memalign(void** memptr, size_t alignment, size_t size);
+
+void* myst_debug_memalign(size_t alignment, size_t size);
+
+size_t myst_debug_malloc_check(bool dump);
+
+void myst_debug_malloc_dump(void);
+
+void myst_debug_malloc_dump_used(void);
+
+extern bool myst_enable_debug_malloc;
+
+#endif /* _MYST_DEBUGMALLOC_H */

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -94,6 +94,9 @@ typedef struct myst_kernel_args
     /* true if --shell option present */
     bool shell_mode;
 
+    /* true if --memcheck option present */
+    bool memcheck;
+
     /* Callback for making target-calls */
     myst_tcall_t tcall;
 

--- a/include/myst/malloc.h
+++ b/include/myst/malloc.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_MALLOC_H
+#define _MYST_MALLOC_H
+
+#include <stddef.h>
+
+void* myst_malloc(size_t size);
+
+void myst_free(void* ptr);
+
+void* myst_calloc(size_t nmemb, size_t size);
+
+void* myst_realloc(void* ptr, size_t size);
+
+int myst_posix_memalign(void** memptr, size_t alignment, size_t size);
+
+void* myst_memalign(size_t alignment, size_t size);
+
+#endif /* _MYST_MALLOC_H */

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -15,6 +15,7 @@ typedef struct myst_options
     bool have_syscall_instruction;
     bool export_ramfs;
     bool shell_mode;
+    bool memcheck;
     char rootfs[PATH_MAX];
 } myst_options_t;
 

--- a/kernel/backtrace.c
+++ b/kernel/backtrace.c
@@ -153,6 +153,9 @@ void myst_dump_backtrace(void** buffer, size_t size)
         if (_addr_to_func_name(addr, &name) == 0)
             myst_eprintf("%p: %s()\n", buffer[i], name);
         else
-            myst_eprintf("%p: unknown\n", buffer[i]);
+        {
+            /* ignore unnknown addresses */
+            break;
+        }
     }
 }

--- a/kernel/debugmalloc.c
+++ b/kernel/debugmalloc.c
@@ -1,0 +1,474 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <myst/backtrace.h>
+#include <myst/debugmalloc.h>
+#include <myst/defs.h>
+#include <myst/malloc.h>
+#include <myst/panic.h>
+#include <myst/spinlock.h>
+
+#define BACKTRACE_MAX 16
+
+/* Flags to control runtime behavior. */
+bool myst_enable_debug_malloc;
+bool myst_enable_debug_malloc_memset = true;
+bool myst_enable_debug_free_memset = true;
+
+/*
+**==============================================================================
+**
+** Debug allocator:
+**
+**     This allocator checks for the following memory errors.
+**
+**         (1) Leaked blocks on program exit.
+**         (2) Memory overwrites just before/after the block.
+**         (3) Assuming blocks are zero filled (fills new blocks with 0xAA).
+**         (3) Use of free memory (fills freed blocks with 0xDD).
+**
+**     This allocator keeps in-use blocks on a linked list. Each block has the
+**     following layout.
+**
+**         [padding] [header] [user-data] [footer]
+**
+**     The padding is applied by memalign() when the alignment is non-zero.
+**
+**==============================================================================
+*/
+
+/*
+**==============================================================================
+**
+** Local definitions:
+**
+**==============================================================================
+*/
+
+#define HEADER_MAGIC1 0x185f0447c6f5440f
+#define HEADER_MAGIC2 0x56cfbed5df804061
+#define FOOTER_MAGIC 0x8bb6dcd8f4724bc7
+
+typedef struct header header_t;
+
+struct header
+{
+    /* Contains HEADER_MAGIC1 */
+    uint64_t magic1;
+
+    /* Headers are kept on a doubly-linked list */
+    header_t* next;
+    header_t* prev;
+
+    /* The alignment passed to memalign() or zero */
+    uint64_t alignment;
+
+    /* Size of user memory */
+    size_t size;
+
+    /* Return addresses obtained by myst_backtrace() */
+    void* addrs[BACKTRACE_MAX];
+    uint64_t num_addrs;
+
+    /* Option if current object is tracked */
+    int32_t session_number;
+
+    /* Padding to make header a multiple of 16 */
+    uint8_t padding[4];
+
+    /* Contains HEADER_MAGIC2 */
+    uint64_t magic2;
+
+    /* User data */
+    uint8_t data[];
+};
+
+/* Verify that the sizeof(header_t) is a multiple of 16 */
+MYST_STATIC_ASSERT(sizeof(header_t) % 16 == 0);
+
+typedef struct footer footer_t;
+
+struct footer
+{
+    /* Contains FOOTER_MAGIC */
+    uint64_t magic;
+};
+
+MYST_STATIC_ASSERT(sizeof(footer_t) == sizeof(uint64_t));
+
+MYST_INLINE uint64_t _round_up_to_multiple(uint64_t x, uint64_t m)
+{
+    return (x + m - 1) / m * m;
+}
+
+MYST_INLINE bool _is_ptrsize_multiple(size_t n)
+{
+    size_t d = n / sizeof(void*);
+    size_t r = n % sizeof(void*);
+    return (d >= 1 && r == 0);
+}
+
+MYST_INLINE bool _is_pow2(size_t n)
+{
+    return (n != 0) && ((n & (n - 1)) == 0);
+}
+
+/* Get a pointer to the header from the user data */
+MYST_INLINE header_t* _get_header(void* ptr)
+{
+    return (header_t*)((uint8_t*)ptr - sizeof(header_t));
+}
+
+/* Get a pointer to the footer from the user data */
+MYST_INLINE footer_t* _get_footer(void* ptr)
+{
+    header_t* header = _get_header(ptr);
+    size_t rsize = _round_up_to_multiple(header->size, sizeof(uint64_t));
+    return (footer_t*)((uint8_t*)ptr + rsize);
+}
+
+/* Use a macro so the function name will not appear in the backtrace */
+#define INIT_BLOCK(HEADER, ALIGNMENT, SIZE)                         \
+    do                                                              \
+    {                                                               \
+        HEADER->magic1 = HEADER_MAGIC1;                             \
+        HEADER->next = NULL;                                        \
+        HEADER->prev = NULL;                                        \
+        HEADER->alignment = ALIGNMENT;                              \
+        HEADER->size = SIZE;                                        \
+        HEADER->num_addrs =                                         \
+            (uint64_t)myst_backtrace(HEADER->addrs, BACKTRACE_MAX); \
+        HEADER->magic2 = HEADER_MAGIC2;                             \
+        _get_footer(HEADER->data)->magic = FOOTER_MAGIC;            \
+    } while (0)
+
+/* Assert and abort if magic numbers are wrong */
+static void _check_block(header_t* header)
+{
+    if (header->magic1 != HEADER_MAGIC1)
+        myst_panic("_check_block() panic: header magic1");
+
+    if (header->magic2 != HEADER_MAGIC2)
+        myst_panic("_check_block() panic: header magic2");
+
+    if (_get_footer(header->data)->magic != FOOTER_MAGIC)
+        myst_panic("_check_block() panic: footer magic");
+}
+
+/* Calculate the padding size for a block with this aligment */
+MYST_INLINE size_t _get_padding_size(size_t alignment)
+{
+    if (!alignment)
+        return 0;
+
+    const size_t header_size = sizeof(header_t);
+    return _round_up_to_multiple(header_size, alignment) - header_size;
+}
+
+MYST_INLINE void* _get_block_address(void* ptr)
+{
+    header_t* header = _get_header(ptr);
+    const size_t padding_size = _get_padding_size(header->alignment);
+    return (uint8_t*)ptr - sizeof(header_t) - padding_size;
+}
+
+MYST_INLINE size_t _calculate_block_size(size_t alignment, size_t size)
+{
+    size_t r = 0;
+    r += _get_padding_size(alignment);
+    r += sizeof(header_t);
+    r += _round_up_to_multiple(size, sizeof(uint64_t));
+    r += sizeof(footer_t);
+
+    /* Check for overflow */
+    if (r < size)
+        return SIZE_MAX;
+
+    return r;
+}
+
+MYST_INLINE size_t _get_block_size(void* ptr)
+{
+    const header_t* header = _get_header(ptr);
+    return _calculate_block_size(header->alignment, header->size);
+}
+
+/* Doubly-linked list of headers */
+typedef struct _list
+{
+    header_t* head;
+    header_t* tail;
+} list_t;
+
+static list_t _list = {NULL, NULL};
+static myst_spinlock_t _spin = MYST_SPINLOCK_INITIALIZER;
+
+static void _list_insert(list_t* list, header_t* header)
+{
+    myst_spin_lock(&_spin);
+    {
+        if (list->head)
+        {
+            header->prev = NULL;
+            header->next = list->head;
+            list->head->prev = header;
+            list->head = header;
+        }
+        else
+        {
+            header->prev = NULL;
+            header->next = NULL;
+            list->head = header;
+            list->tail = header;
+        }
+    }
+    myst_spin_unlock(&_spin);
+}
+
+static void _list_remove(list_t* list, header_t* header)
+{
+    myst_spin_lock(&_spin);
+    {
+        if (header->next)
+            header->next->prev = header->prev;
+
+        if (header->prev)
+            header->prev->next = header->next;
+
+        if (header == list->head)
+            list->head = header->next;
+        else if (header == list->tail)
+            list->tail = header->prev;
+    }
+    myst_spin_unlock(&_spin);
+}
+
+MYST_INLINE bool _check_multiply_overflow(size_t x, size_t y)
+{
+    if (x == 0 || y == 0)
+        return false;
+
+    size_t product = x * y;
+
+    if (x == product / y)
+        return false;
+
+    return true;
+}
+
+static void _malloc_dump(size_t size, void* addrs[], int num_addrs)
+{
+    printf("%lu bytes\n", size);
+    myst_dump_backtrace(addrs, num_addrs);
+}
+
+static void _dump(bool dump_blocks, bool need_lock)
+{
+    list_t* list = &_list;
+
+    if (need_lock)
+        myst_spin_lock(&_spin);
+
+    {
+        size_t blocks = 0;
+        size_t bytes = 0;
+
+        /* Count bytes allocated and blocks still in use */
+        for (header_t* p = list->head; p; p = p->next)
+        {
+            blocks++;
+            bytes += p->size;
+        }
+
+        printf("=== blocks in use: %zu bytes in %zu blocks\n", bytes, blocks);
+
+        if (dump_blocks)
+        {
+            for (header_t* p = list->head; p; p = p->next)
+                _malloc_dump(p->size, p->addrs, (int)p->num_addrs);
+
+            printf("\n");
+        }
+    }
+
+    if (need_lock)
+        myst_spin_unlock(&_spin);
+}
+
+/*
+**==============================================================================
+**
+** Public definitions:
+**
+**==============================================================================
+*/
+
+void* myst_debug_malloc(size_t size)
+{
+    void* block;
+    const size_t block_size = _calculate_block_size(0, size);
+
+    if (!(block = myst_malloc(block_size)))
+        return NULL;
+
+    /* fill block with 0xaa (allocated) bytes */
+    if (myst_enable_debug_malloc_memset)
+        memset(block, 0xAA, block_size);
+
+    header_t* header = (header_t*)block;
+    INIT_BLOCK(header, 0, size);
+    _check_block(header);
+    _list_insert(&_list, header);
+
+    return header->data;
+}
+
+void myst_debug_free(void* ptr)
+{
+    if (ptr)
+    {
+        header_t* header = _get_header(ptr);
+        _check_block(header);
+        _list_remove(&_list, header);
+
+        void* block = _get_block_address(ptr);
+
+        /* fill block with 0xdd (deallocated) bytes */
+        if (myst_enable_debug_free_memset)
+            memset(block, 0xDD, _get_block_size(ptr));
+
+        myst_free(block);
+    }
+}
+
+void* myst_debug_calloc(size_t nmemb, size_t size)
+{
+    void* ptr;
+
+    if (_check_multiply_overflow(nmemb, size))
+        return NULL;
+
+    const size_t total_size = nmemb * size;
+
+    if (!(ptr = myst_debug_malloc(total_size)))
+        return NULL;
+
+    memset(ptr, 0, total_size);
+
+    return ptr;
+}
+
+void* myst_debug_realloc(void* ptr, size_t size)
+{
+    if (ptr)
+    {
+        header_t* header = _get_header(ptr);
+        void* new_ptr;
+
+        _check_block(header);
+
+        /* If the size is the same, just return the pointer */
+        if (header->size == size)
+            return ptr;
+
+        if (!(new_ptr = myst_debug_malloc(size)))
+            return NULL;
+
+        if (size > header->size)
+            memcpy(new_ptr, ptr, header->size);
+        else
+            memcpy(new_ptr, ptr, size);
+
+        myst_debug_free(ptr);
+
+        return new_ptr;
+    }
+    else
+    {
+        return myst_debug_malloc(size);
+    }
+}
+
+int myst_debug_posix_memalign(void** memptr, size_t alignment, size_t size)
+{
+    const size_t padding_size = _get_padding_size(alignment);
+    const size_t block_size = _calculate_block_size(alignment, size);
+    void* block = NULL;
+    header_t* header = NULL;
+
+    if (!memptr)
+        return EINVAL;
+
+    if (!_is_ptrsize_multiple(alignment) || !_is_pow2(alignment))
+        return EINVAL;
+
+    if (myst_posix_memalign(&block, alignment, block_size) != 0)
+        return ENOMEM;
+
+    header = (header_t*)((uint8_t*)block + padding_size);
+
+    INIT_BLOCK(header, alignment, size);
+    _check_block(header);
+    _list_insert(&_list, header);
+    *memptr = header->data;
+
+    return 0;
+}
+
+void* myst_debug_memalign(size_t alignment, size_t size)
+{
+    void* ptr = NULL;
+
+    // posix_memalign requires alignment to be a multiple of sizeof(void*)
+    alignment = _round_up_to_multiple(alignment, sizeof(void*));
+
+    myst_debug_posix_memalign(&ptr, alignment, size);
+    return ptr;
+}
+
+size_t myst_debug_malloc_usable_size(void* ptr)
+{
+    if (!ptr)
+        return 0;
+    return _get_header(ptr)->size;
+}
+
+void myst_debug_malloc_dump(void)
+{
+    _dump(true, true);
+}
+
+void myst_debug_malloc_dump_used(void)
+{
+    _dump(false, true);
+}
+
+size_t myst_debug_malloc_check(bool dump)
+{
+    list_t* list = &_list;
+    size_t count = 0;
+
+    myst_spin_lock(&_spin);
+    {
+        for (header_t* p = list->head; p; p = p->next)
+            count++;
+
+        if (count)
+        {
+            if (dump)
+                _dump(true, false);
+
+            for (header_t* p = list->head; p; p = p->next)
+                _check_block(p);
+        }
+    }
+    myst_spin_unlock(&_spin);
+
+    return count;
+}

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -244,6 +244,7 @@ static long _enter(void* arg_)
     bool trace_errors = false;
     bool trace_syscalls = false;
     bool shell_mode = false;
+    bool memcheck = false;
     bool export_ramfs = false;
     const char* rootfs = NULL;
     config_parsed_data_t parsed_config;
@@ -392,6 +393,7 @@ static long _enter(void* arg_)
         trace_errors = options->trace_errors;
         trace_syscalls = options->trace_syscalls;
         shell_mode = options->shell_mode;
+        memcheck = options->memcheck;
         export_ramfs = options->export_ramfs;
 
         if (strlen(options->rootfs) >= PATH_MAX)
@@ -450,6 +452,7 @@ static long _enter(void* arg_)
             sizeof(err));
 
         kargs.shell_mode = shell_mode;
+        kargs.memcheck = memcheck;
 
         /* set ehdr and verify that the kernel is an ELF image */
         {

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -245,6 +245,10 @@ int exec_action(int argc, const char* argv[], const char* envp[])
         if (cli_getopt(&argc, argv, "--shell", NULL) == 0)
             options.shell_mode = true;
 
+        /* Get --memcheck option */
+        if (cli_getopt(&argc, argv, "--memcheck", NULL) == 0)
+            options.memcheck = true;
+
         /* Get --export-ramfs option */
         if (cli_getopt(&argc, argv, "--export-ramfs", NULL) == 0)
             options.export_ramfs = true;


### PR DESCRIPTION
This change adopts the debug-malloc feature from Open Enclave. This debug allocator checks for three kinds of errors:
- leak detection on shutdown
- use of uninitialzed memory from malloc (memory is filled with 0xaa)
- use of freed memory (memory is filled with 0xdd on free)

To enable pass the ``--memcheck`` option to ``myst``