### PR TITLE
Add Redis Sample w/ data persistence disabled

### DIFF
--- a/samples/redis/Dockerfile
+++ b/samples/redis/Dockerfile
@@ -1,0 +1,1 @@
+FROM redis:6.2-alpine

--- a/samples/redis/Makefile
+++ b/samples/redis/Makefile
@@ -1,0 +1,47 @@
+.PHONY: all package $(APPDIR) private.pem
+
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER    = $(TOP)/scripts/appbuilder
+APPDIR        = appdir
+APP_NAME      = redis-server
+SERVICE_ADDR  = localhost
+SERVICE_PORT  = 6379
+LAUNCH_WAIT   = 10	# waiting time in seconds for service launch
+SHUTDOWN_WAIT = 0  	# waiting time in seconds before service being terminated
+# OPTS += --strace
+
+all: package
+
+package: $(APPDIR) private.pem
+	cp redis.conf $(APPDIR)/etc/redis.conf
+	echo "\n\nport $(SERVICE_PORT)" >> $(APPDIR)/etc/redis.conf
+	$(MYST) package-sgx $(APPDIR) private.pem config.json
+
+run: package
+	# Kill the server from a previous run if it wasn't shut down properly.
+	test -f $(APP_NAME).pid && kill -9 `cat $(APP_NAME).pid` || true
+	# Launch the Redis Server
+	@ echo -e "\n------starting Redis server------\n"
+	myst/bin/$(APP_NAME) $(OPTS) & echo $$! > $(APP_NAME).pid
+	sleep $(LAUNCH_WAIT)
+	# Launch testing client script
+	@echo "Run test client outside of the Enclave ..."
+	python3 redis_test.py $(SERVICE_ADDR) $(SERVICE_PORT)
+	# Kill the running instance of the server before exit.
+	sleep $(SHUTDOWN_WAIT)
+	test -f $(APP_NAME).pid && kill -9 `cat $(APP_NAME).pid` && rm $(APP_NAME).pid || true
+
+gdb: clean package
+	@ echo -e "\n------start debugging Redis server------\n"
+	$(MYST_GDB) --args myst/bin/$(APPNAME) $(OPTS)
+
+$(APPDIR):
+	$(APPBUILDER) -d Dockerfile
+
+private.pem:
+	openssl genrsa -out private.pem -3 3072
+
+clean:
+	rm -rf rootfs $(APPDIR) myst private.pem $(APP_NAME).pid

--- a/samples/redis/config.json
+++ b/samples/redis/config.json
@@ -1,0 +1,27 @@
+{
+    // OpenEnclave specific values
+
+    // Whether we are running in debug mode
+    "Debug": 1,
+    // The stack size of each ethread
+    "StackMemSize": "400k",
+    // The number of ethreads
+    "NumUserThreads": 32,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+
+    // The heap size of the user application. Increase this setting if your app experienced OOM.
+    "MemorySize": "1024m",
+    // The path to the entry point application in rootfs
+    "ApplicationPath": "/usr/local/bin/redis-server",
+    // The parameters to the entry point application
+    "ApplicationParameters": ["/etc/redis.conf"],
+    // Whether we allow "ApplicationParameters" to be overridden by command line options of "myst"
+    "HostApplicationParameters": false,
+    // The enclave environment variables
+    "EnvironmentVariables": [],
+    // The host environment variables accessible inside the enclave.
+    "HostEnvironmentVariables": []
+}

--- a/samples/redis/redis.conf
+++ b/samples/redis/redis.conf
@@ -1,0 +1,55 @@
+# /etc/redis.conf
+
+# configuration in the sample
+# 1. Disable AOF by setting the appendonly configuration directive to no (it is the default value).
+# 2. Disable RDB snapshotting by commenting out all of the save configuration directives (there are 3 that are defined by default)
+
+############################## APPEND ONLY MODE ###############################
+
+# By default Redis asynchronously dumps the dataset on disk. This mode is
+# good enough in many applications, but an issue with the Redis process or
+# a power outage may result into a few minutes of writes lost (depending on
+# the configured save points).
+#
+# The Append Only File is an alternative persistence mode that provides
+# much better durability. For instance using the default data fsync policy
+# (see later in the config file) Redis can lose just one second of writes in a
+# dramatic event like a server power outage, or a single write if something
+# wrong with the Redis process itself happens, but the operating system is
+# still running correctly.
+#
+# AOF and RDB persistence can be enabled at the same time without problems.
+# If the AOF is enabled on startup Redis will load the AOF, that is the file
+# with the better durability guarantees.
+#
+# Please check http://redis.io/topics/persistence for more information.
+
+appendonly no
+
+
+################################ SNAPSHOTTING  ################################
+#
+# Save the DB on disk:
+#
+#   save <seconds> <changes>
+#
+#   Will save the DB if both the given number of seconds and the given
+#   number of write operations against the DB occurred.
+#
+#   In the example below the behavior will be to save:
+#   after 900 sec (15 min) if at least 1 key changed
+#   after 300 sec (5 min) if at least 10 keys changed
+#   after 60 sec if at least 10000 keys changed
+#
+#   Note: you can disable saving completely by commenting out all "save" lines.
+#
+#   It is also possible to remove all the previously configured save
+#   points by adding a save directive with a single empty string argument
+#   like in the following example:
+#
+#   save ""
+
+# save 900 1
+# save 300 10
+# save 60 10000
+save ""

--- a/samples/redis/redis_test.py
+++ b/samples/redis/redis_test.py
@@ -1,0 +1,35 @@
+# to run the test requires install redis-py library through pip,
+# sudo pip3 install redis
+import sys
+from redis import Redis
+
+TIMEOUT_SEC = 15
+ITERATION_NUM = 100
+
+host, port = (sys.argv[1], sys.argv[2]) if len(sys.argv) == 3 else ("localhost", "6379")
+
+
+redis_host = "localhost"
+r = Redis(host=redis_host, port=port, socket_connect_timeout=TIMEOUT_SEC)
+
+# heartbeat check
+r.ping()
+print(f"\n>>>>>>>>>>>>>>Connected to redis server {host}:{port}")
+
+# test set/get function
+key = "key"
+for i in range(ITERATION_NUM):
+    value = f"value-{i}"
+    r.set(key, value)
+    result = r.get(key)
+    assert result.decode("utf-8") == value
+
+# test set/get/delete function
+for i in range(ITERATION_NUM):
+    key, value = f"foo-{i}", f"bar-{i}"
+    r.set(key, value)
+    assert r.get(key).decode("utf-8") == value
+    r.delete(key)
+    assert r.get(key) is None
+
+print("all tests passed")


### PR DESCRIPTION
Data persistence is explicitly disabled through `redis.conf` config file to avoid `SYS_fork` being invoked.