### PR TITLE
Fix the pipeline break caused by gcompat

### DIFF
--- a/third_party/gcompat/Makefile
+++ b/third_party/gcompat/Makefile
@@ -1,4 +1,4 @@
-URL=https://github.com/AdelieLinux/gcompat.git
+URL=https://git.adelielinux.org/adelie/gcompat.git
 
 TAG=1.0.0
 
@@ -16,4 +16,3 @@ distclean:
 genpatch: gcompat
 	rm -f patch.diff
 	( cd gcompat; git add -A && git diff HEAD > $(CURDIR)/patch.diff )
-	

--- a/third_party/gcompat/patch.diff
+++ b/third_party/gcompat/patch.diff
@@ -124,19 +124,6 @@ index 5a82bc4..12c3439 100644
  void *__libc_realloc(void *ptr, size_t size)
  {
  	return realloc(ptr, size);
-diff --git a/libgcompat/pthread.c b/libgcompat/pthread.c
-index 19adceb..05f83eb 100644
---- a/libgcompat/pthread.c
-+++ b/libgcompat/pthread.c
-@@ -67,7 +67,7 @@ int pthread_yield(void)
-  */
- cpu_set_t *__sched_cpualloc(size_t _count)
- {
--	return CPU_ALLOC(__count);
-+	return CPU_ALLOC(_count);
- }
- 
- /**
 diff --git a/libgcompat/readlink.c b/libgcompat/readlink.c
 deleted file mode 100644
 index 42501fe..0000000


### PR DESCRIPTION
The old gcompat URL is no longer public and breaks the pipeline. This PR fixes that by switching to a new repository and removing adjusting the patch (since the new branch fixes the same bug in pthread.c).