### PR TITLE
Add ubuntu based dotnet hello world application

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2124,7 +2124,10 @@ long myst_syscall_sysinfo(struct sysinfo* info)
     ECHECK(myst_get_total_ram(&totalram));
     ECHECK(myst_get_free_ram(&freeram));
 
-    memset(info, 0, sizeof(struct sysinfo));
+    // Only clear out non-reserved portion of the structure.
+    // This is to be defensive against different sizes of this
+    // structure in musl and glibc.
+    memset(info, 0, sizeof(struct sysinfo) - 256);
     info->totalram = totalram;
     info->freeram = freeram;
     info->mem_unit = 1;
@@ -3735,8 +3738,12 @@ long myst_syscall(long n, long params[6])
 
             // ATTN: Return the priority from SYS_sched_setparam.
             if (param != NULL)
-                memset(param, 0, sizeof(*param));
-
+            {
+                // Only memset the non reserved part of the structure
+                // This is to be defensive against different sizes of this
+                // struct in musl and glibc.
+                memset(param, 0, sizeof(*param) - 40);
+            }
             BREAK(_return(n, 0));
         }
         case SYS_sched_setscheduler:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -90,6 +90,7 @@ DIRS += hostfs
 endif
 
 DIRS += msync
+DIRS += dotnet-ubuntu
 
 __tests:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) tests $(NL) )

--- a/tests/dotnet-ubuntu/Dockerfile
+++ b/tests/dotnet-ubuntu/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /src
+COPY ["hello", "hello/"]
+WORKDIR "/src/hello"
+ENV PATH="/lib/x86_64-linux-gnu/:/usr/lib/x86_64-linux-gnu/:${PATH}"
+RUN dotnet publish -o /app/build --self-contained true -r linux-x64
+
+FROM mcr.microsoft.com/dotnet/runtime:5.0
+
+WORKDIR /app
+COPY --from=build /app/build .
+# Hack: Copy over libraries to where musl can find them.
+RUN rmdir /usr/local/lib && ln -s /lib/x86_64-linux-gnu/ /usr/local/lib && \
+	cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/ && \
+	cp /usr/lib/x86_64-linux-gnu/libicu* /lib/x86_64-linux-gnu/ 

--- a/tests/dotnet-ubuntu/Makefile
+++ b/tests/dotnet-ubuntu/Makefile
@@ -13,7 +13,7 @@ all: appdir ext2fs
 appdir:
 	$(APPBUILDER)
 
-ext2fs:
+ext2fs: appdir
 	sudo $(MYST) mkext2 appdir ext2fs
 	$(MYST) fssig --roothash ext2fs > roothash
 

--- a/tests/dotnet-ubuntu/Makefile
+++ b/tests/dotnet-ubuntu/Makefile
@@ -1,0 +1,44 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+HEAP_SIZE="768M"
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+all: appdir ext2fs
+
+appdir:
+	$(APPBUILDER)
+
+ext2fs:
+	sudo $(MYST) mkext2 appdir ext2fs
+	$(MYST) fssig --roothash ext2fs > roothash
+
+clean:
+	sudo rm -fr appdir ext2fs roothash
+
+tests:
+	$(RUNTEST) $(MYST_EXEC) ext2fs --roothash=roothash \
+	--memory-size $(HEAP_SIZE) \
+	/app/hello $(OPTS)
+
+##############################
+# dev targets
+# ############################
+run-ext2-lldb:
+	/mnt/oelldb/oelldb -- $(MYST) exec ext2fs \
+	--roothash=roothash \
+	--memory-size $(HEAP_SIZE) \
+	/app/hello $(OPTS)
+
+run-ext2-gdb:
+	$(MYST_GDB) --args $(MYST) exec ext2fs \
+	--roothash=roothash \
+	--memory-size $(HEAP_SIZE) \
+	/app/hello $(OPTS)
+
+ct:
+	sudo rm -fr /tmp/myst*

--- a/tests/dotnet-ubuntu/hello/Program.cs
+++ b/tests/dotnet-ubuntu/hello/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace hello
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Debugger.Break();
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/tests/dotnet-ubuntu/hello/hello.csproj
+++ b/tests/dotnet-ubuntu/hello/hello.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -298,6 +298,18 @@ index 50cef8e5..803a7f8d 100644
 +{
 +	return 0;
 +}
+diff --git a/src/include/time.h b/src/include/time.h
+index cbabde47..4f94bc39 100644
+--- a/src/include/time.h
++++ b/src/include/time.h
+@@ -10,6 +10,6 @@ hidden char *__asctime_r(const struct tm *, char *);
+ hidden struct tm *__gmtime_r(const time_t *restrict, struct tm *restrict);
+ hidden struct tm *__localtime_r(const time_t *restrict, struct tm *restrict);
+ 
+-hidden size_t __strftime_l(char *restrict, size_t, const char *restrict, const struct tm *restrict, locale_t);
++size_t __strftime_l(char *restrict, size_t, const char *restrict, const struct tm *restrict, locale_t);
+ 
+ #endif
 diff --git a/src/linux/epoll.c b/src/linux/epoll.c
 index deff5b10..fd66b82a 100644
 --- a/src/linux/epoll.c

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -326,6 +326,20 @@ index deff5b10..fd66b82a 100644
  	return epoll_create1(0);
  }
  
+diff --git a/src/misc/setrlimit.c b/src/misc/setrlimit.c
+index 7a66ab29..b6a2143b 100644
+--- a/src/misc/setrlimit.c
++++ b/src/misc/setrlimit.c
+@@ -39,7 +39,8 @@ static void do_setrlimit(void *p)
+ int setrlimit(int resource, const struct rlimit *rlim)
+ {
+ 	struct ctx c = { .res = resource, .rlim = rlim, .err = -1 };
+-	__synccall(do_setrlimit, &c);
++	// __synccall(do_setrlimit, &c);
++	do_setrlimit(&c);
+ 	if (c.err) {
+ 		if (c.err>0) errno = c.err;
+ 		return -1;
 diff --git a/src/misc/syscall.c b/src/misc/syscall.c
 index 6f3ef656..614121c3 100644
 --- a/src/misc/syscall.c


### PR DESCRIPTION
### Summary of changes
- __strftime_l defintion in musl made visible.
- setrlimit is no longer using  `__synccall` mechanism. `__synccall` sends a special signal to all threads in the thread group, and then waits for the target threads to acknowledge the signal. This can cause a hang up situation if any thread is sleeping, as we don't deliver signals to sleeping threads yet.
- Compared to musl, some structure sizes are smaller in glibc, like - sched_param and sysinfo. This was causing buffer overflows for related syscalls, where the kernel is memsetting the entire structure. The size difference between the structures is due to extra reserved fields in musl. To avoid the buffer overflow, the change was to only clear the non reserved portion of these structures.
