### PR TITLE
Fixes for epoll bugs

### DIFF
--- a/include/myst/bufalloc.h
+++ b/include/myst/bufalloc.h
@@ -56,7 +56,10 @@ MYST_INLINE void* myst_buf_calloc(
         return NULL;
 
     if (buf && n && n <= buflen)
+    {
+        memset(buf, 0, n);
         return buf;
+    }
     else
         return calloc(nmemb, size);
 }

--- a/kernel/epolldev.c
+++ b/kernel/epolldev.c
@@ -190,6 +190,8 @@ static int _ed_epoll_wait(
     if (!epolldev || !epoll || !events || maxevents < 0)
         ERAISE(-EINVAL);
 
+    memset(events, 0, maxevents * sizeof(struct epoll_event));
+
     myst_spin_lock(&epoll->lock);
     locked = true;
 
@@ -290,22 +292,22 @@ static int _ed_epoll_wait(
 
                 dest = &events[nevents++];
 
-                if (src->events & POLLIN)
+                if (src->revents & POLLIN)
                     dest->events |= EPOLLIN;
 
-                if (src->events & POLLOUT)
+                if (src->revents & POLLOUT)
                     dest->events |= EPOLLOUT;
 
-                if (src->events & POLLRDHUP)
+                if (src->revents & POLLRDHUP)
                     dest->events |= EPOLLRDHUP;
 
-                if (src->events & POLLPRI)
+                if (src->revents & POLLPRI)
                     dest->events |= EPOLLPRI;
 
-                if (src->events & POLLERR)
+                if (src->revents & POLLERR)
                     dest->events |= EPOLLERR;
 
-                if (src->events & POLLHUP)
+                if (src->revents & POLLHUP)
                     dest->events |= EPOLLHUP;
 
                 dest->data = ent->event.data;

--- a/tests/epoll/Makefile
+++ b/tests/epoll/Makefile
@@ -19,7 +19,13 @@ OPTS = --strace
 endif
 
 tests: all
+	$(MAKE) __tests
+
+__tests:
 	$(RUNTEST) $(MYST_EXEC) rootfs /bin/epoll $(OPTS)
+
+stress:
+	$(foreach i, $(shell seq 1 100), $(MAKE) __tests $(NL) )
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/epoll/server.c
+++ b/tests/epoll/server.c
@@ -278,7 +278,7 @@ void run_server(uint16_t port, size_t num_clients)
                     break;
             }
 
-            /* Handle client input. */
+            /* Handle client output */
             if (client->sock != -1 && (event->events & EPOLLOUT))
             {
                 /* Write until output is exhausted or EAGAIN encountered. */
@@ -308,7 +308,7 @@ void run_server(uint16_t port, size_t num_clients)
                             break;
                         }
                     }
-                    else if (errno == EAGAIN)
+                    else if (n == -1 && errno == EAGAIN)
                     {
                         break;
                     }


### PR DESCRIPTION
This PR fixes three epoll bugs.

This fixes cases where epoll_wait() falsely6 reports input and output events. This caused the test to call recvfrom() and get EAGAIN errors.