### PR TITLE
add cpprestsdk test suite

### DIFF
--- a/solutions/Makefile
+++ b/solutions/Makefile
@@ -32,6 +32,7 @@ endif
 DIRS += nodejs
 DIRS += numpy_core_tests
 DIRS += redis
+DIRS += cpprestsdk
 
 .PHONY: $(DIRS)
 

--- a/solutions/cpprestsdk/Dockerfile
+++ b/solutions/cpprestsdk/Dockerfile
@@ -1,0 +1,22 @@
+# stage 1 build
+FROM alpine:3.12.3 AS cpprest-base-image
+
+RUN apk add --no-cache curl build-base bash git boost-dev cmake zlib-dev openssl-dev ninja
+
+RUN rm -rf /app;mkdir -p /app
+	
+WORKDIR /app
+
+ADD skip-tests.patch .
+RUN git clone https://github.com/Microsoft/cpprestsdk.git casablanca
+        # apply patch to skip un-wanted tests and compile
+RUN cd casablanca;\
+        git apply ../skip-tests.patch;\
+        mkdir -p build.debug; cd build.debug;\
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCPPREST_EXCLUDE_WEBSOCKETS=ON  ..;\
+        cd ..;\
+        mkdir -p build.release; cd build.release;\
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCPPREST_EXCLUDE_WEBSOCKETS=ON  ..;\
+        cd ..;\
+        ninja -C build.debug;\
+        ninja -C build.release;

--- a/solutions/cpprestsdk/Makefile
+++ b/solutions/cpprestsdk/Makefile
@@ -1,0 +1,44 @@
+.PHONY: all package cpio gdb
+
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER    = $(TOP)/scripts/appbuilder
+APPDIR        = appdir
+APP_NAME      = test_runner
+
+# OPTS += --strace
+
+
+all: package
+
+package: $(APPDIR) private.pem
+	$(MYST) package-sgx $(APPDIR) private.pem config.json
+
+run: 
+	myst/bin/$(APP_NAME) $(OPTS)
+
+$(APPDIR):
+	$(APPBUILDER) -v -d Dockerfile
+
+cpio: $(APPDIR)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+# There are 6 test suite come with the CPPRESTSDK, replace the <suite>.so filename to related test suite
+# libhttpclient_test.so
+# libhttplistener_test.so
+# libjson_test.so
+# libpplx_test.so
+# libstreams_test.so
+# liburi_test.so
+run-cpio: cpio
+	$(MYST_EXEC) rootfs /app/casablanca/build.release/Release/Binaries/test_runner libhttpclient_test.so --app-config-path debug-config.json $(OPTS)
+
+gdb: clean cpio
+	$(MYST_GDB) --args $(MYST_EXEC) rootfs /app/casablanca/build.release/Release/Binaries/test_runner libhttplistener_test.so --app-config-path debug-config.json $(OPTS)
+
+private.pem:
+	openssl genrsa -out private.pem -3 3072
+
+clean:
+	rm -rf rootfs $(APPDIR) myst private.pem 

--- a/solutions/cpprestsdk/config.json
+++ b/solutions/cpprestsdk/config.json
@@ -1,0 +1,15 @@
+{
+    // OpenEnclave specific values
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+    "MemorySize": "1024m",
+    "ApplicationPath": "/app/casablanca/build.release/Release/Binaries/test_runner",
+    "CurrentWorkingDirectory": "/app/casablanca/build.release/Release/Binaries/",
+    "ApplicationParameters": ["*test.so"],
+    "HostApplicationParameters": false,
+    "EnvironmentVariables": [],
+    "HostEnvironmentVariables": []
+}

--- a/solutions/cpprestsdk/debug-config.json
+++ b/solutions/cpprestsdk/debug-config.json
@@ -1,0 +1,14 @@
+{
+    // OpenEnclave specific values
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+    "MemorySize": "1024m",
+    "ApplicationPath": "/app/casablanca/build.debug/Release/Binaries/test_runner",
+    "CurrentWorkingDirectory": "/app/casablanca/build.debug/Release/Binaries/",
+    "HostApplicationParameters": true,
+    "EnvironmentVariables": [],
+    "HostEnvironmentVariables": []
+}

--- a/solutions/cpprestsdk/skip-tests.patch
+++ b/solutions/cpprestsdk/skip-tests.patch
@@ -1,0 +1,13 @@
+diff --git a/Release/tests/functional/streams/fstreambuf_tests.cpp b/Release/tests/functional/streams/fstreambuf_tests.cpp
+index 190eb66b..39e65559 100644
+--- a/Release/tests/functional/streams/fstreambuf_tests.cpp
++++ b/Release/tests/functional/streams/fstreambuf_tests.cpp
+@@ -940,7 +940,7 @@ SUITE(file_buffer_tests)
+     }
+ #endif
+ 
+-#if !defined(_WIN32) && defined(__x86_64__)
++#if defined(_TEST_4G_CASE) && !defined(_WIN32) && defined(__x86_64__)
+ 
+     struct TidyStream
+     {


### PR DESCRIPTION
add CPPRESTSDK (https://github.com/microsoft/cpprestsdk) solution. Running the in stock test suites.
All six test suites will end with myst_run_thread_ecall(): failure. Requires further investigation. 

recipe `run-cpio` and `gdb` can run/debug single test suites out of the following 6 test suites:
- libhttpclient_test.so
- libhttplistener_test.so
- libjson_test.so
- libpplx_test.so
- libstreams_test.so
- liburi_test.so