### PR TITLE
ramfs based devfs

### DIFF
--- a/include/myst/devfs.h
+++ b/include/myst/devfs.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_DEVFS_H
+#define _MYST_DEVFS_H
+
+#include <myst/buf.h>
+#include <myst/fs.h>
+#include <stdbool.h>
+
+/*
+**==============================================================================
+**
+** devfs lifetime management
+**
+**==============================================================================
+*/
+
+int devfs_setup();
+
+int devfs_teardown();
+
+#endif /* _MYST_DEVFS_H */

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -8,6 +8,45 @@
 #include <myst/fs.h>
 #include <stdbool.h>
 
+/* Virtual files in ramfs
+
+Loosely defined a virtual file is one whose contents
+are generated on-the-fly.
+
+ramfs supports two types of virtual files:
+- OPEN: files whose contents are generated at open()
+    Useful where the file contents can be populated once.
+    `myst_file_t.vbuf` field is used to store the buffer. Instead of the inode
+    buffer, the file level buffer was used to ensure some protection against
+    concurrent access.
+    Subsequent reads and writes are serviced from the populated buffer.
+    The buffer is released on close().
+
+
+- RW: files for which read and write operations are stateless.
+    Useful where the file is unbounded, or has special behavior on
+    reads and writes.
+    Read and write file operations on these files operate directly
+    on the user provided buffer.
+
+*/
+
+typedef enum myst_virtual_file_type
+{
+    NONE,
+    OPEN,
+    RW,
+} myst_virtual_file_type_t;
+
+typedef union myst_vcallback {
+    int (*open_cb)(myst_buf_t* buf);
+    struct
+    {
+        int (*read_cb)(void* buf, size_t count);
+        int (*write_cb)(const void* buf, size_t count);
+    } rw_callbacks;
+} myst_vcallback_t;
+
 int myst_init_ramfs(
     myst_mount_resolve_callback_t resolve_cb,
     myst_fs_t** fs_out);
@@ -22,7 +61,8 @@ int myst_create_virtual_file(
     myst_fs_t* fs,
     const char* pathname,
     mode_t mode,
-    int (*vcallback)(myst_buf_t* buf));
+    myst_vcallback_t v_cb,
+    myst_virtual_file_type_t v_type);
 
 int myst_release_tree(myst_fs_t* fs, const char* pathname);
 

