### PR TITLE
mkext2 now creates sudo-user owned files

### DIFF
--- a/host/file.c
+++ b/host/file.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/host/file.c
+++ b/host/file.c
@@ -63,3 +63,32 @@ int myst_write_file_fd(int fd, const void* data, size_t size)
 done:
     return ret;
 }
+
+/* change owner to ${SUDO_UID}.${SUDO_GID} if possible */
+int myst_chown_sudo_user(const char* path)
+{
+    int ret = 0;
+    const char* sudo_uid;
+    const char* sudo_gid;
+    int uid = getuid();
+    int gid = getgid();
+    size_t found = 0;
+
+    if ((sudo_uid = getenv("SUDO_UID")))
+    {
+        ECHECK(myst_str2int(sudo_uid, &uid));
+        found++;
+    }
+
+    if ((sudo_gid = getenv("SUDO_GID")))
+    {
+        ECHECK(myst_str2int(sudo_gid, &gid));
+        found++;
+    }
+
+    if (found && chown(path, uid, gid) != 0)
+        ERAISE(-errno);
+
+done:
+    return ret;
+}

--- a/host/file.c
+++ b/host/file.c
@@ -9,6 +9,7 @@
 
 #include <myst/eraise.h>
 #include <myst/file.h>
+#include <myst/strings.h>
 
 int myst_write_file(const char* path, const void* data, size_t size)
 {

--- a/host/strings.c
+++ b/host/strings.c
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include <myst/strings.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#include <myst/eraise.h>
+#include <myst/strings.h>
 
 char* myst_strdup(const char* s)
 {
@@ -29,4 +32,22 @@ int myst_printf(const char* format, ...)
     va_end(ap);
 
     return n;
+}
+
+int myst_str2int(const char* s, int* x)
+{
+    int ret = 0;
+    char* end;
+    long tmp = strtol(s, &end, 10);
+
+    if (!end || *end)
+        ERAISE(-EINVAL);
+
+    if (tmp < INT_MIN || tmp > INT_MAX)
+        ERAISE(-ERANGE);
+
+    *x = (int)tmp;
+
+done:
+    return ret;
 }

--- a/include/myst/file.h
+++ b/include/myst/file.h
@@ -26,4 +26,6 @@ int myst_copy_file(const char* oldpath, const char* newpath);
 
 int myst_copy_file_fd(char* oldpath, int newfd);
 
+int myst_chown_sudo_user(const char* path);
+
 #endif /* _MYST_FILE_H */

--- a/include/myst/strings.h
+++ b/include/myst/strings.h
@@ -39,4 +39,7 @@ ssize_t myst_memremove_u64(void* data, size_t size, size_t pos, size_t count);
 
 bool myst_isspace(char c);
 
+/* convert a whole string to an integer */
+int myst_str2int(const char* s, int* x);
+
 #endif /* _MYST_STRINGS_H */

--- a/tests/libc/Makefile
+++ b/tests/libc/Makefile
@@ -42,7 +42,7 @@ $(APPDIR)/bin/run: run.c
 
 $(ROOTFS): run.c
 	sudo $(MYST) mkext2 --force $(APPDIR) $(ROOTFS)
-	sudo truncate --size=-4096 $(ROOTFS)
+	truncate --size=-4096 $(ROOTFS)
 
 ##==============================================================================
 ##

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -64,7 +64,6 @@ all: ext2fs
 
 ext2fs: appdir
 	sudo $(MYST) mkext2 --force appdir ext2fs
-	sudo chown $(USER).$(USER) ext2fs
 	truncate --size=-4096 ext2fs
 
 URL=https://github.com/mikbras/ltp

--- a/tests/myst/exec-package-ext2/Makefile
+++ b/tests/myst/exec-package-ext2/Makefile
@@ -14,7 +14,6 @@ all: $(PUBKEY)
 	mkdir -p $(APPDIR)/bin
 	$(MUSL_GCC) -Wall -o $(APPDIR)/bin/hello hello.c
 	sudo $(MYST) mkext2 --force --sign=$(PUBKEY):$(PRIVKEY) $(APPDIR) $(ROOTFS)
-	sudo chown $(USER).$(GROUP) $(ROOTFS)
 	$(MYST) package --pubkey=$(PUBKEY) $(PRIVKEY) config.json
 
 $(PUBKEY): $(PRIVKEY)

--- a/utils/strings.c
+++ b/utils/strings.c
@@ -328,3 +328,21 @@ bool myst_isspace(char c)
             return false;
     }
 }
+
+int myst_str2int(const char* s, int* x)
+{
+    int ret = 0;
+    char* end;
+    long tmp = strtol(s, &end, 10);
+
+    if (!end || *end)
+        ERAISE(-EINVAL);
+
+    if (tmp < INT_MIN || tmp > INT_MAX)
+        ERAISE(-ERANGE);
+
+    *x = (int)tmp;
+
+done:
+    return ret;
+}


### PR DESCRIPTION
The ``sudo myst mkext2`` command previously created files owned by root. This changes that command to create files owned by the sudo user (the user that executed sudo). The sudo program passes the following environment variables:

- ``$SUDO_USER``
- ``$SUDO_UID``
- ``$SUDO_GID``

When the latter two are defined, ``myst mkext2`` changes the owner of output files and directories to $SUDO_UID/$SUDO_GID.