### PR TITLE
PLEASE DO NOT REVIEW: Maps

### DIFF
--- a/host/maps.c
+++ b/host/maps.c
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <myst/maps.h>
+
+void myst_maps_dump1(const myst_maps_t* maps)
+{
+    if (maps)
+    {
+        const myst_maps_t* p = maps;
+        char r = (p->prot & PROT_READ) ? 'r' : '-';
+        char w = (p->prot & PROT_WRITE) ? 'w' : '-';
+        char x = (p->prot & PROT_EXEC) ? 'x' : '-';
+        char f = '-';
+
+        if (p->flags & MAP_SHARED)
+            f = 's';
+        else if (p->flags & MAP_PRIVATE)
+            f = 'p';
+
+        printf("%lx-%lx %c%c%c%c\n", p->start, p->end, r, w, x, f);
+    }
+}
+
+void myst_maps_dump(const myst_maps_t* maps)
+{
+    for (const myst_maps_t* p = maps; p; p = p->next)
+        myst_maps_dump1(p);
+}
+
+void myst_maps_free(myst_maps_t* maps)
+{
+    for (myst_maps_t* p = maps; p;)
+    {
+        myst_maps_t* next = p->next;
+        free(p);
+        p = next;
+    }
+}
+
+int myst_maps_load(myst_maps_t** maps_out)
+{
+    int ret = 0;
+    char path[PATH_MAX];
+    FILE* is = NULL;
+    myst_maps_t* head = NULL;
+    myst_maps_t* tail = NULL;
+    char line[4096];
+
+    if (maps_out)
+        *maps_out = NULL;
+
+    if (!maps_out)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    snprintf(path, sizeof(path), "/proc/%d/maps", getpid());
+
+    if (!(is = fopen(path, "r")))
+    {
+        ret = -ENOENT;
+        goto done;
+    }
+
+    /* read line-by-line */
+    while (fgets(line, sizeof(line), is))
+    {
+        uint64_t start;
+        uint64_t end;
+        char r;
+        char w;
+        char x;
+        char f;
+        int n;
+        myst_maps_t* maps;
+
+        n = sscanf(line, "%lx-%lx %c%c%c%c", &start, &end, &r, &w, &x, &f);
+
+        if (n != 6)
+        {
+            ret = -ENOSYS;
+            goto done;
+        }
+
+        if (!(maps = calloc(1, sizeof(myst_maps_t))))
+        {
+            ret = -ENOMEM;
+            goto done;
+        }
+
+        maps->start = start;
+        maps->end = end;
+
+        if (r == 'r')
+            maps->prot |= PROT_READ;
+
+        if (w == 'w')
+            maps->prot |= PROT_WRITE;
+
+        if (x == 'x')
+            maps->prot |= PROT_EXEC;
+
+        if (f == 's')
+            maps->flags |= MAP_SHARED;
+        else if (f == 'p')
+            maps->flags |= MAP_PRIVATE;
+        else
+        {
+            ret = -EINVAL;
+            goto done;
+        }
+
+        if (tail)
+        {
+            tail->next = maps;
+            tail = maps;
+        }
+        else
+        {
+            head = maps;
+            tail = maps;
+        }
+
+#if 0
+        printf("%lx-%lx %c%c%c%c\n", start, end, r, w, x, f);
+        fflush(stdout);
+#endif
+    }
+
+    *maps_out = head;
+    head = NULL;
+
+done:
+
+    if (is)
+        fclose(is);
+
+    if (head)
+        myst_maps_free(head);
+
+    return ret;
+}
+
+void myst_mstat_dump(const struct myst_mstat* buf)
+{
+    if (buf)
+    {
+        char r = (buf->prot & PROT_READ) ? 'r' : '-';
+        char w = (buf->prot & PROT_WRITE) ? 'w' : '-';
+        char x = (buf->prot & PROT_EXEC) ? 'x' : '-';
+        char f = '-';
+
+        if (buf->flags & MAP_SHARED)
+            f = 's';
+        else if (buf->flags & MAP_PRIVATE)
+            f = 'p';
+
+        printf("%c%c%c%c\n", r, w, x, f);
+    }
+}
+
+int myst_mstat(
+    const myst_maps_t* maps,
+    const void* addr,
+    struct myst_mstat* buf)
+{
+    int ret = 0;
+
+    if (buf)
+        memset(buf, 0, sizeof(struct myst_mstat));
+
+    if (!maps || !addr || !buf)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    for (const myst_maps_t* p = maps; p; p = p->next)
+    {
+        if ((uint64_t)addr >= p->start && (uint64_t)addr < p->end)
+        {
+            buf->prot = p->prot;
+            buf->flags = p->flags;
+            goto done;
+        }
+    }
+
+    ret = -ENOMEM;
+
+done:
+    return ret;
+}