--- a/kernel/devfs.c
+++ b/kernel/devfs.c
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+
+#include <myst/buf.h>
+#include <myst/bufu64.h>
+#include <myst/devfs.h>
+#include <myst/eraise.h>
+#include <myst/file.h>
+#include <myst/fs.h>
+#include <myst/mount.h>
+#include <myst/panic.h>
+#include <myst/printf.h>
+#include <myst/ramfs.h>
+#include <myst/tcall.h>
+
+/*************************************
+ * callbacks
+ * ***********************************/
+static int _ignore_read_cb(void* buf, size_t count)
+{
+    (void)buf;
+    (void)count;
+
+    return 0; // EOF
+}
+
+static int _ignore_write_cb(const void* buf, size_t count)
+{
+    (void)buf;
+    (void)count;
+
+    return count;
+}
+
+static int _zero_read_cb(void* buf, size_t count)
+{
+    ssize_t ret = 0;
+
+    if (!buf && count)
+        ERAISE(-EFAULT);
+
+    if (!buf && !count)
+        goto done;
+
+    memset(buf, 0, count);
+
+    ret = count;
+
+done:
+    return ret;
+}
+
+static int _urandom_read_cb(void* buf, size_t count)
+{
+    ssize_t ret = 0;
+
+    if (!buf && count)
+        ERAISE(-EFAULT);
+
+    if (!buf && !count)
+        return 0;
+
+    if (myst_tcall_random(buf, count) != 0)
+        ERAISE(-EIO);
+
+    ret = (ssize_t)count;
+
+done:
+    return ret;
+}
+
+/*****************************
+ * devfs setup and teardown
+ * ***************************/
+
+static myst_fs_t* _devfs;
+
+int devfs_setup()
+{
+    int ret = 0;
+
+    if (myst_init_ramfs(myst_mount_resolve, &_devfs) != 0)
+    {
+        myst_eprintf("failed initialize the dev file system\n");
+        ERAISE(-EINVAL);
+    }
+
+    if (myst_mkdirhier("/dev", 777) != 0)
+    {
+        myst_eprintf("cannot create mount point for devfs\n");
+        ERAISE(-EINVAL);
+    }
+
+    if (myst_mount(_devfs, "/", "/dev") != 0)
+    {
+        myst_eprintf("cannot mount dev file system\n");
+        ERAISE(-EINVAL);
+    }
+
+    /* Create standard /dev files */
+
+    /* /dev/urandom */
+    {
+        myst_vcallback_t v_cb;
+        v_cb.rw_callbacks.read_cb = _urandom_read_cb;
+        v_cb.rw_callbacks.write_cb = _ignore_write_cb;
+
+        myst_create_virtual_file(
+            _devfs, "/urandom", S_IFREG | S_IRUSR | S_IWUSR, v_cb, RW);
+    }
+
+    /* /dev/null */
+    {
+        myst_vcallback_t v_cb;
+        v_cb.rw_callbacks.read_cb = _ignore_read_cb;
+        v_cb.rw_callbacks.write_cb = _ignore_write_cb;
+
+        myst_create_virtual_file(
+            _devfs, "/null", S_IFREG | S_IRUSR | S_IWUSR, v_cb, RW);
+    }
+
+    /* /dev/zero */
+    {
+        myst_vcallback_t v_cb;
+        v_cb.rw_callbacks.read_cb = _zero_read_cb;
+        v_cb.rw_callbacks.write_cb = _ignore_write_cb;
+
+        myst_create_virtual_file(
+            _devfs, "/zero", S_IFREG | S_IRUSR | S_IWUSR, v_cb, RW);
+    }
+
+    /* /dev/fd symlink */
+    _devfs->fs_symlink(_devfs, "/proc/self/fd", "/fd");
+
+done:
+    return ret;
+}
+
+int devfs_teardown()
+{
+    if ((*_devfs->fs_release)(_devfs) != 0)
+    {
+        myst_eprintf("failed to release devfs\n");
+        return -1;
+    }
+
+    return 0;
+}

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -9,6 +9,7 @@
 #include <myst/cpio.h>
 #include <myst/crash.h>
 #include <myst/debugmalloc.h>
+#include <myst/devfs.h>
 #include <myst/eraise.h>
 #include <myst/errno.h>
 #include <myst/exec.h>
@@ -644,6 +645,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         ERAISE(-EINVAL);
     }
 
+    /* Setup devfs */
+    devfs_setup();
+
     /* Create top-level proc entries */
     create_proc_root_entries();
 
@@ -734,6 +738,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
 
     /* Tear down the proc file system */
     procfs_teardown();
+
+    /* Tear down the dev file system */
+    devfs_teardown();
 
     /* Tear down the RAM file system */
     _teardown_ramfs();

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -113,12 +113,19 @@ int create_proc_root_entries()
     int ret = 0;
 
     /* Create /proc/meminfo */
-    ECHECK(myst_create_virtual_file(
-        _procfs, "/meminfo", S_IFREG, _meminfo_vcallback));
+    {
+        myst_vcallback_t v_cb;
+        v_cb.open_cb = _meminfo_vcallback;
+        ECHECK(myst_create_virtual_file(
+            _procfs, "/meminfo", S_IFREG | S_IRUSR, v_cb, OPEN));
+    }
 
     /* Create /proc/self */
-    ECHECK(
-        myst_create_virtual_file(_procfs, "/self", S_IFLNK, _self_vcallback));
+    {
+        myst_vcallback_t v_cb;
+        v_cb.open_cb = _self_vcallback;
+        ECHECK(myst_create_virtual_file(_procfs, "/self", S_IFLNK, v_cb, OPEN));
+    }
 
 done:
     return ret;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -74,8 +74,6 @@
 #include <myst/times.h>
 #include <myst/trace.h>
 
