### PR TITLE
Kernel Stacks

### DIFF
--- a/ext2/ext2dump.c
+++ b/ext2/ext2dump.c
@@ -234,6 +234,8 @@ static void _dump_inode(const ext2_t* ext2, const ext2_inode_t* inode)
     uint32_t n;
     (void)_hex_dump;
     (void)_ascii_dump;
+    (void)n;
+    (void)i;
 
     printf("=== ext2_inode_t\n");
     printf("i_mode=%u (%X)\n", inode->i_mode, inode->i_mode);

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -6,6 +6,7 @@
 
 #include <limits.h>
 
+#include <myst/kstack.h>
 #include <myst/tcall.h>
 #include <myst/types.h>
 
@@ -52,6 +53,10 @@ typedef struct myst_kernel_args
     /* The image that contains the kernel and crt etc. */
     const void* image_data;
     size_t image_size;
+
+    /* the region that contains the kernel stacks */
+    const void* kernel_stacks_data;
+    size_t kernel_stacks_size;
 
     /* The loaded kernel ELF image (ELF header start here) */
     const void* kernel_data;

--- a/include/myst/kstack.h
+++ b/include/myst/kstack.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_KSTACK_H
+#define _MYST_KSTACK_H
+
+#include <stdint.h>
+
+#include <myst/defs.h>
+
+#define MYST_MAX_KSTACKS 1024
+#define MYST_KSTACK_SIZE (64 * 1024)
+#define MYST_ENTER_KSTACK_SIZE (128 * 1024)
+
+/* representation of the kernel stack (used for syscalls) */
+typedef struct myst_kstack
+{
+    uint8_t guard[4096]; /* overlaid onto non-accessible memory */
+    union {
+        struct myst_kstack* next; /* used only when on the free list */
+        uint8_t __data[MYST_KSTACK_SIZE - 4096];
+    } u;
+} myst_kstack_t;
+
+MYST_STATIC_ASSERT(sizeof(myst_kstack_t) == MYST_KSTACK_SIZE);
+
+/* put all the kernel stacks onto the free list */
+void myst_init_kstacks(void);
+
+/* get a kernel stack from the free list; time complexity is O(1)  */
+myst_kstack_t* myst_get_kstack(void);
+
+/* put a kernel stack onto the free list; time complexity is O(1) */
+void myst_put_kstack(myst_kstack_t* kstack);
+
+MYST_INLINE void* myst_kstack_end(myst_kstack_t* kstack)
+{
+    return (uint8_t*)kstack + sizeof(myst_kstack_t);
+}
+
+#endif /* _MYST_KSTACK_H */

--- a/include/myst/regions.h
+++ b/include/myst/regions.h
@@ -15,6 +15,7 @@
 
 /* memory region identifiers */
 #define MYST_REGION_CONFIG "config"
+#define MYST_REGION_KERNEL_STACKS "kernel.stacks"
 #define MYST_REGION_KERNEL "kernel"
 #define MYST_REGION_KERNEL_RELOC "kernel.reloc"
 #define MYST_REGION_KERNEL_SYMTAB "kernel.symtab" /* .symtab section */
@@ -26,6 +27,7 @@
 #define MYST_REGION_ROOTFS "rootfs"
 #define MYST_REGION_MMAN "mman"
 #define MYST_REGION_ARCHIVE "archive"
+#define MYST_REGION_KERNEL_ENTER_STACK "kernel.enter.stack"
 
 typedef struct myst_region_trailer
 {

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -11,6 +11,7 @@
 #include <myst/assume.h>
 #include <myst/defs.h>
 #include <myst/fdtable.h>
+#include <myst/kstack.h>
 #include <myst/setjmp.h>
 #include <myst/spinlock.h>
 #include <myst/tcall.h>
@@ -223,6 +224,9 @@ struct myst_thread
     /* supplemental groups */
     size_t num_supgid;
     gid_t supgid[NGROUPS_MAX];
+
+    // the kernel stack for the current the syscall (used only by SYS_exit)
+    myst_kstack_t* kstack;
 };
 
 MYST_INLINE bool myst_valid_thread(const myst_thread_t* thread)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -29,6 +29,7 @@ WARNINGS += -Wextra
 WARNINGS += -Wno-missing-field-initializers
 WARNINGS += -Wno-type-limits
 WARNINGS += -Wno-conversion
+WARNINGS += -Wstack-usage=512
 
 # ATTN: this optimization makes little difference for the kernel
 #USE_GC_SECTIONS=1

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -475,6 +475,14 @@ done:
 static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
 {
     int ret = 0;
+    struct vars
+    {
+        char err[PATH_MAX + 256];
+    };
+    struct vars* v = NULL;
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
     switch (fstype)
     {
@@ -493,15 +501,13 @@ static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
 #if defined(MYST_ENABLE_EXT2FS)
         case MYST_FSTYPE_EXT2FS:
         {
-            char err[PATH_MAX + 256];
-
             /* setup and mount the EXT2 file system */
-            if (_setup_ext2(args->rootfs, err, sizeof(err)) != 0)
+            if (_setup_ext2(args->rootfs, v->err, sizeof(v->err)) != 0)
             {
                 myst_eprintf(
                     "failed to setup EXT2 rootfs: %s (%s)\n",
                     args->rootfs,
-                    err);
+                    v->err);
                 ERAISE(-EINVAL);
             }
 
@@ -511,8 +517,6 @@ static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
 #if defined(MYST_ENABLE_HOSTFS)
         case MYST_FSTYPE_HOSTFS:
         {
-            char err[PATH_MAX + 256];
-
             /* disallow HOSTFS rootfs in non-debug mode */
             if (!args->tee_debug_mode)
             {
@@ -522,12 +526,12 @@ static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
             }
 
             /* setup and mount the HOSTFS file system */
-            if (_setup_hostfs(args->rootfs, err, sizeof(err)) != 0)
+            if (_setup_hostfs(args->rootfs, v->err, sizeof(v->err)) != 0)
             {
                 myst_eprintf(
                     "failed to setup HOSTFS rootfs: %s (%s)\n",
                     args->rootfs,
-                    err);
+                    v->err);
                 ERAISE(-EINVAL);
             }
 
@@ -544,6 +548,10 @@ static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
     }
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -622,6 +630,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
             ERAISE(-EINVAL);
         }
     }
