### PR TITLE
Fix the build cache for third_party/musl/crt

### DIFF
--- a/third_party/musl/crt/Makefile
+++ b/third_party/musl/crt/Makefile
@@ -7,7 +7,13 @@ URL=git://git.musl-libc.org/musl
 BRANCH=v1.2.0
 
 # get the hash of the remote github repository (for the given branch)
-HASH=$(shell git ls-remote $(URL) -b $(BRANCH) | cut -f1 )
+HASH1=$(shell git ls-remote $(URL) -b $(BRANCH) | cut -f1 )
+
+# get the hash of the patch.diff file
+HASH2=$(shell sha256sum patch.diff | cut -d' ' -f 1)
+
+# get the composite hash (github repository and patch.diff file)
+HASH=$(shell echo "$(HASH1)$(HASH2)" | sha256sum - | cut -d' ' -f 1)
 
 CACHE_DIR=$(HOME)/.mystikos/cache/musl/crt
 


### PR DESCRIPTION
This PR fixes the build cache to measure ``third_party/musl/crt/patch.diff`` (in addition to the github repository branch hash) when computing the cache directory name.

This has no effect unless ``MYST_USE_BUILD_CACHE`` is defined in the user's environement.