### PR TITLE
cpprestsdk: fix for httplistener test

### DIFF
--- a/kernel/sockdev.c
+++ b/kernel/sockdev.c
@@ -336,6 +336,7 @@ static int _sd_sendmsg(
     }
     else
     {
+        /* The IO vector is already flat */
         msg_ptr = msg;
     }
 

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -748,7 +748,6 @@ int myst_load_fssig(const char* path, myst_fssig_t* fssig)
 #define ENCLAVE_SECURITY_VERSION 1
 #define ENCLAVE_DEBUG true
 
-#define ENCLAVE_HEAP_SIZE 131072
 #define ENCLAVE_HEAP_SIZE (256 * 1024)
 
 #ifdef MYST_ENABLE_GCOV

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -749,6 +749,7 @@ int myst_load_fssig(const char* path, myst_fssig_t* fssig)
 #define ENCLAVE_DEBUG true
 
 #define ENCLAVE_HEAP_SIZE 131072
+#define ENCLAVE_HEAP_SIZE (256 * 1024)
 
 #ifdef MYST_ENABLE_GCOV
 #define ENCLAVE_STACK_SIZE 8 * 8192

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -748,7 +748,7 @@ int myst_load_fssig(const char* path, myst_fssig_t* fssig)
 #define ENCLAVE_SECURITY_VERSION 1
 #define ENCLAVE_DEBUG true
 
-#define ENCLAVE_HEAP_SIZE (256 * 1024)
+#define ENCLAVE_HEAP_SIZE 131072
 
 #ifdef MYST_ENABLE_GCOV
 #define ENCLAVE_STACK_SIZE 8 * 8192


### PR DESCRIPTION
This PR fixes the following cpprestsdk tests:

```
libhttplistener_test.so: request_stream_tests:test_chunked_transfer
```

This test calls into the target (OE enclave) and fails to allocate enough memory to serialize (flatten) a gather-write buffer. 

**The fix flattens the gather-write buffer on the kernel side instead of the target side.**