--- a/include/myst/maps.h
+++ b/include/myst/maps.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_MAPS_H
+#define _MYST_MAPS_H
+
+#include <stdint.h>
+
+/*
+**==============================================================================
+**
+** Interface to "/proc/<pid>/maps", which keeps track of memory mappings
+**
+**==============================================================================
+*/
+
+struct myst_mstat
+{
+    int prot;
+    int flags;
+};
+
+typedef struct maps
+{
+    struct maps* next;
+    uint64_t start; /* starting address */
+    uint64_t end;   /* ending address */
+    int prot;       /* PROT_READ | PROT_WRITE | PROT_EXEC */
+    int flags;      /* MAP_SHARED | MAP_PRIVATE */
+} myst_maps_t;
+
+void myst_maps_dump1(const myst_maps_t* maps);
+
+void myst_maps_dump(const myst_maps_t* maps);
+
+void myst_maps_free(myst_maps_t* maps);
+
+int myst_maps_load(myst_maps_t** maps_out);
+
+void myst_mstat_dump(const struct myst_mstat* buf);
+
+int myst_mstat(
+    const myst_maps_t* maps,
+    const void* addr,
+    struct myst_mstat* buf);
+
+#endif /* _MYST_MAPS_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -94,6 +94,8 @@ DIRS += dotnet-ubuntu
 
 DIRS += robust
 
+DIRS += maps
+
 __tests:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) tests $(NL) )
 

--- a/tests/maps/Makefile
+++ b/tests/maps/Makefile
@@ -1,0 +1,23 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+PROGRAM = maps
+
+SOURCES = $(wildcard *.c)
+
+INCLUDES = -I$(INCDIR)
+
+CFLAGS = $(OEHOST_CFLAGS) $(GCOV_CFLAGS)
+
+LDFLAGS = $(OEHOST_LDFLAGS) $(GCOV_LDFLAGS)
+
+LIBS = $(LIBDIR)/libmystutils.a $(LIBDIR)/libmysthost.a
+
+REDEFINE_TESTS=1
+
+CLEAN = rootfs ramfs
+
+include $(TOP)/rules.mak
+
+tests:
+	$(RUNTEST) $(PREFIX) $(SUBBINDIR)/maps

--- a/tests/maps/maps.c
+++ b/tests/maps/maps.c
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <myst/maps.h>
+
+void test_big_mapping()
+{
+    size_t length = 8UL * 1024UL * 1024UL * 1024UL;
+    const int prot = PROT_NONE;
+    const int flags = MAP_ANONYMOUS | MAP_PRIVATE;
+
+    uint8_t* addr = mmap(NULL, length, prot, flags, -1, 0);
+    assert(addr != MAP_FAILED);
+    printf("addr=%p\n", addr);
+    munmap(addr, length);
+}
+
+int main(int argc, const char* argv[])
+{
+    const size_t PAGE_SIZE = 4096;
+    size_t length = 8 * PAGE_SIZE;
+    const int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
+    const int flags = MAP_ANONYMOUS | MAP_PRIVATE;
+    myst_maps_t* maps;
+    int r;
+
+    uint8_t* addr = mmap(NULL, length, prot, flags, -1, 0);
+    assert(addr != MAP_FAILED);
+    mprotect(addr + 0 * PAGE_SIZE, PAGE_SIZE, PROT_NONE);
+    mprotect(addr + 1 * PAGE_SIZE, PAGE_SIZE, PROT_READ);
+    mprotect(addr + 2 * PAGE_SIZE, PAGE_SIZE, PROT_WRITE);
+    mprotect(addr + 3 * PAGE_SIZE, PAGE_SIZE, PROT_EXEC);
+    mprotect(addr + 4 * PAGE_SIZE, PAGE_SIZE, PROT_READ | PROT_WRITE);
+    mprotect(addr + 5 * PAGE_SIZE, PAGE_SIZE, PROT_READ | PROT_EXEC);
+    mprotect(addr + 6 * PAGE_SIZE, PAGE_SIZE, PROT_WRITE | PROT_EXEC);
+
+    if ((r = myst_maps_load(&maps)) != 0)
+    {
+        fprintf(stderr, "load_maps() failed: errno=%d\n", -r);
+        exit(1);
+    }
+
+#if 0
+    myst_maps_dump(maps);
+#endif
+
+    for (size_t i = 0; i < (length / PAGE_SIZE); i++)
+    {
+        uint8_t* p = addr + (i * PAGE_SIZE);
+        struct myst_mstat ms;
+
+        myst_mstat(maps, p, &ms);
+
+#if 0
+        myst_mstat_dump(&ms);
+#endif
+
+        assert(ms.flags == MAP_PRIVATE);
+
+        switch (i)
+        {
+            case 0:
+                assert(ms.prot == PROT_NONE);
+                break;
+            case 1:
+                assert(ms.prot == PROT_READ);
+                break;
+            case 2:
+                assert(ms.prot == PROT_WRITE);
+                break;
+            case 3:
+                assert(ms.prot == PROT_EXEC);
+                break;
+            case 4:
+                assert(ms.prot == (PROT_READ | PROT_WRITE));
+                break;
+            case 5:
+                assert(ms.prot == (PROT_READ | PROT_EXEC));
+                break;
+            case 6:
+                assert(ms.prot == (PROT_WRITE | PROT_EXEC));
+                break;
+            case 7:
+                assert(ms.prot == (PROT_READ | PROT_WRITE | PROT_EXEC));
+                break;
+        }
+    }
+
+    myst_maps_free(maps);
+    munmap(addr, length);
+
+    test_big_mapping();
+
+    printf("=== passed all tests (%s)\n", argv[0]);
+
+    return 0;
+}

