### PR TITLE
eventfd2 syscall

### DIFF
--- a/include/myst/eventfddev.h
+++ b/include/myst/eventfddev.h
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_EVENTFDDEV_H
+#define _MYST_EVENTFDDEV_H
+
+#include <stddef.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+
+#include <myst/fdops.h>
+
+typedef struct myst_eventfddev myst_eventfddev_t;
+
+typedef struct myst_eventfd myst_eventfd_t;
+
+struct myst_eventfddev
+{
+    myst_fdops_t fdops;
+
+    int (*eventfd)(
+        myst_eventfddev_t* eventfddev,
+        unsigned int intval,
+        int flags,
+        myst_eventfd_t** eventfd_out);
+
+    ssize_t (*read)(
+        myst_eventfddev_t* eventfddev,
+        myst_eventfd_t* eventfd,
+        void* buf,
+        size_t count);
+
+    ssize_t (*write)(
+        myst_eventfddev_t* eventfddev,
+        myst_eventfd_t* eventfd,
+        const void* buf,
+        size_t count);
+
+    ssize_t (*readv)(
+        myst_eventfddev_t* eventfddev,
+        myst_eventfd_t* eventfd,
+        const struct iovec* iov,
+        int iovcnt);
+
+    ssize_t (*writev)(
+        myst_eventfddev_t* eventfddev,
+        myst_eventfd_t* eventfd,
+        const struct iovec* iov,
+        int iovcnt);
+
+    int (*fstat)(
+        myst_eventfddev_t* eventfddev,
+        myst_eventfd_t* eventfd,
+        struct stat* statbuf);
+
+    int (*fcntl)(
+        myst_eventfddev_t* eventfddev,
+        myst_eventfd_t* eventfd,
+        int cmd,
+        long arg);
+
+    int (*ioctl)(
+        myst_eventfddev_t* eventfddev,
+        myst_eventfd_t* eventfd,
+        unsigned long request,
+        long arg);
+
+    int (*dup)(
+        myst_eventfddev_t* eventfddev,
+        const myst_eventfd_t* eventfd,
+        myst_eventfd_t** eventfd_out);
+
+    int (*close)(myst_eventfddev_t* eventfddev, myst_eventfd_t* eventfd);
+
+    int (*target_fd)(myst_eventfddev_t* eventfddev, myst_eventfd_t* eventfd);
+
+    int (*get_events)(myst_eventfddev_t* eventfddev, myst_eventfd_t* eventfd);
+};
+
+myst_eventfddev_t* myst_eventfddev_get(void);
+
+#endif /* _MYST_EVENTFDDEV_H */

--- a/include/myst/fdtable.h
+++ b/include/myst/fdtable.h
@@ -11,6 +11,7 @@
 
 #include <myst/defs.h>
 #include <myst/epolldev.h>
+#include <myst/eventfddev.h>
 #include <myst/fs.h>
 #include <myst/inotifydev.h>
 #include <myst/pipedev.h>
@@ -29,6 +30,7 @@ typedef enum myst_fdtable_type
     MYST_FDTABLE_TYPE_SOCK,
     MYST_FDTABLE_TYPE_EPOLL,
     MYST_FDTABLE_TYPE_INOTIFY,
+    MYST_FDTABLE_TYPE_EVENTFD,
 } myst_fdtable_type_t;
 
 typedef struct myst_fdtable_entry
