### PR TITLE
fix mprotect and dotnet-proc-maps tests

### DIFF
--- a/tests/dotnet-proc-maps/Makefile
+++ b/tests/dotnet-proc-maps/Makefile
@@ -11,10 +11,9 @@ endif
 all: rootfs
 
 tests:
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) --memory-size=1024m rootfs /app/HelloWorld > actual.txt
-	@cat actual.txt | grep -E "HelloWorld" > /dev/null
+	$(RUNTEST) ./exec.sh $(MYST_EXEC) $(OPTS) --memory-size=1024m rootfs /app/HelloWorld
 	@ echo "=== passed test (dotnet-proc-maps)"
-	
+
 gdb: rootfs
 	$(MYST_GDB) --args $(MYST_EXEC) $(OPTS) --memory-size=1024m rootfs /app/HelloWorld
 
@@ -25,4 +24,4 @@ rootfs: appdir
 	$(MYST) mkcpio appdir rootfs
 
 clean:
-	sudo rm -fr appdir rootfs HelloWorld/build HelloWorld/obj HelloWorld/bin actual.txt
+	sudo rm -fr appdir rootfs HelloWorld/build HelloWorld/obj HelloWorld/bin stdout.txt

--- a/tests/dotnet-proc-maps/exec.sh
+++ b/tests/dotnet-proc-maps/exec.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+$* > stdout.txt
+if [ "$?" != "0" ]; then
+    exit 1
+fi
+grep -q "HelloWorld" stdout.txt
+if [ "$?" != "0" ]; then
+    exit 1
+fi

--- a/tests/mprotect/Makefile
+++ b/tests/mprotect/Makefile
@@ -15,8 +15,7 @@ rootfs: main.c
 	$(MYST) mkcpio $(APPDIR) rootfs
 
 tests: rootfs
-	$(RUNTEST) $(MYST_EXEC) rootfs /bin/mprotect_test $(OPTS) | grep -v "OE_ENCLAVE_ABORTING" > result
-	diff result expected
+	$(RUNTEST) ./exec.sh $(MYST_EXEC) rootfs /bin/mprotect_test $(OPTS)
 	@ echo "=== passed test (mprotect)"
 
 myst:

--- a/tests/mprotect/exec.sh
+++ b/tests/mprotect/exec.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+$* > stdout.txt
+grep -v OE_ENCLAVE_ABORTING stdout.txt | diff - expected
+if [ "$?" != "0" ]; then
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes the ``mprotect`` and ``dotnet-proc-maps`` tests to run within the ``runtest`` script. When ``make tests`` is typed from the top, tests are invoked by the ``runtest`` script. Each command that could potentially fail must be wrapped by ``$(RUNTEST)`` and must not redirect output.

These two tests are fixed by moving the tests and the checking of their output to an independent ``exec.sh`` script.