### PR TITLE
Add --max-threads options

### DIFF
--- a/include/myst/file.h
+++ b/include/myst/file.h
@@ -24,7 +24,7 @@ ssize_t myst_writen(int fd, const void* data, size_t size);
 
 int myst_copy_file(const char* oldpath, const char* newpath);
 
-int myst_copy_file_fd(char* oldpath, int newfd);
+int myst_copy_file_fd(const char* oldpath, int newfd);
 
 int myst_chown_sudo_user(const char* path);
 

--- a/tests/clock/Makefile
+++ b/tests/clock/Makefile
@@ -19,6 +19,7 @@ all: myst
 	$(MYST) mkcpio $(APPDIR) rootfs
 
 OPTS += --memory-size=16m
+OPTS += --max-threads=2
 
 tests:
 	$(RUNTEST) $(MYST_EXEC) rootfs /bin/clock  $(sec) $(nsec) $(OPTS)

--- a/tests/getcwd/Makefile
+++ b/tests/getcwd/Makefile
@@ -18,6 +18,9 @@ ifdef STRACE
 OPTS = --strace
 endif
 
+OPTS += --max-threads=1
+OPTS += --memory-size=8m
+
 tests: all
 	$(RUNTEST) $(MYST_EXEC) rootfs /bin/getcwd $(OPTS)
 

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -16,6 +16,9 @@ ifdef TRACE
 OPTS += --etrace --strace
 endif
 
+OPTS += --max-threads=3
+OPTS += --memory-size=16m
+
 ifndef FS
 FS=ext2fs
 endif

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -510,6 +510,7 @@ int myst_enter_ecall(
     size_t envp_size,
     uint64_t event)
 {
+    /* WARNING: this function has a very small stack */
     struct enter_arg arg = {
         .options = options,
         .shared_memory = shared_memory,
@@ -542,6 +543,7 @@ int myst_enter_ecall(
 
 long myst_run_thread_ecall(uint64_t cookie, uint64_t event)
 {
+    /* WARNING: this function has a very small stack */
     return myst_run_thread(cookie, event);
 }
 
@@ -775,9 +777,6 @@ int myst_tcall_get_cpuinfo(char* buf, size_t size)
 #else
 #define ENCLAVE_STACK_SIZE 8192
 #endif
-
-/* Note: there should be at least as many kernel stacks as threads */
-#define ENCLAVE_MAX_THREADS MYST_MAX_KSTACKS
 
 OE_SET_ENCLAVE_SGX(
     ENCLAVE_PRODUCT_ID,

--- a/tools/myst/host/archive.c
+++ b/tools/myst/host/archive.c
@@ -49,7 +49,7 @@ void get_archive_options(
         struct stat statbuf;
 
         if (num_pubkeys == max_pubkeys)
-            _err("too many --pubkey options (> %u)", max_pubkeys);
+            _err("too many --pubkey options (> %zu)", max_pubkeys);
 
         if (stat(pubkey, &statbuf) != 0)
             _err("no such file for --pubkey options: %s", pubkey);
@@ -62,7 +62,7 @@ void get_archive_options(
         struct stat statbuf;
 
         if (num_roothashes == max_roothashes)
-            _err("too many --roothash options (> %u)", max_roothashes);
+            _err("too many --roothash options (> %zu)", max_roothashes);
 
         if (stat(roothash, &statbuf) != 0)
             _err("no such file for --roothash options: %s", roothash);

--- a/tools/myst/host/exec.h
+++ b/tools/myst/host/exec.h
@@ -14,6 +14,7 @@ int exec_launch_enclave(
     uint32_t flags,
     const char* argv[],
     const char* envp[],
-    struct myst_options* options);
+    struct myst_options* options,
+    size_t max_threads);
 
 #endif /* _MYST_HOST_EXEC_H */

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -77,6 +77,7 @@ struct options
 static void _get_options(int* argc, const char* argv[], struct options* opts)
 {
     memset(opts, 0, sizeof(struct options));
+    size_t max_threads = 0;
 
     // process ID mapping options
     cli_get_mapping_opts(argc, argv, &opts->mapping);
@@ -179,6 +180,28 @@ static void _get_options(int* argc, const char* argv[], struct options* opts)
         {
             opts->mapping.enc_gid = 0;
             opts->mapping.host_gid = getegid();
+        }
+    }
+
+    /* get the --max-threads=n option */
+    {
+        const char* optarg;
+
+        if (cli_getopt(argc, argv, "--max-threads", &optarg) == 0)
+        {
+            char* end = NULL;
+            max_threads = strtoul(optarg, &end, 10);
+
+            if (!end || *end)
+                _err("bad --max-threads argument: %s", optarg);
+
+            if (max_threads > ENCLAVE_MAX_THREADS)
+            {
+                _err(
+                    "--max-threads must be <= %u: %s",
+                    ENCLAVE_MAX_THREADS,
+                    optarg);
+            }
         }
     }
 }

--- a/tools/myst/host/mkext2/mkext2.c
+++ b/tools/myst/host/mkext2/mkext2.c
@@ -368,7 +368,7 @@ static void _append_hash_tree(
         image);
 
     if ((n = myst_ascii_to_bin(buf, root_hash->data, sizeof(*root_hash))) < 0)
-        _err("malformed root hash: %s", root_hash);
+        _err("malformed root hash: %s", buf);
 }
 
 static int _sign(
@@ -554,7 +554,7 @@ int mkext2_action(int argc, const char* argv[])
         const size_t min_len = 14;
 
         if (strlen(passphrase) < min_len)
-            _err("--passphrase option length must be >= %u", min_len);
+            _err("--passphrase option length must be >= %zu", min_len);
     }
 
     /* get the --sign option */

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -469,6 +469,7 @@ int _exec_package(
     char* unpack_dir = NULL;
     int ret = -1;
     const char** exec_args = NULL;
+    const size_t max_threads = 0;
 
     /* Get options */
     {
@@ -705,7 +706,7 @@ int _exec_package(
     }
 
     ret = exec_launch_enclave(
-        scratch_path, type, flags, exec_args, envp, &options);
+        scratch_path, type, flags, exec_args, envp, &options, max_threads);
     if (ret != 0)
     {
         fprintf(stderr, "Enclave %s returned %d\n", scratch_path, ret);

--- a/tools/myst/host/utils.h
+++ b/tools/myst/host/utils.h
@@ -13,6 +13,7 @@
 #define DEFAULT_MMAN_SIZE (64 * 1024 * 1024)
 
 // print error and exit process with 1
+MYST_PRINTF_FORMAT(1, 2)
 void _err(const char* fmt, ...);
 
 // sets the program file name of the process

--- a/tools/myst/shared.h
+++ b/tools/myst/shared.h
@@ -8,6 +8,8 @@
 #include <myst/options.h>
 #include <myst/regions.h>
 
+#define ENCLAVE_MAX_THREADS MYST_MAX_KSTACKS
+
 int myst_expand_size_string_to_ulong(const char* size_string, size_t* size);
 bool myst_merge_mount_mapping_and_config(
     myst_mounts_config_t* mounts,

--- a/utils/file.c
+++ b/utils/file.c
@@ -101,7 +101,7 @@ done:
     return ret;
 }
 
-int myst_copy_file_fd(char* oldpath, int newfd)
+int myst_copy_file_fd(const char* oldpath, int newfd)
 {
     int ret = 0;
     int oldfd = -1;


### PR DESCRIPTION
Add ``--max threads`` option to speed up the LTP tests (cutting the total execution time in half).