### PR TITLE
Fix for cppreststk SequentialReadWrite test

### DIFF
--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -1195,6 +1195,11 @@ static ssize_t _fs_pwrite(
 
     /* Write count bytes to the file or directory */
     {
+        // When opened for append, Linux pwrite() appends data to the end of
+        // file regadless of the offset.
+        if ((file->operating & O_APPEND))
+            offset = _file_size(file);
+
         size_t new_offset = (size_t)offset + count;
 
         if (new_offset > _file_size(file))

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -1193,10 +1193,6 @@ static ssize_t _fs_pwrite(
         goto done;
     }
 
-    /* Verify that the offset is in bounds */
-    if ((size_t)offset > _file_size(file))
-        ERAISE(-EINVAL);
-
     /* Write count bytes to the file or directory */
     {
         size_t new_offset = (size_t)offset + count;


### PR DESCRIPTION
RAMFS was rejecting pwrite offset parameters that were beyond the end of the file. Apparently this is legal.

```C++
ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
```

The following program should print 1 (one byte written).

```C++
#include <stdio.h>
#include <unistd.h>
#include <assert.h>
#include <string.h>
#include <fcntl.h>
#include <errno.h>

int main()
{
    int fd = open("file", O_CREAT | O_TRUNC | O_WRONLY);

    size_t count = 1;
    off_t offset = 10;
    ssize_t n = pwrite(fd, "a", count, offset);
    printf("%zu\n", n);

    return 0;
}
```