-#define DEV_URANDOM_FD MYST_FDTABLE_SIZE
-
 #define MAX_IPADDR_LEN 64
 
 #define COLOR_RED "\e[31m"
@@ -702,13 +700,6 @@ long myst_syscall_open(const char* pathname, int flags, mode_t mode)
     const myst_fdtable_type_t fdtype = MYST_FDTABLE_TYPE_FILE;
     int fd;
     int r;
-
-    /* Handle /dev/urandom as a special case */
-    if (strcmp(pathname, "/dev/urandom") == 0)
-    {
-        /* ATTN: handle relative paths to /dev/urandom */
-        return DEV_URANDOM_FD;
-    }
 
     ECHECK(myst_mount_resolve(pathname, suffix, &fs));
     ECHECK((*fs->fs_open)(fs, suffix, flags, mode, &fs_out, &file));
@@ -2459,53 +2450,6 @@ static const char* _futex_op_str(int op)
     }
 }
 
-static ssize_t _dev_urandom_read(void* buf, size_t count)
-{
-    ssize_t ret = 0;
-
-    if (!buf && count)
-        ERAISE(-EFAULT);
-
-    if (!buf && !count)
-        return 0;
-
-    if (myst_tcall_random(buf, count) != 0)
-        ERAISE(-EIO);
-
-    ret = (ssize_t)count;
-
-done:
-    return ret;
-}
-
-static ssize_t _dev_urandom_readv(const struct iovec* iov, int iovcnt)
-{
-    ssize_t ret = 0;
-    size_t nread = 0;
-
-    if (!iov && iovcnt)
-        ERAISE(-EINVAL);
-
-    if (_iov_bad_addr(iov, iovcnt))
-        ERAISE(-EFAULT);
-
-    for (int i = 0; i < iovcnt; i++)
-    {
-        if (iov[i].iov_base && iov[i].iov_len)
-        {
-            if (myst_tcall_random(iov[i].iov_base, iov[i].iov_len) != 0)
-                ERAISE(-EINVAL);
-
-            nread += iov[i].iov_len;
-        }
-    }
-
-    ret = (ssize_t)nread;
-
-done:
-    return ret;
-}
-
 void myst_dump_ramfs(void)
 {
     myst_strarr_t paths = MYST_STRARR_INITIALIZER;
@@ -2767,9 +2711,6 @@ long myst_syscall(long n, long params[6])
 
             _strace(n, "fd=%d buf=%p count=%zu", fd, buf, count);
 
-            if (fd == DEV_URANDOM_FD)
-                BREAK(_return(n, _dev_urandom_read(buf, count)));
-
             BREAK(_return(n, myst_syscall_read(fd, buf, count)));
         }
         case SYS_write:
@@ -2791,9 +2732,6 @@ long myst_syscall(long n, long params[6])
 
             _strace(
                 n, "fd=%d buf=%p count=%zu offset=%ld", fd, buf, count, offset);
-
-            if (fd == DEV_URANDOM_FD)
-                BREAK(_return(n, _dev_urandom_read(buf, count)));
 
             BREAK(_return(n, myst_syscall_pread(fd, buf, count, offset)));
         }
@@ -2827,9 +2765,6 @@ long myst_syscall(long n, long params[6])
             int fd = (int)x1;
 
             _strace(n, "fd=%d", fd);
-
-            if (fd == DEV_URANDOM_FD)
-                BREAK(_return(n, 0));
 
             BREAK(_return(n, myst_syscall_close(fd)));
         }
@@ -2880,12 +2815,6 @@ long myst_syscall(long n, long params[6])
             int whence = (int)x3;
 
             _strace(n, "fd=%d offset=%ld whence=%d", fd, offset, whence);
-
-            if (fd == DEV_URANDOM_FD)
-            {
-                /* ATTN: ignored */
-                BREAK(_return(n, 0));
-            }
 
             BREAK(_return(n, myst_syscall_lseek(fd, offset, whence)));
         }
@@ -3039,9 +2968,6 @@ long myst_syscall(long n, long params[6])
             int iovcnt = (int)x3;
 
             _strace(n, "fd=%d iov=%p iovcnt=%d", fd, iov, iovcnt);
