### PR TITLE
Add cpuinfo proc entry

### DIFF
--- a/include/myst/tcall.h
+++ b/include/myst/tcall.h
@@ -55,6 +55,8 @@ typedef enum myst_tcall_number
     MYST_TCALL_LOAD_FSSIG,
     MYST_TCALL_CLOCK_GETRES,
     MYST_TCALL_GCOV,
+    MYST_TCALL_CPUINFO_SIZE,
+    MYST_TCALL_GET_CPUINFO,
 } myst_tcall_number_t;
 
 long myst_tcall(long n, long params[6]);
@@ -154,5 +156,9 @@ int myst_tcall_load_fssig(const char* path, myst_fssig_t* fssig);
 int myst_tcall_mprotect(void* addr, size_t len, int prot);
 
 long myst_gcov(const char* func, long params[6]);
+
+int myst_tcall_cpuinfo_size(void);
+
+int myst_tcall_get_cpuinfo(char* buf, size_t size);
 
 #endif /* _MYST_TCALL_H */

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -1380,19 +1380,13 @@ static int _stat(inode_t* inode, struct stat* statbuf)
     int ret = 0;
     struct stat buf;
     off_t rounded;
-    myst_buf_t vbuf = MYST_BUF_INITIALIZER;
     size_t size;
 
     if (!_inode_valid(inode) || !statbuf)
         ERAISE(-EINVAL);
 
-    if (inode->v_type == OPEN)
-    {
-        ECHECK(inode->v_cb.open_cb(&vbuf));
-        size = vbuf.size;
-        ECHECK(myst_round_up_signed(size, BLKSIZE, &rounded));
-    }
-    else if (inode->v_type == RW)
+    // Linux doesn't report size for /proc and /dev virtual files
+    if (inode->v_type)
     {
         size = 0;
     }
@@ -1420,7 +1414,6 @@ static int _stat(inode_t* inode, struct stat* statbuf)
     *statbuf = buf;
 
 done:
-    myst_buf_release(&vbuf);
     return ret;
 }
 

--- a/kernel/tcall.c
+++ b/kernel/tcall.c
@@ -250,3 +250,15 @@ long myst_gcov(const char* func, long gcov_params[6])
     return myst_tcall(MYST_TCALL_GCOV, params);
 }
 #endif
+
+int myst_tcall_cpuinfo_size(void)
+{
+    long params[6] = {0};
+    return myst_tcall(MYST_TCALL_CPUINFO_SIZE, params);
+}
+
+int myst_tcall_get_cpuinfo(char* data, size_t size)
+{
+    long params[6] = {(long)data, (long)size};
+    return myst_tcall(MYST_TCALL_GET_CPUINFO, params);
+}

--- a/target/linux/Makefile
+++ b/target/linux/Makefile
@@ -16,6 +16,7 @@ SOURCES += ../shared/poll.c
 SOURCES += ../shared/luks.c
 SOURCES += ../shared/sha256.c
 SOURCES += ../shared/verify.c
+SOURCES += ../shared/cpuinfo.c
 
 CFLAGS = $(DEFAULT_CFLAGS)
 

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -517,6 +517,14 @@ long myst_tcall(long n, long params[6])
             return myst_gcov(func, gcov_params);
         }
 #endif
+        case MYST_TCALL_CPUINFO_SIZE:
+        {
+            return myst_tcall_cpuinfo_size();
+        }
+        case MYST_TCALL_GET_CPUINFO:
+        {
+            return myst_tcall_get_cpuinfo((void*)x1, (size_t)x2);
+        }
         case SYS_ioctl:
         {
             int fd = (int)x1;

--- a/target/sgx/enclave/Makefile
+++ b/target/sgx/enclave/Makefile
@@ -15,6 +15,7 @@ SOURCES += ../../shared/luks.c
 SOURCES += ../../shared/crypto.c
 SOURCES += ../../shared/sha256.c
 SOURCES += ../../shared/verify.c
+SOURCES += ../../shared/cpuinfo.c
 
 CFLAGS = $(OEENCLAVE_CFLAGS)
 

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -585,6 +585,14 @@ long myst_tcall(long n, long params[6])
             return myst_gcov(func, gcov_params);
         }
 #endif
+        case MYST_TCALL_CPUINFO_SIZE:
+        {
+            return myst_tcall_cpuinfo_size();
+        }
+        case MYST_TCALL_GET_CPUINFO:
+        {
+            return myst_tcall_get_cpuinfo((void*)x1, (size_t)x2);
+        }
         case SYS_read:
         case SYS_write:
         case SYS_close:

--- a/target/shared/cpuinfo.c
+++ b/target/shared/cpuinfo.c
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 #include <errno.h>
-#include <myst/tcall.h>
 #include <fcntl.h>
+#include <myst/tcall.h>
 #include <string.h>
 
 int myst_tcall_cpuinfo_size()