@@ -140,6 +142,16 @@ MYST_INLINE int myst_fdtable_get_inotify(
 {
     const myst_fdtable_type_t type = MYST_FDTABLE_TYPE_INOTIFY;
     return myst_fdtable_get(fdtable, fd, type, (void**)device, (void**)inotify);
+}
+
+MYST_INLINE int myst_fdtable_get_eventfd(
+    myst_fdtable_t* fdtable,
+    int fd,
+    myst_eventfddev_t** device,
+    myst_eventfd_t** eventfd)
+{
+    const myst_fdtable_type_t type = MYST_FDTABLE_TYPE_EVENTFD;
+    return myst_fdtable_get(fdtable, fd, type, (void**)device, (void**)eventfd);
 }
 
 int myst_fdtable_get_any(

--- a/kernel/eventfddev.c
+++ b/kernel/eventfddev.c
@@ -1,0 +1,532 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <myst/cond.h>
+#include <myst/defs.h>
+#include <myst/eraise.h>
+#include <myst/eventfddev.h>
+#include <myst/id.h>
+#include <myst/panic.h>
+#include <myst/process.h>
+#include <myst/round.h>
+#include <myst/syscall.h>
+
+#define MAGIC 0x9906acdc
+
+#define MAX_COUNTER_VALUE ((uint64_t)0xfffffffffffffffe)
+
+struct myst_eventfd
+{
+    uint32_t magic;
+    int flags;
+    int fdflags;
+    uint64_t counter;
+    myst_mutex_t mutex;
+    myst_cond_t cond;
+};
+
+MYST_INLINE bool _valid_eventfd(const myst_eventfd_t* eventfd)
+{
+    return eventfd && eventfd->magic == MAGIC;
+}
+
+static void _lock(myst_eventfd_t* eventfd)
+{
+    myst_assume(_valid_eventfd(eventfd));
+    myst_mutex_lock(&eventfd->mutex);
+}
+
+static void _unlock(myst_eventfd_t* eventfd)
+{
+    myst_assume(_valid_eventfd(eventfd));
+    myst_mutex_unlock(&eventfd->mutex);
+}
+
+static int _eventfd(
+    myst_eventfddev_t* eventfddev,
+    unsigned int initval,
+    int flags,
+    myst_eventfd_t** eventfd_out)
+{
+    int ret = 0;
+    myst_eventfd_t* eventfd = NULL;
+
+    if (!eventfddev || !eventfd_out)
+        ERAISE(-EINVAL);
+
+    if ((flags & ~(EFD_CLOEXEC | EFD_NONBLOCK | EFD_SEMAPHORE)))
+        ERAISE(-EINVAL);
+
+    /* Create the read eventfd */
+    {
+        if (!(eventfd = calloc(1, sizeof(myst_eventfd_t))))
+            ERAISE(-ENOMEM);
+
+        eventfd->magic = MAGIC;
+        eventfd->counter = initval;
+
+        if (flags & EFD_CLOEXEC)
+            eventfd->fdflags = FD_CLOEXEC;
+
+        eventfd->flags = flags;
+    }
+
+    *eventfd_out = eventfd;
+    eventfd = NULL;
+
+done:
+
+    if (eventfd)
+        free(eventfd);
+
+    return ret;
+}
+
+static ssize_t _read(
+    myst_eventfddev_t* eventfddev,
+    myst_eventfd_t* eventfd,
+    void* buf,
+    size_t count)
+{
+    ssize_t ret = 0;
+    bool locked = false;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EBADF);
+
+    if (!buf)
+        ERAISE(-EINVAL);
+
+    if (count < sizeof(uint64_t))
+        ERAISE(-EINVAL);
+
+    _lock(eventfd);
+    locked = true;
+
+    /* check validitiy of eventfd a second time (now that lock is obtained) */
+    if (!_valid_eventfd(eventfd))
+    {
+        /* cannot unlock since mutex is no longer valid */
+        locked = false;
+        ERAISE(-EBADF);
+    }
+
+    /* if the counter is readable (non-zero) */
+    if (eventfd->counter != 0)
+    {
+        memcpy(buf, &eventfd->counter, sizeof(uint64_t));
+
+        if ((eventfd->flags & EFD_SEMAPHORE))
+            eventfd->counter--;
+        else
+            eventfd->counter = 0;
+
+        myst_cond_signal(&eventfd->cond);
+        ret = sizeof(uint64_t);
+        goto done;
+    }
+
+    /* handle non-blocking read */
+    if (eventfd->flags & EFD_NONBLOCK)
+    {
+        ERAISE(-EAGAIN);
+    }
+
+    /* wait here for another thread to write to the counter */
+    for (;;)
+    {
+        if (myst_cond_wait(&eventfd->cond, &eventfd->mutex) != 0)
+        {
+            /* unexpected */
+            ERAISE(-EPIPE);
+        }
+
+        if (eventfd->counter != 0)
+        {
+            memcpy(buf, &eventfd->counter, sizeof(uint64_t));
+
+            if (eventfd->flags & EFD_SEMAPHORE)
+                eventfd->counter--;
+            else
+                eventfd->counter = 0;
+
+            myst_cond_signal(&eventfd->cond);
+            ret = sizeof(uint64_t);
+            goto done;
+        }
+    }
+
+    /* unreachable */
+
+done:
+
+    if (locked)
+        _unlock(eventfd);
+
+    if (ret > 0)
+        myst_tcall_poll_wake();
+
+    return ret;
+}
+
+static ssize_t _write(
+    myst_eventfddev_t* eventfddev,
+    myst_eventfd_t* eventfd,
+    const void* buf,
+    size_t count)
+{
+    ssize_t ret = 0;
+    uint64_t value;
+    bool locked = false;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EBADF);
+
+    if (!buf)
+        ERAISE(-EINVAL);
+
+    if (count < sizeof(uint64_t))
+        ERAISE(-EINVAL);
+
+    if (value == UINT64_MAX)
+        ERAISE(-EINVAL);
+
+    memcpy(&value, buf, sizeof(uint64_t));
+
+    _lock(eventfd);
+    locked = true;
+
+    /* check validitiy of eventfd a second time (now that lock is obtained) */
+    if (!_valid_eventfd(eventfd))
+    {
+        /* cannot unlock since mutex is no longer valid */
+        ERAISE(-EBADF);
+    }
+
+    /* if able to write the the counter */
+    if (eventfd->counter < MAX_COUNTER_VALUE - value)
+    {
+        eventfd->counter += value;
+        myst_cond_signal(&eventfd->cond);
+        ret = sizeof(uint64_t);
+        goto done;
+    }
+
+    /* handle non-blocking case */
+    if (eventfd->flags & EFD_NONBLOCK)
+    {
+        ERAISE(-EAGAIN);
+    }
+
+    /* wait here for another thread to read the counter */
+    for (;;)
+    {
+        if (myst_cond_wait(&eventfd->cond, &eventfd->mutex) != 0)
+        {
+            /* unexpected */
+            ERAISE(-EPIPE);
+        }
+
+        if (eventfd->counter < MAX_COUNTER_VALUE - value)
+        {
+            eventfd->counter += value;
+            myst_cond_signal(&eventfd->cond);
+            ret = sizeof(uint64_t);
+            goto done;
+        }
+    }
+
+    ret = count;
+
+done:
+
+    if (locked)
+        _unlock(eventfd);
+
+    if (ret > 0)
+        myst_tcall_poll_wake();
+
+    return ret;
+}
+
+static ssize_t _readv(
+    myst_eventfddev_t* eventfddev,
+    myst_eventfd_t* eventfd,
+    const struct iovec* iov,
+    int iovcnt)
+{
+    ssize_t ret = 0;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EINVAL);
+
+    ret = myst_fdops_readv(&eventfddev->fdops, eventfd, iov, iovcnt);
+    ECHECK(ret);
+
+done:
+
+    return ret;
+}
+
+static ssize_t _writev(
+    myst_eventfddev_t* eventfddev,
+    myst_eventfd_t* eventfd,
+    const struct iovec* iov,
+    int iovcnt)
+{
+    ssize_t ret = 0;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EINVAL);
+
+    ret = myst_fdops_writev(&eventfddev->fdops, eventfd, iov, iovcnt);
+    ECHECK(ret);
+
+done:
+
+    return ret;
+}
+
+static int _fstat(
+    myst_eventfddev_t* eventfddev,
+    myst_eventfd_t* eventfd,
+    struct stat* statbuf)
+{
+    int ret = 0;
+    struct stat buf;
+
+    if (!eventfddev || !_valid_eventfd(eventfd) || !statbuf)
+        ERAISE(-EINVAL);
+
+    memset(&buf, 0, sizeof(buf));
+    buf.st_dev = 13; /* event fd */
+    buf.st_ino = (ino_t)eventfd;
+    buf.st_mode = 0600;
+    buf.st_nlink = 1;
+    buf.st_uid = 0;
+    buf.st_gid = 0;
+    buf.st_rdev = 0;
+    buf.st_size = 0;
+    buf.st_blksize = 4096;
+    buf.st_blocks = 0;
+    memset(&buf.st_atim, 0, sizeof(buf.st_atim));
+    memset(&buf.st_mtim, 0, sizeof(buf.st_mtim));
+    memset(&buf.st_ctim, 0, sizeof(buf.st_ctim));
+
+    *statbuf = buf;
+
+done:
+    return ret;
+}
+
+static int _fcntl(
+    myst_eventfddev_t* eventfddev,
+    myst_eventfd_t* eventfd,
+    int cmd,
+    long arg)
+{
+    int ret = 0;
+    bool locked = false;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EINVAL);
+
+    _lock(eventfd);
+    locked = true;
+
+    switch (cmd)
+    {
+        case F_SETFD:
+        {
+            if (arg != FD_CLOEXEC && arg != 0)
+                ERAISE(-EINVAL);
+
+            eventfd->fdflags = arg;
+            goto done;
+        }
+        case F_GETFD:
+        {
+            ret = eventfd->fdflags;
+            goto done;
+        }
+        case F_GETFL:
+        {
+            ret = eventfd->flags;
+            goto done;
+        }
+        default:
+        {
+            ERAISE(-ENOTSUP);
+        }
+    }
+
+    /* unreachable */
+    myst_assume(false);
+
+done:
+
+    if (locked)
+        _unlock(eventfd);
+
+    return ret;
+}
+
+static int _ioctl(
+    myst_eventfddev_t* eventfddev,
+    myst_eventfd_t* eventfd,
+    unsigned long request,
+    long arg)
+{
+    int ret = 0;
+
+    (void)arg;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EBADF);
+
+    if (request == TIOCGWINSZ)
+        ERAISE(-EINVAL);
+
+    ERAISE(-ENOTSUP);
+
+done:
+
+    return ret;
+}
+
+static int _dup(
+    myst_eventfddev_t* eventfddev,
+    const myst_eventfd_t* eventfd,
+    myst_eventfd_t** eventfd_out)
+{
+    int ret = 0;
+    myst_eventfd_t* new_eventfd = NULL;
+
+    if (eventfd_out)
+        *eventfd_out = NULL;
+
+    if (!eventfddev || !_valid_eventfd(eventfd) || !eventfd_out)
+        ERAISE(-EINVAL);
+
+    if (!(new_eventfd = calloc(1, sizeof(myst_eventfd_t))))
+        ERAISE(-ENOMEM);
+
+    /* do not dup fdflags, cond, and mutex */
+    _lock((myst_eventfd_t*)eventfd);
+    new_eventfd->magic = eventfd->magic;
+    new_eventfd->flags = eventfd->flags;
+    new_eventfd->counter = eventfd->counter;
+    _unlock((myst_eventfd_t*)eventfd);
+
+    *eventfd_out = new_eventfd;
+    new_eventfd = NULL;
+
+done:
+
+    if (new_eventfd)
+        free(new_eventfd);
+
+    return ret;
+}
+
+static int _close(myst_eventfddev_t* eventfddev, myst_eventfd_t* eventfd)
+{
+    int ret = 0;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EBADF);
+
+    /* signal any threads blocked on read or write */
+    _lock(eventfd);
+    myst_cond_signal(&eventfd->cond);
+    _unlock(eventfd);
+
+    memset(eventfd, 0, sizeof(myst_eventfd_t));
+    free(eventfd);
+
+done:
+
+    return ret;
+}
+
+static int _target_fd(myst_eventfddev_t* eventfddev, myst_eventfd_t* eventfd)
+{
+    int ret = 0;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EINVAL);
+
+    ret = -ENOTSUP;
+
+done:
+    return ret;
+}
+
+static int _get_events(myst_eventfddev_t* eventfddev, myst_eventfd_t* eventfd)
+{
+    int ret = 0;
+    int events = 0;
+
+    if (!eventfddev || !_valid_eventfd(eventfd))
+        ERAISE(-EINVAL);
+
+    _lock(eventfd);
+    {
+        if (eventfd->counter != 0)
+            events |= POLLIN;
+
+        if (eventfd->counter != MAX_COUNTER_VALUE)
+            events |= POLLOUT;
+    }
+    _unlock(eventfd);
+
+    ret = events;
+
+done:
+    return ret;
+}
+
+extern myst_eventfddev_t* myst_eventfddev_get(void)
+{
+    // clang-format-off
+    static myst_eventfddev_t _pipdev = {
+        {
+            .fd_read = (void*)_read,
+            .fd_write = (void*)_write,
+            .fd_readv = (void*)_readv,
+            .fd_writev = (void*)_writev,
+            .fd_fstat = (void*)_fstat,
+            .fd_fcntl = (void*)_fcntl,
+            .fd_ioctl = (void*)_ioctl,
+            .fd_dup = (void*)_dup,
+            .fd_close = (void*)_close,
+            .fd_target_fd = (void*)_target_fd,
+            .fd_get_events = (void*)_get_events,
+        },
+        .eventfd = _eventfd,
+        .read = _read,
+        .write = _write,
+        .readv = _readv,
+        .writev = _writev,
+        .fstat = _fstat,
+        .fcntl = _fcntl,
+        .ioctl = _ioctl,
+        .dup = _dup,
+        .close = _close,
+        .target_fd = _target_fd,
+        .get_events = _get_events,
+    };
+    // clang-format-on
+
+    return &_pipdev;
+}