--- a/tests/maps/maps.c
+++ b/tests/maps/maps.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#define _GNU_SOURCE
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -15,16 +16,23 @@
 
 #include <myst/maps.h>
 
-void test_big_mapping()
+/* read info about the given page from "/proc/self/maps" */
+int mstat(const void* addr, int* prot, int* flags)
 {
-    size_t length = 8UL * 1024UL * 1024UL * 1024UL;
-    const int prot = PROT_NONE;
-    const int flags = MAP_ANONYMOUS | MAP_PRIVATE;
+    myst_maps_t* maps;
+    struct myst_mstat buf;
 
-    uint8_t* addr = mmap(NULL, length, prot, flags, -1, 0);
-    assert(addr != MAP_FAILED);
-    printf("addr=%p\n", addr);
-    munmap(addr, length);
+    if (myst_maps_load(&maps) != 0)
+        return -1;
+
+    if (myst_mstat(maps, addr, &buf) != 0)
+        return -1;
+
+    myst_maps_free(maps);
+
+    *prot = buf.prot;
+    *flags = buf.flags;
+    return 0;
 }
 
 int main(int argc, const char* argv[])
@@ -33,11 +41,12 @@ int main(int argc, const char* argv[])
     size_t length = 8 * PAGE_SIZE;
     const int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
     const int flags = MAP_ANONYMOUS | MAP_PRIVATE;
-    myst_maps_t* maps;
-    int r;
 
+    /* map 8 pages and give them different protections */
     uint8_t* addr = mmap(NULL, length, prot, flags, -1, 0);
     assert(addr != MAP_FAILED);
+
+    /* set the permissions of the first 7 pages */
     mprotect(addr + 0 * PAGE_SIZE, PAGE_SIZE, PROT_NONE);
     mprotect(addr + 1 * PAGE_SIZE, PAGE_SIZE, PROT_READ);
     mprotect(addr + 2 * PAGE_SIZE, PAGE_SIZE, PROT_WRITE);
@@ -46,62 +55,110 @@ int main(int argc, const char* argv[])
     mprotect(addr + 5 * PAGE_SIZE, PAGE_SIZE, PROT_READ | PROT_EXEC);
     mprotect(addr + 6 * PAGE_SIZE, PAGE_SIZE, PROT_WRITE | PROT_EXEC);
 