@@ -24,23 +24,12 @@ int myst_tcall_cpuinfo_size()
 
 int myst_tcall_get_cpuinfo(char* buf, size_t size)
 {
-    int fd, nbytes, count = 0;
-    char tmp[1024];
-    char* p = buf;
+    int fd = open("/proc/cpuinfo", O_RDONLY);
 
-    fd = open("/proc/cpuinfo", O_RDONLY);
     if (fd < 0)
         return errno;
 
-    while ((nbytes = read(fd, tmp, sizeof(tmp))))
-    {
-        count += nbytes;
-        if (count > size)
-            break;
-
-        memcpy(p, tmp, nbytes);
-        p += nbytes;
-    }
+    read(fd, buf, size);
     close(fd);
 
     return 0;

--- a/target/shared/cpuinfo.c
+++ b/target/shared/cpuinfo.c
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <errno.h>
+#include <myst/tcall.h>
+#include <fcntl.h>
+#include <string.h>
+
+int myst_tcall_cpuinfo_size()
+{
+    int fd, nbytes, size = 0;
+    char buf[1024];
+
+    fd = open("/proc/cpuinfo", O_RDONLY);
+    if (fd < 0)
+        return errno;
+
+    while ((nbytes = read(fd, buf, sizeof(buf))))
+        size += nbytes;
+    close(fd);
+
+    return size;
+}
+
+int myst_tcall_get_cpuinfo(char* buf, size_t size)
+{
+    int fd, nbytes, count = 0;
+    char tmp[1024];
+    char* p = buf;
+
+    fd = open("/proc/cpuinfo", O_RDONLY);
+    if (fd < 0)
+        return errno;
+
+    while ((nbytes = read(fd, tmp, sizeof(tmp))))
+    {
+        count += nbytes;
+        if (count > size)
+            break;
+
+        memcpy(p, tmp, nbytes);
+        p += nbytes;
+    }
+    close(fd);
+
+    return 0;
+}

--- a/tests/procfs/procfs.c
+++ b/tests/procfs/procfs.c
@@ -86,12 +86,26 @@ int test_maps()
     printf("%s\n", buf);
 }
 
+int test_cpuinfo()
+{
+    int fd;
+    char buf[1024];
+
+    fd = open("/proc/cpuinfo", O_RDONLY);
+    assert(fd > 0);
+    while (read(fd, buf, sizeof(buf)))
+        printf("%s", buf);
+
+    close(fd);
+}
+
 int main(int argc, const char* argv[])
 {
     test_meminfo();
     test_self_links(argv[0]);
     test_readonly();
     test_maps();
+    test_cpuinfo();
 
     printf("\n=== passed test (%s)\n", argv[0]);
     return 0;

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -744,6 +744,26 @@ int myst_load_fssig(const char* path, myst_fssig_t* fssig)
     return retval;
 }
 
+int myst_tcall_cpuinfo_size()
+{
+    int retval;
+
+    if (myst_cpuinfo_size_ocall(&retval) != OE_OK)
+        return -EINVAL;
+
+    return retval;
+}
+
+int myst_tcall_get_cpuinfo(char* buf, size_t size)
+{
+    int retval;
+
+    if (myst_get_cpuinfo_ocall(&retval, buf, size) != OE_OK)
+        return -EINVAL;
+
+    return retval;
+}
+
 #define ENCLAVE_PRODUCT_ID 1
 #define ENCLAVE_SECURITY_VERSION 1
 #define ENCLAVE_DEBUG true

--- a/tools/myst/host/host.c
+++ b/tools/myst/host/host.c
@@ -93,6 +93,16 @@ void myst_cpuid_ocall(
     __cpuid_count(leaf, subleaf, *rax, *rbx, *rcx, *rdx);
 }
 
+int myst_cpuinfo_size_ocall()
+{
+    return myst_tcall_cpuinfo_size();
+}
+
+int myst_get_cpuinfo_ocall(char* buf, size_t size)
+{
+    return myst_tcall_get_cpuinfo(buf, size);
+}
+
 OE_EXPORT
 OE_NEVER_INLINE
 void oe_notify_debugger_library_load(oe_debug_image_t* image)

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -357,6 +357,10 @@ enclave
 
         int myst_mprotect_ocall(void* addr, size_t len, int prot);
 
+        int myst_cpuinfo_size_ocall();
+
+        int myst_get_cpuinfo_ocall([out, size=size] char* buf, size_t size);
+
         /*
         **======================================================================
         **


### PR DESCRIPTION
### Summary
This PR adds support for /proc/cpuinfo file. 
Two calls are made to the target, first one to get the size of the cpuinfo file on the host. The second one passes a buffer of that size, and the contents of /proc/cpuinfo on the host are copied over into the buffer.
The buffer is cached inside the kernel, so that subsequent requests can be serviced without target calls.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>