-
-            if (fd == DEV_URANDOM_FD)
-                BREAK(_return(n, (long)_dev_urandom_readv(iov, iovcnt)));
 
             BREAK(_return(n, myst_syscall_readv(fd, iov, iovcnt)));
         }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -94,6 +94,7 @@ DIRS += msync
 DIRS += dotnet-ubuntu
 
 DIRS += robust
+DIRS += devfs
 
 __tests:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) tests $(NL) )

--- a/tests/devfs/Makefile
+++ b/tests/devfs/Makefile
@@ -1,0 +1,29 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC -g
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+all: myst rootfs
+
+rootfs: devfs.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/devfs devfs.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+tests:
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/devfs $(OPTS)
+
+gdb:
+	$(MYST_GDB) --args $(MYST_EXEC) rootfs /bin/devfs $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/devfs/devfs.c
+++ b/tests/devfs/devfs.c
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+void test_urandom()
+{
+    int ret;
+    char buf[1024];
+
+    int fd = open("/dev/urandom", O_RDONLY);
+    assert(fd > 0);
+
+    ret = read(fd, buf, 1024);
+    assert(ret == 1024);
+
+    ret = lseek(fd, 10000L, 1);
+    assert(ret == 0);
+
+    ret = ftruncate(fd, 10);
+    assert(ret == -1);
+
+    struct stat statbuf;
+    ret = fstat(fd, &statbuf);
+    assert(ret == 0);
+
+    ret = close(fd);
+    assert(ret == 0);
+}
+
+void test_zero()
+{
+    int ret;
+    char buf[1024];
+
+    int fd = open("/dev/zero", O_RDWR);
+    assert(fd > 0);
+
+    ret = read(fd, buf, 1024);
+    assert(ret == 1024);
+    for (int i = 0; i < 1024; i++)
+        assert(buf[i] == '\0');
+
+    ret = write(fd, buf, 1024);
+    assert(ret == 1024);
+
+    ret = lseek(fd, 10000L, 1);
+    assert(ret == 0);
+
+    ret = ftruncate(fd, 10);
+    assert(ret == -1);
+
+    ret = close(fd);
+    assert(ret == 0);
+}
+
+void test_null()
+{
+    int ret;
+    char buf[1024];
+
+    int fd = open("/dev/null", O_RDWR);
+    assert(fd > 0);
+
+    ret = read(fd, buf, 1024);
+    assert(ret == 0); // Check for EOF
+
+    ret = write(fd, buf, 1024);
+    assert(ret == 1024);
+
+    ret = lseek(fd, 10000L, 1);
+    assert(ret == 0);
+
+    ret = ftruncate(fd, 10);
+    assert(ret == -1);
+
+    ret = close(fd);
+    assert(ret == 0);
+}
+
+void test_fd_link()
+{
+    {
+        char buf[1024];
+        int expected_len = strlen("/proc/self/fd");
+        int ret = readlink("/dev/fd", buf, 1024);
+        assert(ret == expected_len);
+        assert(strncmp(buf, "/proc/self/fd", expected_len) == 0);
+    }
+
+    {
+        struct dirent* fd_ent;
+        DIR* fd_dir = opendir("/dev/fd");
+        assert(fd_dir);
+
+        while ((fd_ent = readdir(fd_dir)) != NULL)
+        {
+            printf("%s\n", fd_ent->d_name);
+        }
+        closedir(fd_dir);
+    }
+}
+
+int main(int argc, const char* argv[])
+{
+    test_urandom();
+    test_zero();
+    test_null();
+    test_fd_link();
+    printf("\n=== passed test (%s)\n", argv[0]);
+    return 0;
+}

--- a/tests/ext2/verity/main.c
+++ b/tests/ext2/verity/main.c
@@ -407,7 +407,7 @@ int main(int argc, const char* argv[])
             while (ent = readdir(dir))
                 n++;
 
-            assert(n == 7);
+            assert(n == 8);
 
             rewinddir(dir);
         }


### PR DESCRIPTION
### Summary
The virtual files supported by ramfs is extended to support /dev special files like urandom, zero and null.
