### PR TITLE
Handle dlopened library with R_X86_64_TPOFF64 symbols

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -59,6 +59,7 @@ DIRS += tlscert
 DIRS += tlscert2
 DIRS += wake_and_kill
 DIRS += cross_fs_symlinks
+DIRS += openmp
 
 ifndef MYST_SKIP_LTP_TESTS
 DIRS += ltp

--- a/tests/openmp/Dockerfile
+++ b/tests/openmp/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y gcc libgomp1
+
+RUN rm -rf /app;mkdir -p /app
+ADD omp_dlopen.c /app
+
+RUN cd /app && \
+    gcc -o omp-dlopen -Wall -g omp_dlopen.c -ldl
+
+CMD ["/bin/bash"]

--- a/tests/openmp/Makefile
+++ b/tests/openmp/Makefile
@@ -1,0 +1,25 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+all: appdir rootfs
+
+appdir:
+	$(APPBUILDER) Dockerfile
+
+rootfs: appdir
+	$(MYST) mkcpio appdir rootfs
+
+tests:
+	$(MYST_EXEC) $(OPTS) rootfs /app/omp-dlopen
+
+gdb:
+	$(MYST_GDB) --args $(MYST_EXEC) $(OPTS) rootfs /app/omp-dlopen
+
+clean:
+	rm -rf rootfs appdir

--- a/tests/openmp/omp_dlopen.c
+++ b/tests/openmp/omp_dlopen.c
@@ -1,0 +1,19 @@
+#include <dlfcn.h>
+#include <stdio.h>
+
+int main()
+{
+    void* handle;
+
+    handle = dlopen("libgomp.so.1.0.0", RTLD_GLOBAL);
+    if (!handle)
+    {
+        printf("%s\n", dlerror());
+        return (-1);
+    }
+
+    printf("dlopen libgomp.so succeed\n");
+
+    dlclose(handle);
+    return (0);
+}

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -194,7 +194,7 @@ index 20d50f2c..c6ad4096 100644
 +    return -ENOTSUP;
 +}
 diff --git a/ldso/dynlink.c b/ldso/dynlink.c
-index afec985a..4cd45927 100644
+index afec985a..5435b9b5 100644
 --- a/ldso/dynlink.c
 +++ b/ldso/dynlink.c
 @@ -27,6 +27,13 @@
@@ -287,7 +287,18 @@ index afec985a..4cd45927 100644
  	for(;;);
  }
  
-@@ -2100,6 +2083,7 @@ end:
+@@ -2058,6 +2041,10 @@ void *dlopen(const char *file, int mode)
+ 	pthread_mutex_lock(&init_fini_lock);
+ 	if (!p->constructed) ctor_queue = queue_ctors(p);
+ 	pthread_mutex_unlock(&init_fini_lock);
++
++  // Update static_tls_cnt for the subsequent relocations
++  static_tls_cnt = tls_cnt;
++
+ 	if (!p->relocated && (mode & RTLD_LAZY)) {
+ 		prepare_lazy(p);
+ 		for (i=0; p->deps[i]; i++)
+@@ -2100,6 +2087,7 @@ end:
  		free(ctor_queue);
  	}
  	pthread_setcancelstate(cs, 0);


### PR DESCRIPTION
Signed-off-by: Xuejun Yang <xuejya@microsoft.com>

MUSL maintains a counter for the number of loaded dynamic libraries that contain `TLS` section (verifiable with `readelf -l <.so file path>`). When a `R_X86_64_TPOFF64` symbol needs to be relocated, it checks whether the `tls_id` of the library being relocated is smaller than the number of total number of loaded dynamic libraries that contain `TLS` section.

The bug is that musl failed to update the total number before the relocation for the dlopen case, causing an assertion failure.

Fix https://github.com/deislabs/mystikos/issues/372