### PR TITLE
Allow clearing FD_CLOEXEC flag

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -4966,7 +4966,10 @@ static int _ext2_fcntl(myst_fs_t* fs, myst_file_t* file, int cmd, long arg)
             if (arg != FD_CLOEXEC && arg != 0)
                 ERAISE(-EINVAL);
 
-            file->fdflags = FD_CLOEXEC;
+            if (arg == FD_CLOEXEC)
+                file->fdflags = FD_CLOEXEC;
+            else
+                file->fdflags = 0;
             /* ATTN.TIMESTAMPS */
             goto done;
         }

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -2170,7 +2170,11 @@ static int _fs_fcntl(myst_fs_t* fs, myst_file_t* file, int cmd, long arg)
             if (arg != FD_CLOEXEC && arg != 0)
                 ERAISE(-EINVAL);
 
-            file->fdflags = FD_CLOEXEC;
+            if (arg == FD_CLOEXEC)
+                file->fdflags = FD_CLOEXEC;
+            else
+                file->fdflags = 0;
+
             _update_timestamps(file->inode, CHANGE);
             goto done;
         }

--- a/tests/fs/fs.c
+++ b/tests/fs/fs.c
@@ -752,6 +752,25 @@ void test_openat(void)
     _passed(__FUNCTION__);
 }
 
+void test_fcntl(void)
+{
+    assert(mkdir("/fcntl", 0777) == 0);
+    int fd;
+    assert((fd = open("/fcntl/file", O_CREAT | O_WRONLY, 0666)) >= 0);
+
+    assert(fcntl(fd, F_GETFD) == 0);
+
+    assert(fcntl(fd, F_SETFD, FD_CLOEXEC) == 0);
+    assert(fcntl(fd, F_GETFD) == FD_CLOEXEC);
+
+    assert(fcntl(fd, F_SETFD, 0) == 0);
+    assert(fcntl(fd, F_GETFD) == 0);
+
+    assert(close(fd) == 0);
+
+    _passed(__FUNCTION__);
+}
+
 void diff_timestamps(
     struct stat* st1,
     struct stat* st2,
@@ -846,6 +865,7 @@ int main(int argc, const char* argv[])
     test_statfs(argv[0]);
     test_fstatfs(argv[0]);
     test_openat();
+    test_fcntl();
 
     printf("=== passed all tests (%s)\n", argv[0]);
 


### PR DESCRIPTION
Python 3.8 sets and clear this fd flag, according to #247.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>