--- a/kernel/fdtable.c
+++ b/kernel/fdtable.c
@@ -480,6 +480,8 @@ static const char* _type_name(myst_fdtable_type_t type)
             return "epoll";
         case MYST_FDTABLE_TYPE_INOTIFY:
             return "inotify";
+        case MYST_FDTABLE_TYPE_EVENTFD:
+            return "eventfd";
         case MYST_FDTABLE_TYPE_NONE:
             return "none";
     }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -36,6 +36,7 @@
 #include <myst/epolldev.h>
 #include <myst/eraise.h>
 #include <myst/errno.h>
+#include <myst/eventfddev.h>
 #include <myst/exec.h>
 #include <myst/ext2.h>
 #include <myst/fdops.h>
@@ -1843,6 +1844,33 @@ long myst_syscall_pipe2(int pipefd[2], int flags)
 
     if (__options.trace_syscalls)
         myst_eprintf("pipe2(): [%d:%d]\n", fd0, fd1);
+
+done:
+    return ret;
+}
+
+long myst_syscall_eventfd(unsigned int initval, int flags)
+{
+    long ret = 0;
+    const myst_fdtable_type_t type = MYST_FDTABLE_TYPE_EVENTFD;
+    myst_eventfddev_t* dev = myst_eventfddev_get();
+    myst_eventfd_t* obj = NULL;
+    myst_fdtable_t* fdtable = myst_fdtable_current();
+    int fd;
+
+    if (!dev)
+        ERAISE(-EINVAL);
+
+    ECHECK((*dev->eventfd)(dev, initval, flags, &obj));
+
+    if ((fd = myst_fdtable_assign(fdtable, type, dev, obj)) < 0)
+    {
+        myst_fdtable_remove(fdtable, fd);
+        (*dev->close)(dev, obj);
+        ERAISE(fd);
+    }
+
+    ret = fd;
 
 done:
     return ret;
@@ -4782,7 +4810,15 @@ static long _syscall(void* args_)
         case SYS_signalfd4:
             break;
         case SYS_eventfd2:
-            break;
+        {
+            unsigned int initval = (unsigned int)x1;
+            int flags = (int)x2;
+
+            _strace(n, "initval=%u flags=%d", initval, flags);
+
+            long ret = myst_syscall_eventfd(initval, flags);
+            BREAK(_return(n, ret));
+        }
         case SYS_epoll_create1:
         {
             int flags = (int)x1;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -103,6 +103,8 @@ DIRS += callonce
 DIRS += syscall_exception
 DIRS += dotnet-proc-maps
 #DIRS += mprotect
+DIRS += eventfd
+DIRS += polleventfd
 
 __tests:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) tests $(NL) )

