### PR TITLE
reenable and optimize ext2/plain test

### DIFF
--- a/ext2/Makefile
+++ b/ext2/Makefile
@@ -17,7 +17,6 @@ CFLAGS += -ffunction-sections
 CFLAGS += -fdata-sections
 CFLAGS += -Wno-conversion
 CFLAGS += -Wno-parentheses
-CFLAGS += -O3
 
 # ATTN: enable this!
 #CFLAGS += -Wextra

--- a/ext2/ext2common.h
+++ b/ext2/ext2common.h
@@ -12,7 +12,7 @@ MYST_INLINE bool ext2_test_bit(
 {
     uint32_t byte = index / 8;
     uint32_t bit = index % 8;
-    return ((uint32_t)(data[byte]) & (1 << bit)) ? 1 : 0;
+    return ((uint32_t)(data[byte]) & (1 << bit));
 }
 
 extern const uint8_t ext2_count_bits_table[];

--- a/include/myst/strings.h
+++ b/include/myst/strings.h
@@ -42,4 +42,8 @@ bool myst_isspace(char c);
 /* convert a whole string to an integer */
 int myst_str2int(const char* s, int* x);
 
+// BSD memcchr() function: return a pointer to the first byte that is not
+// equal to c or null if not found.
+void* myst_memcchr(const void* b, int c, size_t len);
+
 #endif /* _MYST_STRINGS_H */

--- a/tests/ext2/Makefile
+++ b/tests/ext2/Makefile
@@ -2,7 +2,7 @@ TOP=$(abspath ../..)
 include $(TOP)/defs.mak
 
 DIRS =
-#DIRS += plain
+DIRS += plain
 DIRS += crypt
 DIRS += verity
 

--- a/tests/ext2/plain/Makefile
+++ b/tests/ext2/plain/Makefile
@@ -34,11 +34,14 @@ EXT2FS_SIZE=134217728
 tests:
 	mkdir -p $(SUBOBJDIR)
 	sudo $(MYST) mkext2 --force --size=$(EXT2FS_SIZE) ext2dir $(EXT2FS)
+	chown $(USER).$(USER) $(EXT2FS)
 	$(PREFIX) $(RUNTEST) $(PREFIX) $(SUBBINDIR)/ext2 $(EXT2FS)
-	rm -rf $(EXT2FS)
 
-cg:
-	$(MAKE) USE_CALLGRIND=1 tests
+cachegrind:
+	mkdir -p $(SUBOBJDIR)
+	sudo $(MYST) mkext2 --force --size=$(EXT2FS_SIZE) ext2dir $(EXT2FS)
+	chown $(USER).$(USER) $(EXT2FS)
+	$(CACHEGRIND_COMMAND) $(SUBBINDIR)/ext2 $(EXT2FS)
 
 ann:
 	cg_annotate --auto=yes -I$(TOP)/ext2 cachegrind.out

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -20,6 +20,7 @@ CFLAGS += -fdata-sections
 CFLAGS += -Wno-conversion
 CFLAGS += -Wno-parentheses
 CFLAGS += -Wstack-usage=512
+CFLAGS += -O3
 
 LDFLAGS = $(DEFAULT_LDFLAGS)
 


### PR DESCRIPTION
This PR reenables the ext2/plain test (disabled as part of another PR). It also optimizes byte scanning operations with the new ``myst_memcchr`` function.

It also optimizes the kernel's ``memset`` function to be highly efficient.