+
+    /* initialize the kernel stacks free list */
+    myst_init_kstacks();
 
     /* Setup the memory manager */
     if (myst_setup_mman(args->mman_data, args->mman_size) != 0)

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -733,6 +733,10 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     }
     else
     {
+        /* release the kernel stack that was passed to SYS_exit if any */
+        if (thread->kstack)
+            myst_put_kstack(thread->kstack);
+
         /* thread jumps here on SYS_exit syscall */
         exit_status = thread->exit_status;
 

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -475,13 +475,13 @@ done:
 static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
 {
     int ret = 0;
-    struct vars
+    struct locals
     {
         char err[PATH_MAX + 256];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     switch (fstype)
@@ -502,12 +502,13 @@ static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
         case MYST_FSTYPE_EXT2FS:
         {
             /* setup and mount the EXT2 file system */
-            if (_setup_ext2(args->rootfs, v->err, sizeof(v->err)) != 0)
+            if (_setup_ext2(args->rootfs, locals->err, sizeof(locals->err)) !=
+                0)
             {
                 myst_eprintf(
                     "failed to setup EXT2 rootfs: %s (%s)\n",
                     args->rootfs,
-                    v->err);
+                    locals->err);
                 ERAISE(-EINVAL);
             }
 
@@ -526,12 +527,13 @@ static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
             }
 
             /* setup and mount the HOSTFS file system */
-            if (_setup_hostfs(args->rootfs, v->err, sizeof(v->err)) != 0)
+            if (_setup_hostfs(args->rootfs, locals->err, sizeof(locals->err)) !=
+                0)
             {
                 myst_eprintf(
                     "failed to setup HOSTFS rootfs: %s (%s)\n",
                     args->rootfs,
-                    v->err);
+                    locals->err);
                 ERAISE(-EINVAL);
             }
 
@@ -549,8 +551,8 @@ static int _mount_rootfs(myst_kernel_args_t* args, myst_fstype_t fstype)
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -761,20 +761,31 @@ typedef struct entry_args
 static int _setup_exe_link(const char* path)
 {
     int ret = 0;
-    char buf[PATH_MAX];
-    char target[PATH_MAX];
     pid_t pid = (pid_t)myst_getpid();
+    struct vars
+    {
+        char buf[PATH_MAX];
+        char target[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    if (myst_normalize(path, target, sizeof(target)) != 0)
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    if (myst_normalize(path, v->target, sizeof(v->target)) != 0)
         ERAISE(-EINVAL);
 
-    snprintf(buf, sizeof(buf), "/proc/%u", pid);
-    ECHECK(myst_mkdirhier(buf, 0777));
+    snprintf(v->buf, sizeof(v->buf), "/proc/%u", pid);
+    ECHECK(myst_mkdirhier(v->buf, 0777));
 
-    snprintf(buf, sizeof(buf), "/proc/%u/exe", pid);
-    ECHECK(myst_syscall_symlink(target, buf));
+    snprintf(v->buf, sizeof(v->buf), "/proc/%u/exe", pid);
+    ECHECK(myst_syscall_symlink(v->target, v->buf));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -762,29 +762,29 @@ static int _setup_exe_link(const char* path)
 {
     int ret = 0;
     pid_t pid = (pid_t)myst_getpid();
-    struct vars
+    struct locals
     {
         char buf[PATH_MAX];
         char target[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
-    if (myst_normalize(path, v->target, sizeof(v->target)) != 0)
+    if (myst_normalize(path, locals->target, sizeof(locals->target)) != 0)
         ERAISE(-EINVAL);
 
-    snprintf(v->buf, sizeof(v->buf), "/proc/%u", pid);
-    ECHECK(myst_mkdirhier(v->buf, 0777));
+    snprintf(locals->buf, sizeof(locals->buf), "/proc/%u", pid);
+    ECHECK(myst_mkdirhier(locals->buf, 0777));
 
-    snprintf(v->buf, sizeof(v->buf), "/proc/%u/exe", pid);
-    ECHECK(myst_syscall_symlink(v->target, v->buf));
+    snprintf(locals->buf, sizeof(locals->buf), "/proc/%u/exe", pid);
+    ECHECK(myst_syscall_symlink(locals->target, locals->buf));
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/fdtable.c
+++ b/kernel/fdtable.c
@@ -490,17 +490,17 @@ static const char* _type_name(myst_fdtable_type_t type)
 int myst_fdtable_list(const myst_fdtable_t* fdtable)
 {
     int ret = 0;
-    struct vars
+    struct locals
     {
         char linkpath[PATH_MAX];
         char buf[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
     if (!fdtable)
         ERAISE(-EINVAL);
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     for (int i = 0; i < MYST_FDTABLE_SIZE; i++)
@@ -516,19 +516,20 @@ int myst_fdtable_list(const myst_fdtable_t* fdtable)
 
             if (entry->type == MYST_FDTABLE_TYPE_FILE)
             {
-                const size_t n = sizeof(v->linkpath);
-                if (snprintf(v->linkpath, n, "/proc/%d/fd/%d", pid, i) >=
+                const size_t n = sizeof(locals->linkpath);
+                if (snprintf(locals->linkpath, n, "/proc/%d/fd/%d", pid, i) >=
                     (int)n)
                 {
                     ERAISE(-ENAMETOOLONG);
                 }
 
                 if ((m = myst_syscall_readlink(
-                         v->linkpath, v->buf, sizeof(v->buf))) < 0)
+                         locals->linkpath, locals->buf, sizeof(locals->buf))) <
+                    0)
                 {
                     ERAISE(-ENAMETOOLONG);
                 }
-                printf(" (%s)", v->buf);
+                printf(" (%s)", locals->buf);
             }
 
             printf("\n");
@@ -539,8 +540,8 @@ int myst_fdtable_list(const myst_fdtable_t* fdtable)
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/inotifydev.c
+++ b/kernel/inotifydev.c
@@ -291,20 +291,20 @@ static int _id_inotify_add_watch(
     int ret = 0;
     watch_t* watch = NULL;
     bool found = false;
-    struct vars
+    struct locals
     {
         char path[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
     if (!dev || !_valid_inotify(obj) || !pathname)
         ERAISE(-EINVAL);
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     /* normalize the path */
-    ECHECK(myst_normalize(pathname, v->path, sizeof(v->path)));
+    ECHECK(myst_normalize(pathname, locals->path, sizeof(locals->path)));
 
     /* see if there's already a watch for this path */
     {
@@ -331,7 +331,7 @@ static int _id_inotify_add_watch(
         if (!(watch = calloc(1, sizeof(watch_t))))
             ERAISE(-ENOMEM);
 
-        myst_strlcpy(watch->path, v->path, sizeof(watch->path));
+        myst_strlcpy(watch->path, locals->path, sizeof(watch->path));
         ECHECK((wd = _get_wd()));
         watch->wd = wd;
         watch->mask = mask;
@@ -346,8 +346,8 @@ static int _id_inotify_add_watch(
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     if (watch)
         free(watch);

--- a/kernel/kstack.c
+++ b/kernel/kstack.c
@@ -1,0 +1,55 @@
+#include <myst/kernel.h>
+#include <myst/kstack.h>
+#include <myst/spinlock.h>
+#include <myst/time.h>
+
+static int _initialized;
+static myst_kstack_t* _head;
+static myst_spinlock_t _lock;
+
+void myst_init_kstacks(void)
+{
+    myst_spin_lock(&_lock);
+    {
+        if (_initialized == 0)
+        {
+            uint8_t* p = (uint8_t*)__myst_kernel_args.kernel_stacks_data;
+
+            for (size_t i = 0; i < MYST_MAX_KSTACKS; i++)
+            {
+                myst_kstack_t* kstack = (myst_kstack_t*)p;
+                kstack->u.next = _head;
+                _head = kstack;
+
+                p += MYST_KSTACK_SIZE;
+            }
+
+            _initialized = 1;
+        }
+    }
+    myst_spin_unlock(&_lock);
+}
+
+myst_kstack_t* myst_get_kstack(void)
+{
+    myst_kstack_t* kstack;
+
+    myst_spin_lock(&_lock);
+    {
+        if ((kstack = _head))
+            _head = _head->u.next;
+    }
+    myst_spin_unlock(&_lock);
+
+    return kstack;
+}
+
+void myst_put_kstack(myst_kstack_t* kstack)
+{
+    myst_spin_lock(&_lock);
+    {
+        kstack->u.next = _head;
+        _head = kstack;
+    }
+    myst_spin_unlock(&_lock);
+}

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -115,16 +115,16 @@ static ssize_t _map_file_onto_memory(
     ssize_t ret = 0;
     ssize_t bytes_read = 0;
     int flags;
-    struct vars
+    struct locals
     {
         char buf[BUFSIZ];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
     if (fd < 0 || !addr || !length)
         ERAISE(-EINVAL);
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     // ATTN: generate EACCES error if non-regular file or file not opened
@@ -137,16 +137,16 @@ static ssize_t _map_file_onto_memory(
         size_t r = length;
         size_t o = offset;
 
-        while ((n = pread(fd, v->buf, sizeof v->buf, o)) > 0)
+        while ((n = pread(fd, locals->buf, sizeof locals->buf, o)) > 0)
         {
             /* if copy would write past end of buffer */
             if (r < (size_t)n)
             {
-                memcpy(p, v->buf, r);
+                memcpy(p, locals->buf, r);
                 break;
             }
 
-            memcpy(p, v->buf, (size_t)n);
+            memcpy(p, locals->buf, (size_t)n);
             p += n;
             o += n;
             r -= (size_t)n;
@@ -182,8 +182,8 @@ static ssize_t _map_file_onto_memory(
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/paths.c
+++ b/kernel/paths.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <errno.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <myst/eraise.h>
@@ -55,6 +56,14 @@ done:
 int myst_path_absolute(const char* path, char* buf, size_t size)
 {
     int ret = 0;
+    struct vars
+    {
+        char cwd[PATH_MAX];
+    };
+    struct vars* v = NULL;
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
     if (buf)
         *buf = '\0';
@@ -70,15 +79,18 @@ int myst_path_absolute(const char* path, char* buf, size_t size)
     else
     {
         long r;
-        char cwd[PATH_MAX];
 
-        if ((r = myst_syscall_getcwd(cwd, sizeof(cwd))) < 0)
+        if ((r = myst_syscall_getcwd(v->cwd, sizeof(v->cwd))) < 0)
             ERAISE((int)r);
 
-        ERAISE(myst_path_absolute_cwd(cwd, path, buf, size));
+        ERAISE(myst_path_absolute_cwd(v->cwd, path, buf, size));
     }
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 

--- a/kernel/paths.c
+++ b/kernel/paths.c
@@ -56,13 +56,13 @@ done:
 int myst_path_absolute(const char* path, char* buf, size_t size)
 {
     int ret = 0;
-    struct vars
+    struct locals
     {
         char cwd[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     if (buf)
@@ -80,16 +80,16 @@ int myst_path_absolute(const char* path, char* buf, size_t size)
     {
         long r;
 
-        if ((r = myst_syscall_getcwd(v->cwd, sizeof(v->cwd))) < 0)
+        if ((r = myst_syscall_getcwd(locals->cwd, sizeof(locals->cwd))) < 0)
             ERAISE((int)r);
 
-        ERAISE(myst_path_absolute_cwd(v->cwd, path, buf, size));
+        ERAISE(myst_path_absolute_cwd(locals->cwd, path, buf, size));
     }
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -13,31 +13,61 @@
 
 int myst_console_printf(int fd, const char* format, ...)
 {
-    char buf[1024];
+    int ret = 0;
     va_list ap;
     int count;
+    struct vars
+    {
+        char buf[1024];
+    };
+    struct vars* v = NULL;
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
     va_start(ap, format);
-    count = vsnprintf(buf, sizeof(buf), format, ap);
+    count = vsnprintf(v->buf, sizeof(v->buf), format, ap);
     va_end(ap);
 
-    if (count < 0 || (size_t)count >= sizeof(buf))
-        return -EINVAL;
+    if (count < 0 || (size_t)count >= sizeof(v->buf))
+        ERAISE(-EINVAL);
 
-    return (int)myst_tcall_write_console(fd, buf, (size_t)count);
+    ECHECK(myst_tcall_write_console(fd, v->buf, (size_t)count));
+
+done:
+
+    if (v)
+        free(v);
+
+    return ret;
 }
 
 int myst_console_vprintf(int fd, const char* format, va_list ap)
 {
-    char buf[1024];
+    int ret = 0;
     int count;
+    struct vars
+    {
+        char buf[1024];
+    };
+    struct vars* v = NULL;
 
-    count = vsnprintf(buf, sizeof(buf), format, ap);
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
-    if (count < 0 || (size_t)count >= sizeof(buf))
+    count = vsnprintf(v->buf, sizeof(v->buf), format, ap);
+
+    if (count < 0 || (size_t)count >= sizeof(v->buf))
         return -EINVAL;
 
-    return (int)myst_tcall_write_console(fd, buf, (size_t)count);
+    ECHECK(myst_tcall_write_console(fd, v->buf, (size_t)count));
+
+done:
+
+    if (v)
+        free(v);
+
+    return ret;
 }
 
 int myst_veprintf(const char* format, va_list ap)

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -16,28 +16,28 @@ int myst_console_printf(int fd, const char* format, ...)
     int ret = 0;
     va_list ap;
     int count;
-    struct vars
+    struct locals
     {
         char buf[1024];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     va_start(ap, format);
-    count = vsnprintf(v->buf, sizeof(v->buf), format, ap);
+    count = vsnprintf(locals->buf, sizeof(locals->buf), format, ap);
     va_end(ap);
 
-    if (count < 0 || (size_t)count >= sizeof(v->buf))
+    if (count < 0 || (size_t)count >= sizeof(locals->buf))
         ERAISE(-EINVAL);
 
-    ECHECK(myst_tcall_write_console(fd, v->buf, (size_t)count));
+    ECHECK(myst_tcall_write_console(fd, locals->buf, (size_t)count));
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }
@@ -46,26 +46,26 @@ int myst_console_vprintf(int fd, const char* format, va_list ap)
 {
     int ret = 0;
     int count;
-    struct vars
+    struct locals
     {
         char buf[1024];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
-    count = vsnprintf(v->buf, sizeof(v->buf), format, ap);
+    count = vsnprintf(locals->buf, sizeof(locals->buf), format, ap);
 
-    if (count < 0 || (size_t)count >= sizeof(v->buf))
+    if (count < 0 || (size_t)count >= sizeof(locals->buf))
         return -EINVAL;
 
-    ECHECK(myst_tcall_write_console(fd, v->buf, (size_t)count));
+    ECHECK(myst_tcall_write_console(fd, locals->buf, (size_t)count));
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 
@@ -18,6 +19,14 @@ static myst_fs_t* _procfs;
 int procfs_setup()
 {
     int ret = 0;
+    struct vars
+    {
+        char fdpath[PATH_MAX];
+    };
+    struct vars* v = NULL;
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
     if (myst_init_ramfs(myst_mount_resolve, &_procfs) != 0)
     {
@@ -38,16 +47,19 @@ int procfs_setup()
     }
 
     /* Create /proc/[pid]/fd directory for main thread */
-    char fdpath[PATH_MAX];
-    const size_t n = sizeof(fdpath);
-    snprintf(fdpath, n, "/proc/%d/fd", myst_getpid());
-    if (myst_mkdirhier(fdpath, 777) != 0)
+    const size_t n = sizeof(v->fdpath);
+    snprintf(v->fdpath, n, "/proc/%d/fd", myst_getpid());
+    if (myst_mkdirhier(v->fdpath, 777) != 0)
     {
         myst_eprintf("cannot create the /proc/[pid]/fd directory\n");
         ERAISE(-EINVAL);
     }
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -65,15 +77,26 @@ int procfs_teardown()
 int procfs_pid_cleanup(pid_t pid)
 {
     int ret = 0;
-    char pid_dir_path[PATH_MAX];
+    struct vars
+    {
+        char pid_dir_path[PATH_MAX];
+    };
+    struct vars* v = NULL;
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
     if (!pid)
         ERAISE(-EINVAL);
 
-    snprintf(pid_dir_path, sizeof(pid_dir_path), "/%d", pid);
-    ECHECK(myst_release_tree(_procfs, pid_dir_path));
+    snprintf(v->pid_dir_path, sizeof(v->pid_dir_path), "/%d", pid);
+    ECHECK(myst_release_tree(_procfs, v->pid_dir_path));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -100,12 +123,28 @@ done:
 
 static int _self_vcallback(myst_buf_t* vbuf)
 {
-    char linkpath[PATH_MAX];
-    const size_t n = sizeof(linkpath);
-    snprintf(linkpath, n, "/proc/%d", myst_getpid());
+    int ret = 0;
+
+    struct vars
+    {
+        char linkpath[PATH_MAX];
+    };
+    struct vars* v = NULL;
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    const size_t n = sizeof(v->linkpath);
+    snprintf(v->linkpath, n, "/proc/%d", myst_getpid());
     myst_buf_clear(vbuf);
-    myst_buf_append(vbuf, linkpath, sizeof(linkpath));
-    return 0;
+    myst_buf_append(vbuf, v->linkpath, sizeof(v->linkpath));
+
+done:
+
+    if (v)
+        free(v);
+
+    return ret;
 }
 
 int create_proc_root_entries()

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -19,13 +19,13 @@ static myst_fs_t* _procfs;
 int procfs_setup()
 {
     int ret = 0;
-    struct vars
+    struct locals
     {
         char fdpath[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     if (myst_init_ramfs(myst_mount_resolve, &_procfs) != 0)
@@ -47,9 +47,9 @@ int procfs_setup()
     }
 
     /* Create /proc/[pid]/fd directory for main thread */
-    const size_t n = sizeof(v->fdpath);
-    snprintf(v->fdpath, n, "/proc/%d/fd", myst_getpid());
-    if (myst_mkdirhier(v->fdpath, 777) != 0)
+    const size_t n = sizeof(locals->fdpath);
+    snprintf(locals->fdpath, n, "/proc/%d/fd", myst_getpid());
+    if (myst_mkdirhier(locals->fdpath, 777) != 0)
     {
         myst_eprintf("cannot create the /proc/[pid]/fd directory\n");
         ERAISE(-EINVAL);
@@ -57,8 +57,8 @@ int procfs_setup()
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }
@@ -77,25 +77,25 @@ int procfs_teardown()
 int procfs_pid_cleanup(pid_t pid)
 {
     int ret = 0;
-    struct vars
+    struct locals
     {
         char pid_dir_path[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     if (!pid)
         ERAISE(-EINVAL);
 
-    snprintf(v->pid_dir_path, sizeof(v->pid_dir_path), "/%d", pid);
-    ECHECK(myst_release_tree(_procfs, v->pid_dir_path));
+    snprintf(locals->pid_dir_path, sizeof(locals->pid_dir_path), "/%d", pid);
+    ECHECK(myst_release_tree(_procfs, locals->pid_dir_path));
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }
@@ -125,24 +125,24 @@ static int _self_vcallback(myst_buf_t* vbuf)
 {
     int ret = 0;
 
-    struct vars
+    struct locals
     {
         char linkpath[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
-    const size_t n = sizeof(v->linkpath);
-    snprintf(v->linkpath, n, "/proc/%d", myst_getpid());
+    const size_t n = sizeof(locals->linkpath);
+    snprintf(locals->linkpath, n, "/proc/%d", myst_getpid());
     myst_buf_clear(vbuf);
-    myst_buf_append(vbuf, v->linkpath, sizeof(v->linkpath));
+    myst_buf_append(vbuf, locals->linkpath, sizeof(locals->linkpath));
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/realpath.c
+++ b/kernel/realpath.c
@@ -13,13 +13,14 @@
 int myst_realpath(const char* path, myst_path_t* resolved_path)
 {
     int ret = 0;
-    typedef struct _variables
+    struct vars
     {
         char buf[PATH_MAX];
         const char* in[PATH_MAX];
         const char* out[PATH_MAX];
-    } variables_t;
-    variables_t* v = NULL;
+        char cwd[PATH_MAX];
+    };
+    struct vars* v = NULL;
     size_t nin = 0;
     size_t nout = 0;
 
@@ -29,9 +30,10 @@ int myst_realpath(const char* path, myst_path_t* resolved_path)
     if (!path || !resolved_path)
         ERAISE(-EINVAL);
 
-    /* Allocate variables on the heap since too big for the stack. */
-    if (!(v = calloc(1, sizeof(variables_t))))
+    if (!(v = malloc(sizeof(struct vars))))
         ERAISE(-ENOMEM);
+
+    memset(v, 0, sizeof(struct vars));
 
     if (path[0] == '/')
     {
@@ -40,13 +42,12 @@ int myst_realpath(const char* path, myst_path_t* resolved_path)
     }
     else
     {
-        char cwd[PATH_MAX];
         long r;
 
-        if ((r = myst_syscall_getcwd(cwd, sizeof(cwd))) < 0)
+        if ((r = myst_syscall_getcwd(v->cwd, sizeof(v->cwd))) < 0)
             ERAISE((int)r);
 
-        if (myst_strlcpy(v->buf, cwd, sizeof(v->buf)) >= sizeof(v->buf))
+        if (myst_strlcpy(v->buf, v->cwd, sizeof(v->buf)) >= sizeof(v->buf))
             ERAISE(-ENAMETOOLONG);
 
         if (myst_strlcat(v->buf, "/", sizeof(v->buf)) >= sizeof(v->buf))

--- a/kernel/select.c
+++ b/kernel/select.c
@@ -98,16 +98,16 @@ long myst_syscall_select(
     long ret = 0;
     int num_ready = 0;
     int poll_timeout = -1;
-    struct vars
+    struct locals
     {
         poll_fds_t fds;
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
-    memset(&v->fds, 0, sizeof(v->fds));
+    memset(&locals->fds, 0, sizeof(locals->fds));
 
     if (timeout)
     {
@@ -118,22 +118,22 @@ long myst_syscall_select(
     if (readfds)
     {
         const short events = POLLIN | POLLRDNORM | POLLRDBAND;
-        ECHECK(_fdset_to_fds(&v->fds, events, readfds, nfds));
+        ECHECK(_fdset_to_fds(&locals->fds, events, readfds, nfds));
     }
 
     if (writefds)
     {
         const short events = POLLOUT | POLLWRNORM | POLLWRBAND;
-        ECHECK(_fdset_to_fds(&v->fds, events, writefds, nfds));
+        ECHECK(_fdset_to_fds(&locals->fds, events, writefds, nfds));
     }
 
     if (exceptfds)
     {
         const short events = POLLERR | POLLHUP | POLLRDHUP;
-        ECHECK(_fdset_to_fds(&v->fds, events, exceptfds, nfds));
+        ECHECK(_fdset_to_fds(&locals->fds, events, exceptfds, nfds));
     }
 
-    ECHECK(myst_syscall_poll(v->fds.data, v->fds.size, poll_timeout));
+    ECHECK(myst_syscall_poll(locals->fds.data, locals->fds.size, poll_timeout));
 
     if (readfds)
         FD_ZERO(readfds);
@@ -149,7 +149,7 @@ long myst_syscall_select(
         short events = POLLIN | POLLRDNORM | POLLRDBAND;
         int n;
 
-        if ((n = _fds_to_fdset(&v->fds, events, readfds)) > num_ready)
+        if ((n = _fds_to_fdset(&locals->fds, events, readfds)) > num_ready)
             num_ready += n;
     }
 
@@ -158,7 +158,7 @@ long myst_syscall_select(
         short events = POLLOUT | POLLWRNORM | POLLWRBAND;
         int n;
 
-        if ((n = _fds_to_fdset(&v->fds, events, writefds)) > num_ready)
+        if ((n = _fds_to_fdset(&locals->fds, events, writefds)) > num_ready)
             num_ready += n;
     }
 
@@ -167,7 +167,7 @@ long myst_syscall_select(
         short events = POLLERR | POLLHUP | POLLRDHUP;
         int n;
 
-        if ((n = _fds_to_fdset(&v->fds, events, exceptfds)) > num_ready)
+        if ((n = _fds_to_fdset(&locals->fds, events, exceptfds)) > num_ready)
             num_ready += n;
     }
 
@@ -175,8 +175,8 @@ long myst_syscall_select(
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/sendfile.c
+++ b/kernel/sendfile.c
@@ -9,16 +9,16 @@ long myst_syscall_sendfile(int out_fd, int in_fd, off_t* offset, size_t count)
     long ret = 0;
     ssize_t nwritten = 0;
     off_t original_offset = 0;
-    struct vars
+    struct locals
     {
         char buf[BUFSIZ];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
     if (out_fd < 0 || in_fd < 0)
         ERAISE(-EINVAL);
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     /* if offset is not null, set file offset to this value */
@@ -37,9 +37,9 @@ long myst_syscall_sendfile(int out_fd, int in_fd, off_t* offset, size_t count)
         ssize_t n;
         size_t r = count;
 
-        while (r > 0 && (n = read(in_fd, v->buf, sizeof(v->buf))) > 0)
+        while (r > 0 && (n = read(in_fd, locals->buf, sizeof(locals->buf))) > 0)
         {
-            ssize_t m = write(out_fd, v->buf, n);
+            ssize_t m = write(out_fd, locals->buf, n);
             ECHECK(m);
 
             if (m != n)
@@ -70,8 +70,8 @@ long myst_syscall_sendfile(int out_fd, int in_fd, off_t* offset, size_t count)
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/shell.c
+++ b/kernel/shell.c
@@ -98,13 +98,13 @@ static void _ls_command(int argc, char** argv)
 {
     DIR* dir;
     struct dirent* ent;
-    struct vars
+    struct locals
     {
         char dirname[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         myst_panic("out of memory");
 
     if (argc > 2)
@@ -115,18 +115,18 @@ static void _ls_command(int argc, char** argv)
 
     if (argc == 2)
     {
-        myst_strlcpy(v->dirname, argv[1], sizeof(v->dirname));
+        myst_strlcpy(locals->dirname, argv[1], sizeof(locals->dirname));
     }
     else
     {
-        memset(v->dirname, 'a', sizeof(v->dirname));
-        if (myst_syscall_getcwd(v->dirname, sizeof(v->dirname)) < 0)
+        memset(locals->dirname, 'a', sizeof(locals->dirname));
+        if (myst_syscall_getcwd(locals->dirname, sizeof(locals->dirname)) < 0)
             myst_panic("getcwd() failed");
     }
 
-    if (!(dir = opendir(v->dirname)))
+    if (!(dir = opendir(locals->dirname)))
     {
-        myst_eprintf("%s: no such directory: %s\n", argv[0], v->dirname);
+        myst_eprintf("%s: no such directory: %s\n", argv[0], locals->dirname);
         return;
     }
 
@@ -146,28 +146,28 @@ static void _ls_command(int argc, char** argv)
     printf("\n");
     closedir(dir);
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 }
 
 static void _pwd_command(void)
 {
-    struct vars
+    struct locals
     {
         char cwd[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         myst_panic("out of memory");
 
-    if (myst_syscall_getcwd(v->cwd, sizeof(v->cwd)) < 0)
+    if (myst_syscall_getcwd(locals->cwd, sizeof(locals->cwd)) < 0)
         myst_panic("getcwd() failed");
 
-    printf("%s\n", v->cwd);
+    printf("%s\n", locals->cwd);
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 }
 
 static void _cd_command(int argc, char** argv)
@@ -195,33 +195,33 @@ static void _mem_command(int argc, char** argv)
     extern void dlmalloc_stats(void);
     const size_t mb = 1024 * 1024;
     size_t n;
-    struct vars
+    struct locals
     {
         myst_mman_stats_t buf;
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         myst_panic("out of memory");
 
-    myst_mman_stats(&v->buf);
+    myst_mman_stats(&locals->buf);
 
     (void)argc;
     (void)argv;
 
-    n = v->buf.total_size;
+    n = locals->buf.total_size;
     printf("total ram    =%11zu (%zumb)\n", n, n / mb);
 
-    n = v->buf.free_size;
+    n = locals->buf.free_size;
     printf("free ram     =%11zu (%zumb)\n", n, n / mb);
 
-    n = v->buf.used_size;
+    n = locals->buf.used_size;
     printf("used ram     =%11zu (%zumb)\n", n, n / mb);
 
-    n = v->buf.map_size;
+    n = locals->buf.map_size;
     printf("map used     =%11zu (%zumb)\n", n, n / mb);
 
-    n = v->buf.brk_size;
+    n = locals->buf.brk_size;
     printf("brk used     =%11zu (%zumb)\n", n, n / mb);
 
     n = __myst_kernel_args.rootfs_size;
@@ -238,8 +238,8 @@ static void _mem_command(int argc, char** argv)
 
     printf("\n");
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 }
 
 static void _env_command(int argc, char** argv)
@@ -271,13 +271,13 @@ static void _args_command(int argc, char** argv)
 void myst_start_shell(const char* msg)
 {
     char** argv = NULL;
-    struct vars
+    struct locals
     {
         char line[1024];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         myst_panic("out of memory");
 
     if (msg)
@@ -290,7 +290,7 @@ void myst_start_shell(const char* msg)
         long n;
         size_t argc;
 
-        if ((n = _readline("myst$ ", v->line, sizeof(v->line))) < 0)
+        if ((n = _readline("myst$ ", locals->line, sizeof(locals->line))) < 0)
         {
             myst_eprintf("error: readline failed: %ld!\n", n);
             myst_panic("readline failed\n");
@@ -298,7 +298,7 @@ void myst_start_shell(const char* msg)
         }
 
         /* split the string into tokens */
-        if (myst_strsplit(v->line, " \r\n\t", &argv, &argc) != 0)
+        if (myst_strsplit(locals->line, " \r\n\t", &argv, &argc) != 0)
             myst_panic("myst_strsplit() failed");
 
         if (argc == 0)
@@ -380,8 +380,8 @@ void myst_start_shell(const char* msg)
     if (argv)
         free(argv);
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 }
 
 #endif /* !defined(MYST_RELEASE) */

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -132,16 +132,16 @@ static long _handle_one_signal(unsigned signum, siginfo_t* siginfo)
 {
     long ret = 0;
     ECHECK(_check_signum(signum));
-    struct vars
+    struct locals
     {
         ucontext_t context;
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
-    memset(&v->context, 0, sizeof(v->context));
+    memset(&locals->context, 0, sizeof(locals->context));
 
     myst_thread_t* thread = myst_thread_self();
 
@@ -182,7 +182,7 @@ static long _handle_one_signal(unsigned signum, siginfo_t* siginfo)
             // Use a zeroed ucontext_t. Only usage in libc seems to be
             // pthread_cancel, which we modified to avoid the dependency.
             ((sigaction_function_t)(action->handler))(
-                signum, siginfo, &v->context);
+                signum, siginfo, &locals->context);
         }
         else
         {
@@ -197,8 +197,8 @@ static long _handle_one_signal(unsigned signum, siginfo_t* siginfo)
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -737,8 +737,8 @@ long myst_syscall_open(const char* pathname, int flags, mode_t mode)
     if (!(v = malloc(sizeof(struct vars))))
         ERAISE(-ENOMEM);
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_open)(fs, suffix, flags, mode, &fs_out, &file));
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ECHECK((*fs->fs_open)(fs, v->suffix, flags, mode, &fs_out, &file));
 
     if ((fd = myst_fdtable_assign(fdtable, fdtype, fs_out, file)) < 0)
     {

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -50,10 +50,12 @@
 #include <myst/initfini.h>
 #include <myst/inotifydev.h>
 #include <myst/kernel.h>
+#include <myst/kstack.h>
 #include <myst/libc.h>
 #include <myst/lsr.h>
 #include <myst/mmanutils.h>
 #include <myst/mount.h>
+#include <myst/once.h>
 #include <myst/options.h>
 #include <myst/panic.h>
 #include <myst/paths.h>
@@ -71,6 +73,7 @@
 #include <myst/tcall.h>
 #include <myst/tee.h>
 #include <myst/thread.h>
+#include <myst/time.h>
 #include <myst/times.h>
 #include <myst/trace.h>
 
@@ -515,21 +518,23 @@ __attribute__((format(printf, 2, 3))) static void _strace(
 {
     if (__options.trace_syscalls)
     {
+        char null_char = '\0';
+        char* buf = &null_char;
         const bool isatty = myst_syscall_isatty(STDERR_FILENO) == 1;
         const char* blue = isatty ? COLOR_GREEN : "";
         const char* reset = isatty ? COLOR_RESET : "";
-        char buf[1024];
 
         if (fmt)
         {
+            const size_t buf_size = 1024;
+
+            if (!(buf = malloc(buf_size)))
+                myst_panic("out of memory");
+
             va_list ap;
             va_start(ap, fmt);
-            vsnprintf(buf, sizeof(buf), fmt, ap);
+            vsnprintf(buf, buf_size, fmt, ap);
             va_end(ap);
-        }
-        else
-        {
-            *buf = '\0';
         }
 
         myst_eprintf(
@@ -539,6 +544,9 @@ __attribute__((format(printf, 2, 3))) static void _strace(
             reset,
             buf,
             myst_gettid());
+
+        if (buf != &null_char)
+            free(buf);
     }
 }
 
@@ -638,21 +646,32 @@ done:
 static int _add_fd_link(myst_fs_t* fs, myst_file_t* file, int fd)
 {
     int ret = 0;
-    char realpath[PATH_MAX];
-    char linkpath[PATH_MAX];
-    const size_t n = sizeof(linkpath);
+    struct vars
+    {
+        char realpath[PATH_MAX];
+        char linkpath[PATH_MAX];
+    };
+    struct vars* v = NULL;
+    const size_t n = sizeof(v->linkpath);
 
     if (!fs || !file)
         ERAISE(-EINVAL);
 
-    ECHECK((*fs->fs_realpath)(fs, file, realpath, sizeof(realpath)));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
-    if (snprintf(linkpath, n, "/proc/%d/fd/%d", myst_getpid(), fd) >= (int)n)
+    ECHECK((*fs->fs_realpath)(fs, file, v->realpath, sizeof(v->realpath)));
+
+    if (snprintf(v->linkpath, n, "/proc/%d/fd/%d", myst_getpid(), fd) >= (int)n)
         ERAISE(-ENAMETOOLONG);
 
-    ECHECK(symlink(realpath, linkpath));
+    ECHECK(symlink(v->realpath, v->linkpath));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -660,15 +679,22 @@ long myst_syscall_creat(const char* pathname, mode_t mode)
 {
     long ret = 0;
     int fd;
-    char suffix[PATH_MAX];
     myst_fs_t *fs, *fs_out;
     myst_file_t* file;
     myst_fdtable_t* fdtable = myst_fdtable_current();
     const myst_fdtable_type_t fdtype = MYST_FDTABLE_TYPE_FILE;
     long r;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_creat)(fs, suffix, mode, &fs_out, &file));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ECHECK((*fs->fs_creat)(fs, v->suffix, mode, &fs_out, &file));
 
     if ((fd = myst_fdtable_assign(fdtable, fdtype, fs_out, file)) < 0)
     {
@@ -687,19 +713,29 @@ long myst_syscall_creat(const char* pathname, mode_t mode)
 
 done:
 
+    if (v)
+        free(v);
+
     return ret;
 }
 
 long myst_syscall_open(const char* pathname, int flags, mode_t mode)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t *fs, *fs_out;
     myst_file_t* file;
     myst_fdtable_t* fdtable = myst_fdtable_current();
     const myst_fdtable_type_t fdtype = MYST_FDTABLE_TYPE_FILE;
     int fd;
     int r;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
     ECHECK(myst_mount_resolve(pathname, suffix, &fs));
     ECHECK((*fs->fs_open)(fs, suffix, flags, mode, &fs_out, &file));
@@ -721,6 +757,9 @@ long myst_syscall_open(const char* pathname, int flags, mode_t mode)
 
 done:
 
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -733,6 +772,13 @@ static long _openat(
     myst_file_t** file_out)
 {
     long ret = 0;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+        char dirname[PATH_MAX];
+        char filename[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
     if (fs_out)
         *fs_out = NULL;
@@ -746,16 +792,19 @@ static long _openat(
     if (*pathname == '\0')
         ERAISE(-ENOENT);
 
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
     /* if pathname is absolute or AT_FDCWD */
     if (*pathname == '/' || dirfd == AT_FDCWD)
     {
         if (fs_out && file_out)
         {
-            char suffix[PATH_MAX];
             myst_fs_t* fs;
 
-            ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-            ECHECK((*fs->fs_open)(fs, suffix, flags, mode, fs_out, file_out));
+            ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+            ECHECK(
+                (*fs->fs_open)(fs, v->suffix, flags, mode, fs_out, file_out));
         }
         else
         {
@@ -767,8 +816,6 @@ static long _openat(
         myst_fdtable_t* fdtable = myst_fdtable_current();
         myst_fs_t* fs;
         myst_file_t* file;
-        char dirname[PATH_MAX];
-        char filename[PATH_MAX];
 
         if (dirfd < 0)
             ERAISE(-EBADF);
@@ -786,24 +833,29 @@ static long _openat(
         }
 
         /* get the full path of dirfd */
-        ECHECK((*fs->fs_realpath)(fs, file, dirname, sizeof(dirname)));
-        ECHECK(myst_make_path(filename, sizeof(filename), dirname, pathname));
+        ECHECK((*fs->fs_realpath)(fs, file, v->dirname, sizeof(v->dirname)));
+        ECHECK(myst_make_path(
+            v->filename, sizeof(v->filename), v->dirname, pathname));
 
         if (fs_out && file_out)
         {
-            char suffix[PATH_MAX];
             myst_fs_t* fs;
 
-            ECHECK(myst_mount_resolve(filename, suffix, &fs));
-            ECHECK((*fs->fs_open)(fs, suffix, flags, mode, fs_out, file_out));
+            ECHECK(myst_mount_resolve(v->filename, v->suffix, &fs));
+            ECHECK(
+                (*fs->fs_open)(fs, v->suffix, flags, mode, fs_out, file_out));
         }
         else
         {
-            ret = myst_syscall_open(filename, flags, mode);
+            ret = myst_syscall_open(v->filename, flags, mode);
         }
     }
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -1056,26 +1108,48 @@ done:
 long myst_syscall_stat(const char* pathname, struct stat* statbuf)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_stat)(fs, suffix, statbuf));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ECHECK((*fs->fs_stat)(fs, v->suffix, statbuf));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
 long myst_syscall_lstat(const char* pathname, struct stat* statbuf)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_lstat)(fs, suffix, statbuf));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ECHECK((*fs->fs_lstat)(fs, v->suffix, statbuf));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -1104,9 +1178,19 @@ long myst_syscall_fstatat(
     int flags)
 {
     long ret = 0;
+    struct vars
+    {
+        char realpath[PATH_MAX];
+        char dirpath[PATH_MAX];
+        char path[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
     if (!pathname || !statbuf)
         ERAISE(-EINVAL);
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
     /* If pathname is absolute, then ignore dirfd */
     if (*pathname == '/' || dirfd == AT_FDCWD)
@@ -1132,11 +1216,11 @@ long myst_syscall_fstatat(
             myst_fdtable_t* fdtable = myst_fdtable_current();
             myst_fs_t* fs;
             myst_file_t* file;
-            char realpath[PATH_MAX];
 
             ECHECK(myst_fdtable_get_file(fdtable, dirfd, &fs, &file));
-            ECHECK((*fs->fs_realpath)(fs, file, realpath, sizeof(realpath)));
-            ECHECK(myst_syscall_lstat(realpath, statbuf));
+            ECHECK(
+                (*fs->fs_realpath)(fs, file, v->realpath, sizeof(v->realpath)));
+            ECHECK(myst_syscall_lstat(v->realpath, statbuf));
             goto done;
         }
         else
@@ -1150,26 +1234,28 @@ long myst_syscall_fstatat(
         myst_fdtable_t* fdtable = myst_fdtable_current();
         myst_fs_t* fs;
         myst_file_t* file;
-        char dirpath[PATH_MAX];
-        char path[PATH_MAX];
 
         ECHECK(myst_fdtable_get_file(fdtable, dirfd, &fs, &file));
-        ECHECK((*fs->fs_realpath)(fs, file, dirpath, sizeof(dirpath)));
-        ECHECK(myst_make_path(path, sizeof(path), dirpath, pathname));
+        ECHECK((*fs->fs_realpath)(fs, file, v->dirpath, sizeof(v->dirpath)));
+        ECHECK(myst_make_path(v->path, sizeof(v->path), v->dirpath, pathname));
 
         if (flags & AT_SYMLINK_NOFOLLOW)
         {
-            ECHECK(myst_syscall_lstat(path, statbuf));
+            ECHECK(myst_syscall_lstat(v->path, statbuf));
             goto done;
         }
         else
         {
-            ECHECK(myst_syscall_stat(path, statbuf));
+            ECHECK(myst_syscall_stat(v->path, statbuf));
             goto done;
         }
     }
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -1200,34 +1286,56 @@ static const char* _trim_trailing_slashes(
 long myst_syscall_mkdir(const char* pathname, mode_t mode)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
-    char buf[PATH_MAX];
+    struct vars
+    {
+        char suffix[PATH_MAX];
+        char buf[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
     if (!pathname)
         ERAISE(-EINVAL);
 
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
     /* remove trailing slash from directory name if any */
-    if (!(pathname = _trim_trailing_slashes(pathname, buf, sizeof(buf))))
+    if (!(pathname = _trim_trailing_slashes(pathname, v->buf, sizeof(v->buf))))
         ERAISE(-ENAMETOOLONG);
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_mkdir)(fs, suffix, mode));
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ECHECK((*fs->fs_mkdir)(fs, v->suffix, mode));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
 long myst_syscall_rmdir(const char* pathname)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_rmdir)(fs, suffix));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ECHECK((*fs->fs_rmdir)(fs, v->suffix));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -1250,13 +1358,20 @@ done:
 long myst_syscall_link(const char* oldpath, const char* newpath)
 {
     long ret = 0;
-    char old_suffix[PATH_MAX];
-    char new_suffix[PATH_MAX];
     myst_fs_t* old_fs;
     myst_fs_t* new_fs;
+    struct vars
+    {
+        char old_suffix[PATH_MAX];
+        char new_suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(oldpath, old_suffix, &old_fs));
-    ECHECK(myst_mount_resolve(newpath, new_suffix, &new_fs));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(oldpath, v->old_suffix, &old_fs));
+    ECHECK(myst_mount_resolve(newpath, v->new_suffix, &new_fs));
 
     if (old_fs != new_fs)
     {
@@ -1264,48 +1379,81 @@ long myst_syscall_link(const char* oldpath, const char* newpath)
         ERAISE(-EXDEV);
     }
 
-    ECHECK((*old_fs->fs_link)(old_fs, old_suffix, new_suffix));
+    ECHECK((*old_fs->fs_link)(old_fs, v->old_suffix, v->new_suffix));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
 long myst_syscall_unlink(const char* pathname)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_unlink)(fs, suffix));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ECHECK((*fs->fs_unlink)(fs, v->suffix));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
 long myst_syscall_access(const char* pathname, int mode)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ECHECK((*fs->fs_access)(fs, suffix, mode));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ECHECK((*fs->fs_access)(fs, v->suffix, mode));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
 long myst_syscall_rename(const char* oldpath, const char* newpath)
 {
     long ret = 0;
-    char old_suffix[PATH_MAX];
-    char new_suffix[PATH_MAX];
     myst_fs_t* old_fs;
     myst_fs_t* new_fs;
+    struct vars
+    {
+        char old_suffix[PATH_MAX];
+        char new_suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(oldpath, old_suffix, &old_fs));
-    ECHECK(myst_mount_resolve(newpath, new_suffix, &new_fs));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(oldpath, v->old_suffix, &old_fs));
+    ECHECK(myst_mount_resolve(newpath, v->new_suffix, &new_fs));
 
     if (old_fs != new_fs)
     {
@@ -1313,22 +1461,37 @@ long myst_syscall_rename(const char* oldpath, const char* newpath)
         ERAISE(-EXDEV);
     }
 
-    ECHECK((*old_fs->fs_rename)(old_fs, old_suffix, new_suffix));
+    ECHECK((*old_fs->fs_rename)(old_fs, v->old_suffix, v->new_suffix));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
 long myst_syscall_truncate(const char* path, off_t length)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(path, suffix, &fs));
-    ERAISE((*fs->fs_truncate)(fs, suffix, length));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(path, v->suffix, &fs));
+    ERAISE((*fs->fs_truncate)(fs, v->suffix, length));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -1350,26 +1513,48 @@ done:
 long myst_syscall_readlink(const char* pathname, char* buf, size_t bufsiz)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(pathname, suffix, &fs));
-    ERAISE((*fs->fs_readlink)(fs, suffix, buf, bufsiz));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(pathname, v->suffix, &fs));
+    ERAISE((*fs->fs_readlink)(fs, v->suffix, buf, bufsiz));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
 long myst_syscall_symlink(const char* target, const char* linkpath)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(linkpath, suffix, &fs));
-    ERAISE((*fs->fs_symlink)(fs, target, suffix));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(linkpath, v->suffix, &fs));
+    ERAISE((*fs->fs_symlink)(fs, target, v->suffix));
 
 done:
+
+    if (v)
+        free(v);
+
     return ret;
 }
 
@@ -1378,11 +1563,18 @@ long myst_syscall_chdir(const char* path)
     long ret = 0;
     myst_thread_t* thread = myst_thread_self();
     myst_thread_t* process_thread = myst_find_process_thread(thread);
-    char buf[PATH_MAX];
-    char buf2[PATH_MAX];
+    struct vars
+    {
+        char buf[PATH_MAX];
+        char buf2[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
     if (_bad_addr(path))
         ERAISE(-EFAULT);
+
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
 
     myst_spin_lock(&process_thread->main.cwd_lock);
 
@@ -1394,24 +1586,27 @@ long myst_syscall_chdir(const char* path)
         ERAISE(-ENAMETOOLONG);
 
     ECHECK(myst_path_absolute_cwd(
-        process_thread->main.cwd, path, buf, sizeof(buf)));
-    ECHECK(myst_normalize(buf, buf2, sizeof(buf2)));
+        process_thread->main.cwd, path, v->buf, sizeof(v->buf)));
+    ECHECK(myst_normalize(v->buf, v->buf2, sizeof(v->buf2)));
 
     /* fail if the directory does not exist */
     {
         struct stat buf;
 
-        if (myst_syscall_stat(buf2, &buf) != 0 || !S_ISDIR(buf.st_mode))
+        if (myst_syscall_stat(v->buf2, &buf) != 0 || !S_ISDIR(buf.st_mode))
             ERAISE(-ENOENT);
     }
 
-    char* tmp = strdup(buf2);
+    char* tmp = strdup(v->buf2);
     if (tmp == NULL)
         ERAISE(-ENOMEM);
     free(process_thread->main.cwd);
     process_thread->main.cwd = tmp;
 
 done:
+
+    if (v)
+        free(v);
 
     myst_spin_unlock(&process_thread->main.cwd_lock);
 
@@ -1444,15 +1639,25 @@ done:
 long myst_syscall_statfs(const char* path, struct statfs* buf)
 {
     long ret = 0;
-    char suffix[PATH_MAX];
     myst_fs_t* fs;
+    struct vars
+    {
+        char suffix[PATH_MAX];
+    };
+    struct vars* v = NULL;
 
-    ECHECK(myst_mount_resolve(path, suffix, &fs));
+    if (!(v = malloc(sizeof(struct vars))))
+        ERAISE(-ENOMEM);
+
+    ECHECK(myst_mount_resolve(path, v->suffix, &fs));
     if (buf)
         memset(buf, 0, sizeof(*buf));
-    ECHECK((*fs->fs_statfs)(fs, suffix, buf));
+    ECHECK((*fs->fs_statfs)(fs, v->suffix, buf));
 
 done:
+
+    if (v)
+        free(v);
 
     return ret;
 }
@@ -2518,8 +2723,20 @@ done:
         goto done;           \
     } while (0)
 
-long myst_syscall(long n, long params[6])
+typedef struct syscall_args
 {
+    long n;
+    long* params;
+} syscall_args_t;
+
+/* ATTN: optimize _syscall() stack usage later */
+#pragma GCC diagnostic push
+#pragma GCC optimize "-Og" // reduces stack usage across case statements
+static long _syscall(void* args_)
+{
+    syscall_args_t* args = (syscall_args_t*)args_;
+    long n = args->n;
+    long* params = args->params;
     long syscall_ret = 0;
     long x1 = params[0];
     long x2 = params[1];
@@ -3203,10 +3420,18 @@ long myst_syscall(long n, long params[6])
                 newtls,
                 ctid);
 
-            BREAK(_return(
-                n,
-                myst_syscall_clone(
-                    fn, child_stack, flags, arg, ptid, newtls, ctid)));
+            long ret = myst_syscall_clone(
+                fn, child_stack, flags, arg, ptid, newtls, ctid);
+
+            if ((flags & CLONE_VFORK))
+            {
+                // ATTN: give the thread a little time to start to avoid a
+                // syncyhronization error. This suppresses a failure in the
+                // popen test. This should be investigated later.
+                myst_sleep_msec(5);
+            }
+
+            BREAK(_return(n, ret));
         }
         case SYS_fork:
             break;
@@ -5048,6 +5273,33 @@ done:
     myst_signal_process(thread);
 
     return syscall_ret;
+}
+#pragma GCC diagnostic pop
+
+long myst_syscall(long n, long params[6])
+{
+    long ret;
+
+    // handle SYS_exit on the user stack since it never returns and is unable
+    // to relinquish the kernel stack.
+    if (n == SYS_exit)
+    {
+        syscall_args_t args = {.n = n, .params = params};
+        ret = _syscall(&args);
+    }
+    else
+    {
+        myst_kstack_t* kstack = myst_get_kstack();
+
+        if (!kstack)
+            myst_panic("no more kernel stacks");
+
+        syscall_args_t args = {.n = n, .params = params};
+        ret = myst_call_on_stack(myst_kstack_end(kstack), _syscall, &args);
+        myst_put_kstack(kstack);
+    }
+
+    return ret;
 }
 
 /*

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -752,16 +752,16 @@ static long _syscall_clone_vfork(
     uint64_t cookie = 0;
     myst_thread_t* parent = myst_thread_self();
     myst_thread_t* child;
-    struct vars
+    struct locals
     {
         char fdpath[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
     if (!fn)
         ERAISE(-EINVAL);
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     /* Check whether the maximum number of threads has been reached */
@@ -848,9 +848,9 @@ static long _syscall_clone_vfork(
 
         /* Create /proc/[pid]/fd directory for new process thread */
         {
-            const size_t n = sizeof(v->fdpath);
-            snprintf(v->fdpath, n, "/proc/%d/fd", child->pid);
-            if (myst_mkdirhier(v->fdpath, 777) != 0)
+            const size_t n = sizeof(locals->fdpath);
+            snprintf(locals->fdpath, n, "/proc/%d/fd", child->pid);
+            if (myst_mkdirhier(locals->fdpath, 777) != 0)
             {
                 myst_eprintf("cannot create the /proc/[pid]/fd directory\n");
                 ERAISE(-EINVAL);
@@ -867,8 +867,8 @@ static long _syscall_clone_vfork(
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     return ret;
 }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -517,6 +517,10 @@ static long _run_thread(void* arg_)
 
         /* ---------- running target thread descriptor ---------- */
 
+        /* release the kernel stack that was passed to SYS_exit if any */
+        if (thread->kstack)
+            myst_put_kstack(thread->kstack);
+
         /* Wake up any thread waiting on ctid */
         if (is_child_thread)
         {

--- a/solutions/aspnet/Makefile
+++ b/solutions/aspnet/Makefile
@@ -4,11 +4,11 @@ include $(TOP)/defs.mak
 APPBUILDER=$(TOP)/scripts/appbuilder
 APPNAME=webapp
 
-#ifdef STRACE
-#OPTS += --strace
-#endif
+ifdef STRACE
+OPTS += --strace
+endif
 
-OPTS = --memory-size=256m
+OPTS = --memory-size=1024m
 
 all: appdir private.pem
 
@@ -23,13 +23,28 @@ run: appdir private.pem
 	curl 127.0.0.1:5050
 	curl 127.0.0.1:5050
 	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
-	
+
 gdb: appdir private.pem
 	$(MYST) package appdir private.pem config.json
 	$(MYST_GDB) --args myst/bin/$(APPNAME) $(OPTS)
 
 appdir:
 	$(APPBUILDER) Dockerfile
+
+rootfs:
+	sudo $(MYST) mkext2 appdir rootfs
+	sudo chown $(USER).$(USER) rootfs
+	truncate --size=-4096 rootfs
+
+# standalone server rule:
+server:
+	$(MAKE) appdir
+	$(MAKE) rootfs
+	$(MYST_EXEC) $(OPTS) rootfs /app/webapp
+
+# standalone client rule:
+client:
+	curl 127.0.0.1:5050
 
 private.pem:
 	openssl genrsa -out private.pem -3 3072

--- a/tests/popen/Makefile
+++ b/tests/popen/Makefile
@@ -20,7 +20,13 @@ OPTS = --strace
 endif
 
 tests: all
+	$(MAKE) __tests
+
+__tests:
 	$(RUNTEST) $(MYST_EXEC) rootfs /bin/popen $(OPTS)
+
+stress:
+	$(foreach i, $(shell seq 1 100), $(MAKE) -s __tests TARGET=linux $(NL))
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tools/myst/host/regions.c
+++ b/tools/myst/host/regions.c
@@ -418,6 +418,107 @@ done:
     return ret;
 }
 
+static int _add_kernel_stacks_region(
+    myst_region_context_t* context,
+    uint64_t baseaddr,
+    uint64_t* vaddr)
+{
+    int ret = 0;
+    __attribute__((__aligned__(PAGE_SIZE))) uint8_t page[PAGE_SIZE];
+    const size_t num_stacks = MYST_MAX_KSTACKS;
+    const size_t num_stack_pages = MYST_KSTACK_SIZE / PAGE_SIZE;
+    const char name[] = MYST_REGION_KERNEL_STACKS;
+
+    if (!context || !vaddr)
+        ERAISE(-EINVAL);
+
+    if (myst_region_open(context) != 0)
+        ERAISE(-EINVAL);
+
+    memset(page, 0, sizeof(page));
+
+    /* add the kernel stacks */
+    for (size_t i = 0; i < num_stacks; i++)
+    {
+        /* add the guard page */
+        {
+            int flags = PROT_NONE | MYST_REGION_EXTEND;
+
+            if (_add_page(context, *vaddr, page, flags) != 0)
+                ERAISE(-EINVAL);
+
+            *vaddr += sizeof(page);
+        }
+
+        /* add the stack pages */
+        for (size_t i = 0; i < num_stack_pages - 1; i++)
+        {
+            int flags = PROT_READ | PROT_WRITE;
+
+            if (_add_page(context, *vaddr, page, flags) != 0)
+                ERAISE(-EINVAL);
+
+            *vaddr += sizeof(page);
+        }
+    }
+
+    if (myst_region_close(context, name, *vaddr) != 0)
+        ERAISE(-EINVAL);
+
+    *(vaddr) += PAGE_SIZE;
+
+done:
+    return ret;
+}
+
+static int _add_kernel_entry_stack_region(
+    myst_region_context_t* context,
+    uint64_t baseaddr,
+    uint64_t* vaddr)
+{
+    int ret = 0;
+    __attribute__((__aligned__(PAGE_SIZE))) uint8_t page[PAGE_SIZE];
+    const size_t num_stack_pages = MYST_ENTER_KSTACK_SIZE / PAGE_SIZE;
+    const char name[] = MYST_REGION_KERNEL_ENTER_STACK;
+
+    if (!context || !vaddr)
+        ERAISE(-EINVAL);
+
+    if (myst_region_open(context) != 0)
+        ERAISE(-EINVAL);
+
+    memset(page, 0, sizeof(page));
+
+    /* add the guard page */
+    {
+        int flags = PROT_NONE | MYST_REGION_EXTEND;
+
+        if (_add_page(context, *vaddr, page, flags) != 0)
+            ERAISE(-EINVAL);
+
+        *vaddr += sizeof(page);
+    }
+
+    /* add the stack pages */
+    for (size_t i = 0; i < num_stack_pages - 1; i++)
+    {
+        int flags = PROT_READ | PROT_WRITE;
+
+        if (_add_page(context, *vaddr, page, flags) != 0)
+            ERAISE(-EINVAL);
+
+        *vaddr += sizeof(page);
+    }
+
+    if (myst_region_close(context, name, *vaddr) != 0)
+        ERAISE(-EINVAL);
+
+    *(vaddr) += PAGE_SIZE;
+
+done:
+    return ret;
+}
+
 static int _add_kernel_region(
     myst_region_context_t* context,
     uint64_t baseaddr,
@@ -713,6 +814,9 @@ int add_regions(void* arg, uint64_t baseaddr, myst_add_page_t add_page)
     if (myst_region_init(add_page, arg, &context) != 0)
         _err("myst_region_init() failed");
 
+    if (_add_kernel_stacks_region(context, baseaddr, &vaddr) != 0)
+        _err("_add_kernel_stacks_region() failed");
+
     if (_add_kernel_region(context, baseaddr, &vaddr) != 0)
         _err("_add_kernel_region() failed");
 
@@ -748,6 +852,9 @@ int add_regions(void* arg, uint64_t baseaddr, myst_add_page_t add_page)
 
     if (_add_config_region(context, &vaddr) != 0)
         _err("_add_config_region() failed");
+
+    if (_add_kernel_entry_stack_region(context, baseaddr, &vaddr) != 0)
+        _err("_add_kernel_entry_stack_region() failed");
 
     if (myst_region_release(context) != 0)
         _err("myst_region_release() failed");

--- a/tools/myst/kargs.c
+++ b/tools/myst/kargs.c
@@ -73,6 +73,15 @@ int init_kernel_args(
     if (!args || !argv || !envp || !cwd || !regions_end || !err)
         ERAISE(-EINVAL);
 
+    /* find the kernel stacks region */
+    ECHECK(_find_region(
+        regions_end,
+        MYST_REGION_KERNEL_STACKS,
+        (void**)&args->kernel_stacks_data,
+        &args->kernel_stacks_size,
+        err,
+        err_size));
+
     /* find the kernel region */
     ECHECK(_find_region(
         regions_end,

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -19,7 +19,7 @@ CFLAGS += -ffunction-sections
 CFLAGS += -fdata-sections
 CFLAGS += -Wno-conversion
 CFLAGS += -Wno-parentheses
-# CFLAGS += -O3
+CFLAGS += -Wstack-usage=512
 
 LDFLAGS = $(DEFAULT_LDFLAGS)
 

--- a/utils/lsr.c
+++ b/utils/lsr.c
@@ -14,17 +14,17 @@ int myst_lsr(const char* root, myst_strarr_t* paths, bool include_dirs)
     DIR* dir = NULL;
     struct dirent* ent;
     myst_strarr_t dirs = MYST_STRARR_INITIALIZER;
-    struct vars
+    struct locals
     {
         char path[PATH_MAX];
     };
-    struct vars* v = NULL;
+    struct locals* locals = NULL;
 
     /* Check parameters */
     if (!root || !paths)
         goto done;
 
-    if (!(v = malloc(sizeof(struct vars))))
+    if (!(locals = malloc(sizeof(struct locals))))
         goto done;
 
     /* Open the directory */
@@ -39,30 +39,30 @@ int myst_lsr(const char* root, myst_strarr_t* paths, bool include_dirs)
             continue;
         }
 
-        myst_strlcpy(v->path, root, sizeof(v->path));
+        myst_strlcpy(locals->path, root, sizeof(locals->path));
 
         if (strcmp(root, "/") != 0)
-            myst_strlcat(v->path, "/", sizeof(v->path));
+            myst_strlcat(locals->path, "/", sizeof(locals->path));
 
-        myst_strlcat(v->path, ent->d_name, sizeof(v->path));
+        myst_strlcat(locals->path, ent->d_name, sizeof(locals->path));
 
         /* Append to dirs[] array */
         if (ent->d_type & DT_DIR)
         {
-            if (myst_strarr_append(&dirs, v->path) != 0)
+            if (myst_strarr_append(&dirs, locals->path) != 0)
                 goto done;
 
             if (include_dirs)
             {
                 /* Append to paths[] array */
-                if (myst_strarr_append(paths, v->path) != 0)
+                if (myst_strarr_append(paths, locals->path) != 0)
                     goto done;
             }
         }
         else
         {
             /* Append to paths[] array */
-            if (myst_strarr_append(paths, v->path) != 0)
+            if (myst_strarr_append(paths, locals->path) != 0)
                 goto done;
         }
     }
@@ -82,8 +82,8 @@ int myst_lsr(const char* root, myst_strarr_t* paths, bool include_dirs)
 
 done:
 
-    if (v)
-        free(v);
+    if (locals)
+        free(locals);
 
     if (dir)
         closedir(dir);


### PR DESCRIPTION
This PR introduces the **kernel stacks region**, which sets up a kernel stack for each thread (1024 currently but will be configurable later with the --max-threads option). 

The kernel switches to a kernel stack when handling a syscall and switches back to the user stack upon return. Every kernel stack has a guard page at the top of the stack, which causes an easy-to-trace segmentation fault on stack overflow (so that the exact site of overflow can be determined in a backtrace in gdb).

This change also reduces kernel stack usage by putting large buffers onto the heap (e.g., PATH_MAX buffers). Functions like this:

```C++
int f(const char* path)
{
    int ret = 0;
    char dirname[PATH_MAX]; /* 4096 bytes */
    char filename[PATH_MAX]; /* 4096 bytes */
    
    split(path, dirname, filename);

    /* do something here with v->dirname and v->filename */    

done:
    return ret;
}
```

Are transformed to use heap memory as follows.

```C++
int f(const char* path)
{
    int ret = 0;
    struct vars
    {
        char dirname[PATH_MAX]; /* 4096 bytes */
        char filename[PATH_MAX]; /* 4096 bytes */
    };
    struct vars* v = NULL;

    if (!(v = malloc(sizeof struct vars)))
        ERAISE(-ENOMEM);
    
    ECHECK(split_path(path, v->dirname, v->filename));

    /* do something here with v->dirname and v->filename */    

done:

    if (v)
        free(v);

    return ret;
}
```

In cases where a certain function  (**split_path()** in this example) is used very often, the function could be modified to produce heap-allocated output parameters. This PR postpones such an approach for later to minimize possible introduction of bugs. The above pattern (struct vars) therefore has two man advantages.
- It is less prone to introduce bugs (as opposed to rewriting many functions)
- It can group several buffers into a single allocation (more efficient).

The current PR adds compiler pragmas like this one:

```C++
#pragma GCC diagnostic error "-Wstack-usage=256"
```

And compiler flags like this one:

```
-Wstack-usage=512
```

These detect functions that use more than the given stack-usage limit.

The ``myst_syscall`` function itself is unoptimized and allows for a 4096 byte stack. It will be the focus of future work.

The original kernel stack size was 128 kilobytes but was reduced to 64 kilobytes as a result of this work. 32 kilobytes works in most places except during attestation operations where the OE stack grows very deep. This is a place for further optimization.