-    if ((r = myst_maps_load(&maps)) != 0)
-    {
-        fprintf(stderr, "load_maps() failed: errno=%d\n", -r);
-        exit(1);
-    }
-
-#if 0
-    myst_maps_dump(maps);
-#endif
-
+    /* verify the permissions of the pages */
     for (size_t i = 0; i < (length / PAGE_SIZE); i++)
     {
         uint8_t* p = addr + (i * PAGE_SIZE);
-        struct myst_mstat ms;
+        int mstat_prot;
+        int mstat_flags;
 
-        myst_mstat(maps, p, &ms);
+        /* get the protection and flags for this page */
+        assert(mstat(p, &mstat_prot, &mstat_flags) == 0);
 
-#if 0
-        myst_mstat_dump(&ms);
-#endif
-
-        assert(ms.flags == MAP_PRIVATE);
+        assert(mstat_flags == MAP_PRIVATE);
 
         switch (i)
         {
             case 0:
-                assert(ms.prot == PROT_NONE);
+                assert(mstat_prot == PROT_NONE);
                 break;
             case 1:
-                assert(ms.prot == PROT_READ);
+                assert(mstat_prot == PROT_READ);
                 break;
             case 2:
-                assert(ms.prot == PROT_WRITE);
+                assert(mstat_prot == PROT_WRITE);
                 break;
             case 3:
-                assert(ms.prot == PROT_EXEC);
+                assert(mstat_prot == PROT_EXEC);
                 break;
             case 4:
-                assert(ms.prot == (PROT_READ | PROT_WRITE));
+                assert(mstat_prot == (PROT_READ | PROT_WRITE));
                 break;
             case 5:
-                assert(ms.prot == (PROT_READ | PROT_EXEC));
+                assert(mstat_prot == (PROT_READ | PROT_EXEC));
                 break;
             case 6:
-                assert(ms.prot == (PROT_WRITE | PROT_EXEC));
+                assert(mstat_prot == (PROT_WRITE | PROT_EXEC));
                 break;
             case 7:
-                assert(ms.prot == (PROT_READ | PROT_WRITE | PROT_EXEC));
+                assert(mstat_prot == (PROT_READ | PROT_WRITE | PROT_EXEC));
                 break;
         }
     }
 
-    myst_maps_free(maps);
-    munmap(addr, length);
+    /* shrink the mapping by one page */
+    size_t length2 = length - PAGE_SIZE;
+    int mremap_flags = MREMAP_MAYMOVE;
+    uint8_t* addr2 = mremap(addr, length, length2, mremap_flags);
+    assert(addr2 != MAP_FAILED);
 
-    test_big_mapping();
+    /* verify that the permissions of the remapped memory have not changed */
+    for (size_t i = 0; i < (length2 / PAGE_SIZE); i++)
+    {
+        uint8_t* p = addr2 + (i * PAGE_SIZE);
+        int mstat_prot;
+        int mstat_flags;
+
+        /* get the protection and flags for this page */
+        assert(mstat(p, &mstat_prot, &mstat_flags) == 0);
+
+        assert(mstat_flags == MAP_PRIVATE);
+
+        switch (i)
+        {
+            case 0:
+                assert(mstat_prot == PROT_NONE);
+                break;
+            case 1:
+                assert(mstat_prot == PROT_READ);
+                break;
+            case 2:
+                assert(mstat_prot == PROT_WRITE);
+                break;
+            case 3:
+                assert(mstat_prot == PROT_EXEC);
+                break;
+            case 4:
+                assert(mstat_prot == (PROT_READ | PROT_WRITE));
+                break;
+            case 5:
+                assert(mstat_prot == (PROT_READ | PROT_EXEC));
+                break;
+            case 6:
+                assert(mstat_prot == (PROT_WRITE | PROT_EXEC));
+                break;
+        }
+    }
+
+    /* without making permission consistent, mremap() fails with EFAULT */
+    mprotect(addr, length, PROT_READ | PROT_WRITE | PROT_EXEC);
+
+    /* expand the mapping by two pages */
+    size_t length3 = length + PAGE_SIZE;
+    uint8_t* addr3 = mremap(addr2, length2, length3, mremap_flags);
+    assert(addr3 != MAP_FAILED);
+
+    /* verify permissions of remapped memory (new page will be r-w-x */
+    for (size_t i = 0; i < (length3 / PAGE_SIZE); i++)
+    {
+        uint8_t* p = addr3 + (i * PAGE_SIZE);
+        int mstat_prot;
+        int mstat_flags;
+
+        assert(mstat(p, &mstat_prot, &mstat_flags) == 0);
+        assert(mstat_flags == MAP_PRIVATE);
+        assert(mstat_prot == (PROT_READ | PROT_WRITE | PROT_EXEC));
+    }
 
     printf("=== passed all tests (%s)\n", argv[0]);
 


### PR DESCRIPTION
This example verifies permission propagation performed by mremap. Conclusions:
- when mremap() makes a mapping the same size or smaller, the permissions of the overlapping pages are propagated.
- when mremap() makes a mapping larger, the permissions for all pages must be the consistent (them same), else mremap() fails with EFAULT.