--- a/tests/eventfd/Makefile
+++ b/tests/eventfd/Makefile
@@ -1,0 +1,28 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs: eventfd.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/eventfd eventfd.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+tests: all
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/eventfd $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/eventfd/eventfd.c
+++ b/tests/eventfd/eventfd.c
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "../utils/utils.h"
+
+const size_t N = 256;
+static int fd;
+
+static void* _read_thread(void* arg)
+{
+    long slow = (long)arg;
+
+    for (size_t i = 0; i < N; i++)
+    {
+        uint64_t val = 0;
+
+        if (slow)
+            sleep_msec(3);
+
+        ssize_t n = read(fd, &val, sizeof(val));
+        assert(n == sizeof(val));
+    }
+
+    return NULL;
+}
+
+static void* _write_thread(void* arg)
+{
+    long slow = (long)arg;
+
+    for (size_t i = 0; i < N; i++)
+    {
+        if (slow)
+            sleep_msec(3);
+
+        uint64_t val = 1;
+        ssize_t n = write(fd, &val, sizeof(val));
+        assert(n == sizeof(uint64_t));
+    }
+
+    return NULL;
+}
+
+static void _dump_stat_buf(struct stat* buf)
+{
+    printf("st_dev=%lu\n", buf->st_dev);
+    printf("st_ino=%lu\n", buf->st_ino);
+    printf("st_mode=%o\n", buf->st_mode);
+    printf("st_nlink=%lu\n", buf->st_nlink);
+    printf("st_uid=%d\n", buf->st_uid);
+    printf("st_gid=%d\n", buf->st_gid);
+    printf("st_rdev=%lu\n", buf->st_rdev);
+    printf("st_size=%zu\n", buf->st_size);
+    printf("st_blksize=%zu\n", buf->st_blksize);
+    printf("st_blocks=%zu\n", buf->st_blocks);
+}
+
+void test_eventfd(long slow_write, long slow_read)
+{
+    const size_t NUM_THREADS = 2;
+    pthread_t threads[NUM_THREADS];
+    const char* msg1 = slow_write ? "slow-writer" : "fast-writer";
+    const char* msg2 = slow_read ? "slow-reader" : "fast-reader";
+
+    printf("=== start test (%s: %s/%s)\n", __FUNCTION__, msg1, msg2);
+
+    fd = eventfd(0, EFD_SEMAPHORE);
+    assert(fd >= 0);
+
+    /* Create the reader thread */
+    if (pthread_create(&threads[0], NULL, _read_thread, (void*)slow_write) != 0)
+    {
+        fprintf(stderr, "pthread_create() failed\n");
+        abort();
+    }
+
+    /* Create the write thread */
+    if (pthread_create(&threads[1], NULL, _write_thread, (void*)slow_read) != 0)
+    {
+        fprintf(stderr, "pthread_create() failed\n");
+        abort();
+    }
+
+    /* Join the threads */
+    for (size_t i = 0; i < NUM_THREADS; i++)
+    {
+        void* retval;
+
+        if (pthread_join(threads[i], &retval) != 0)
+        {
+            fprintf(stderr, "pthread_join() failed\n");
+            abort();
+        }
+    }
+
+    close(fd);
+
+    printf("=== passed test (%s: %s/%s)\n", __FUNCTION__, msg1, msg2);
+}
+
+void test1(void)
+{
+    /* test fast-writer/fast-reader */
+    test_eventfd(0, 0);
+
+    /* test fast-writer/slow-reader */
+    test_eventfd(0, 1);
+
+    /* test slow-writer/fast-reader */
+    test_eventfd(1, 0);
+
+    /* test slow-writer/slow-reader */
+    test_eventfd(1, 1);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void* _child(void* arg)
+{
+    for (uint64_t i = 0; i < N; i++)
+        assert(write(fd, &i, sizeof(i)) == sizeof(uint64_t));
+
+    return NULL;
+}
+
+void test2(void)
+{
+    pthread_t thread;
+    void* retval;
+
+    fd = eventfd(0, 0);
+    assert(fd >= 0);
+
+    if (pthread_create(&thread, NULL, _child, NULL) != 0)
+    {
+        fprintf(stderr, "pthread_create() failed\n");
+        abort();
+    }
+
+    if (pthread_join(thread, &retval) != 0)
+    {
+        fprintf(stderr, "pthread_join() failed\n");
+        abort();
+    }
+
+    const uint64_t expect = ((N - 1) * ((N - 1) + 1)) / 2;
+
+    uint64_t val = 0;
+    assert(read(fd, &val, sizeof(val)) == sizeof(uint64_t));
+    assert(val == expect);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+int main(int argc, const char* argv[])
+{
+    test1();
+    test2();
+
+    printf("=== passed test (%s)\n", argv[0]);
+
+    return 0;
+}

--- a/tests/polleventfd/Makefile
+++ b/tests/polleventfd/Makefile
@@ -1,0 +1,28 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs: polleventfd.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/polleventfd polleventfd.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+tests: all
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/polleventfd $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/polleventfd/polleventfd.c
+++ b/tests/polleventfd/polleventfd.c
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#define ITERATIONS 1000
+
+#ifdef TRACE
+#define T(EXPR) EXPR
+#else
+#define T(EXPR)
+#endif
+
+static int efd;
+
+static void _sleep_msec(uint32_t msec)
+{
+    struct timespec ts;
+    ts.tv_sec = (uint64_t)msec / 1000;
+    ts.tv_nsec = ((int64_t)msec % 1000) * 1000000;
+    nanosleep(&ts, NULL);
+}
+
+static void* _reader(void* arg)
+{
+    for (size_t i = 0; i < ITERATIONS; i++)
+    {
+        struct pollfd fds;
+        int n;
+
+        fds.fd = efd;
+        fds.events = POLLIN;
+
+        while ((n = poll(&fds, 1, 1000)) == -1 && errno == EINTR)
+        {
+            T(printf("retry poll()\n"));
+        }
+
+        assert(n == 1);
+
+        uint64_t val;
+        ssize_t count = read(efd, &val, sizeof(val));
+        T(printf("read: %zu %zu %lu\n", i, count, val);)
+        assert(count == sizeof(val));
+    }
+
+    return NULL;
+}
+
+static void* _writer(void* arg)
+{
+    int* pipefd = (int*)arg;
+    (void)pipefd;
+
+    for (uint64_t i = 0; i < ITERATIONS; i++)
+    {
+        T(printf("write: i=%zu\n", i););
+        uint64_t val = 1;
+        ssize_t n = write(efd, &val, sizeof(val));
+        assert(n == sizeof(val));
+    }
+
+    return NULL;
+}
+
+int main(int argc, const char* argv[])
+{
+    pthread_t reader;
+    pthread_t writer;
+
+    efd = eventfd(0, EFD_SEMAPHORE);
+
+    assert(pthread_create(&reader, NULL, _reader, NULL) == 0);
+    _sleep_msec(100);
+    assert(pthread_create(&writer, NULL, _writer, NULL) == 0);
+
+    assert(pthread_join(writer, NULL) == 0);
+    assert(pthread_join(reader, NULL) == 0);
+
+    assert(close(efd) == 0);
+
+    printf("=== passed test (%s)\n", argv[0]);
+
+    return 0;
+}


### PR DESCRIPTION
Implement the ``eventfd2`` syscall (and hence the ``eventfd()`` C library function) and add two tests.
- ``tests/eventfd``
- ``tests/eventfdpoll``

This change is highly orthogonal and therefore is unlikely to cause problems with existing workloads.