### PR TITLE
Fixed auto-mount test

### DIFF
--- a/tests/myst/auto-mount/Makefile
+++ b/tests/myst/auto-mount/Makefile
@@ -30,6 +30,7 @@ rootfs: build ramfs
 
 ramfs:
 	mkdir -p $(RAMFSDIR)
+	mkdir -p $(APPDIR)
 	touch $(RAMFSDIR)/ramfs-file
 	$(MYST) mkcpio $(RAMFSDIR) $(RAMFS)
 


### PR DESCRIPTION
One of dependencies needed to create a directory itself in case it is
not already created

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>