### PR TITLE
Forward hardware exceptions as signals to kernel

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -159,7 +159,7 @@ typedef struct myst_kernel_args
     long (*myst_syscall)(long n, long params[6]);
 
     /* pointer to myst_handle_host_signal(). Set by myst_enter_kernel */
-    long (*myst_handle_host_signal)(unsigned signo, mcontext_t* context);
+    long (*myst_handle_host_signal)(siginfo_t* siginfo, mcontext_t* context);
 
 } myst_kernel_args_t;
 

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -5,10 +5,10 @@
 #define _MYST_KERNEL_H
 
 #include <limits.h>
-
 #include <myst/kstack.h>
 #include <myst/tcall.h>
 #include <myst/types.h>
+#include <signal.h>
 
 typedef struct _myst_host_enc_id_mapping
 {
@@ -157,6 +157,9 @@ typedef struct myst_kernel_args
 
     /* pointer to myst_syscall() that is set by myst_enter_kernel() */
     long (*myst_syscall)(long n, long params[6]);
+
+    /* pointer to myst_handle_host_signal(). Set by myst_enter_kernel */
+    long (*myst_handle_host_signal)(unsigned signo, mcontext_t* context);
 
 } myst_kernel_args_t;
 

--- a/include/myst/signal.h
+++ b/include/myst/signal.h
@@ -33,4 +33,6 @@ long myst_signal_sigpending(sigset_t* set, unsigned size);
 
 long myst_signal_clone(myst_thread_t* parent, myst_thread_t* child);
 
+long myst_handle_host_signal(unsigned signo, mcontext_t* mcontext);
+
 #endif /* _MYST_SIGNAL_H */

--- a/include/myst/signal.h
+++ b/include/myst/signal.h
@@ -33,6 +33,6 @@ long myst_signal_sigpending(sigset_t* set, unsigned size);
 
 long myst_signal_clone(myst_thread_t* parent, myst_thread_t* child);
 
-long myst_handle_host_signal(unsigned signo, mcontext_t* mcontext);
+long myst_handle_host_signal(siginfo_t* siginfo, mcontext_t* mcontext);
 
 #endif /* _MYST_SIGNAL_H */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -572,6 +572,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     /* args->myst_syscall() can be called from enclave exception handlers */
     args->myst_syscall = myst_syscall;
 
+    /* myst_handle_host_signal can be called from enclave exception handlers */
+    args->myst_handle_host_signal = myst_handle_host_signal;
+
     /* Save the aguments */
     __myst_kernel_args = *args;
 

--- a/kernel/mman.c
+++ b/kernel/mman.c
@@ -1575,6 +1575,9 @@ int myst_mman_mprotect(myst_mman_t* mman, void* addr, size_t len, int prot)
     uintptr_t end = 0;
     bool locked = false;
 
+    if (len == 0)
+        return 0;
+
     _mman_lock(mman, &locked);
 
     _mman_clear_err(mman);
@@ -1595,14 +1598,6 @@ int myst_mman_mprotect(myst_mman_t* mman, void* addr, size_t len, int prot)
     {
         _mman_set_err(
             mman, "bad addr parameter: must be multiple of page size");
-        ret = -EINVAL;
-        goto done;
-    }
-
-    /* len must be non-zero */
-    if (len == 0)
-    {
-        _mman_set_err(mman, "invalid len parameter: must be non-zero");
         ret = -EINVAL;
         goto done;
     }

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -309,10 +309,7 @@ done:
     return ret;
 }
 
-long myst_handle_host_signal(unsigned signum, mcontext_t* mcontext)
+long myst_handle_host_signal(siginfo_t* siginfo, mcontext_t* mcontext)
 {
-    siginfo_t siginfo = {0};
-    siginfo.si_code = SI_KERNEL;
-    siginfo.si_signo = signum;
-    return _handle_one_signal(signum, &siginfo, mcontext);
+    return _handle_one_signal(siginfo->si_signo, siginfo, mcontext);
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -106,7 +106,7 @@ DIRS += devfs
 DIRS += callonce
 DIRS += syscall_exception
 DIRS += mutex
-#DIRS += mprotect
+DIRS += mprotect
 DIRS += eventfd
 DIRS += polleventfd
 

--- a/tests/mprotect/Makefile
+++ b/tests/mprotect/Makefile
@@ -15,8 +15,7 @@ rootfs: main.c
 	$(MYST) mkcpio $(APPDIR) rootfs
 
 tests: rootfs
-	$(RUNTEST) ./exec.sh $(MYST_EXEC) rootfs /bin/mprotect_test $(OPTS)
-	@ echo "=== passed test (mprotect)"
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/mprotect_test $(OPTS)
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/mprotect/exec.sh
+++ b/tests/mprotect/exec.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-$* > stdout.txt
-grep -v OE_ENCLAVE_ABORTING stdout.txt | diff - expected
-if [ "$?" != "0" ]; then
-    exit 1
-fi

--- a/tests/mprotect/expected
+++ b/tests/mprotect/expected
@@ -1,3 +1,0 @@
-R/W/X PAGES: all pages readable as expected
-R/W/X PAGES: all pages writable as expected
-R/O PAGES: all pages readable as expected

--- a/tests/mprotect/main.c
+++ b/tests/mprotect/main.c
@@ -68,9 +68,9 @@ int main(int argc, const char* argv[])
         printf("Error - mprotect() didn't reject invalid addr\n");
         assert(0);
     }
-    if (!mprotect(addr, 0, PROT_READ | PROT_WRITE))
+    if (mprotect(addr, 0, PROT_READ | PROT_WRITE))
     {
-        printf("Error - mprotect() didn't reject invalid length\n");
+        printf("Error - mprotect() didn't take 0 length\n");
         assert(0);
     }
     for (size_t i = 0; i < length; i++)
@@ -103,11 +103,14 @@ int main(int argc, const char* argv[])
         assert(0 && "Error - sigaction failed unexpectedly\n");
     }
 
-    /* Don't crash thanks to the lenient segv handler. */
-    data = addr[0];
-    assert(_segv_handled == 1);
-    printf("mprotect and sigsegv handling successful\n");
-
+    const char* target = getenv("MYST_TARGET");
+    if (target && strcmp(target, "linux") != 0)
+    {
+        /* Don't crash thanks to the lenient segv handler. */
+        data = addr[0];
+        assert(_segv_handled == 1);
+        printf("mprotect and sigsegv handling successful\n");
+    }
     printf("\n=== passed test (%s)\n", argv[0]);
     return 0;
 }

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#define _GNU_SOURCE
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>
@@ -28,6 +29,7 @@
 #include <myst/tcall.h>
 #include <myst/thread.h>
 #include <myst/trace.h>
+#include <signal.h>
 
 #include "../config.h"
 #include "../kargs.h"
@@ -40,12 +42,94 @@
 #define IRETFRAME_Rsp IRETFRAME_EFlags + 8
 
 static myst_kernel_args_t _kargs;
+static mcontext_t _mcontext;
 
 extern const void* __oe_get_heap_base(void);
 
 long _exception_handler_syscall(long n, long params[6])
 {
     return (*_kargs.myst_syscall)(n, params);
+}
+
+static void _oe_context_to_mcontext(oe_context_t* oe_context, mcontext_t* mc)
+{
+    memset(mc, 0, sizeof(mcontext_t));
+    mc->gregs[REG_R8] = (int64_t)(oe_context->r8);
+    mc->gregs[REG_R9] = (int64_t)(oe_context->r9);
+    mc->gregs[REG_R10] = (int64_t)(oe_context->r10);
+    mc->gregs[REG_R11] = (int64_t)(oe_context->r11);
+    mc->gregs[REG_R12] = (int64_t)(oe_context->r12);
+    mc->gregs[REG_R13] = (int64_t)(oe_context->r13);
+    mc->gregs[REG_R14] = (int64_t)(oe_context->r14);
+    mc->gregs[REG_R15] = (int64_t)(oe_context->r15);
+
+    mc->gregs[REG_RSI] = (int64_t)(oe_context->rsi);
+    mc->gregs[REG_RDI] = (int64_t)(oe_context->rdi);
+    mc->gregs[REG_RBP] = (int64_t)(oe_context->rbp);
+    mc->gregs[REG_RSP] = (int64_t)(oe_context->rsp);
+    mc->gregs[REG_RIP] = (int64_t)(oe_context->rip);
+
+    mc->gregs[REG_RAX] = (int64_t)(oe_context->rax);
+    mc->gregs[REG_RBX] = (int64_t)(oe_context->rbx);
+    mc->gregs[REG_RCX] = (int64_t)(oe_context->rcx);
+    mc->gregs[REG_RDX] = (int64_t)(oe_context->rdx);
+
+    mc->gregs[REG_EFL] = (int64_t)(oe_context->flags);
+}
+
+static void _mcontext_to_oe_context(mcontext_t* mc, oe_context_t* oe_context)
+{
+    oe_context->r8 = (uint64_t)(mc->gregs[REG_R8]);
+    oe_context->r9 = (uint64_t)(mc->gregs[REG_R9]);
+    oe_context->r10 = (uint64_t)(mc->gregs[REG_R10]);
+    oe_context->r11 = (uint64_t)(mc->gregs[REG_R11]);
+    oe_context->r12 = (uint64_t)(mc->gregs[REG_R12]);
+    oe_context->r13 = (uint64_t)(mc->gregs[REG_R13]);
+    oe_context->r14 = (uint64_t)(mc->gregs[REG_R14]);
+    oe_context->r15 = (uint64_t)(mc->gregs[REG_R15]);
+
+    oe_context->rsi = (uint64_t)(mc->gregs[REG_RSI]);
+    oe_context->rdi = (uint64_t)(mc->gregs[REG_RDI]);
+    oe_context->rbp = (uint64_t)(mc->gregs[REG_RBP]);
+    oe_context->rsp = (uint64_t)(mc->gregs[REG_RSP]);
+    oe_context->rip = (uint64_t)(mc->gregs[REG_RIP]);
+
+    oe_context->rax = (uint64_t)(mc->gregs[REG_RAX]);
+    oe_context->rbx = (uint64_t)(mc->gregs[REG_RBX]);
+    oe_context->rcx = (uint64_t)(mc->gregs[REG_RCX]);
+    oe_context->rdx = (uint64_t)(mc->gregs[REG_RDX]);
+
+    oe_context->flags = (uint64_t)(mc->gregs[REG_EFL]);
+}
+
+static uint64_t _forward_exception_as_signal_to_kernel(
+    uint32_t oe_exception_code,
+    oe_context_t* oe_context)
+{
+    _oe_context_to_mcontext(oe_context, &_mcontext);
+
+    // Kernel should be the ultimate handler of #PF, #MF, and #UD.
+    // If we are still alive after kernel handling, it means kernel
+    // wanted the execution to continue.
+    if (oe_exception_code == OE_EXCEPTION_ILLEGAL_INSTRUCTION)
+    {
+        (*_kargs.myst_handle_host_signal)(SIGILL, &_mcontext);
+        _mcontext_to_oe_context(&_mcontext, oe_context);
+        return OE_EXCEPTION_CONTINUE_EXECUTION;
+    }
+    if (oe_exception_code == OE_EXCEPTION_PAGE_FAULT)
+    {
+        (*_kargs.myst_handle_host_signal)(SIGSEGV, &_mcontext);
+        _mcontext_to_oe_context(&_mcontext, oe_context);
+        return OE_EXCEPTION_CONTINUE_EXECUTION;
+    }
+    if (oe_exception_code == OE_EXCEPTION_X87_FLOAT_POINT)
+    {
+        (*_kargs.myst_handle_host_signal)(SIGFPE, &_mcontext);
+        _mcontext_to_oe_context(&_mcontext, oe_context);
+        return OE_EXCEPTION_CONTINUE_EXECUTION;
+    }
+    return OE_EXCEPTION_CONTINUE_SEARCH;
 }
 
 extern volatile const oe_sgx_enclave_properties_t oe_enclave_properties_sgx;
@@ -171,7 +255,7 @@ static uint64_t _vectored_handler(oe_exception_record_t* er)
         }
     }
 
-    return OE_EXCEPTION_CONTINUE_SEARCH;
+    return _forward_exception_as_signal_to_kernel(er->code, er->context);
 }
 
 static bool _is_allowed_env_variable(


### PR DESCRIPTION
Signed-off-by: Xuejun Yang <xuejya@microsoft.com>

This PR translate relevant hardware exceptions into signals and forward them from enclave to the kernel. If the user application has registered a handler, the kernel would further forward the signal to the custom handler.

With the forwarding, I have re-enabled tests/mprotect by providing a lenient handler that won't crash on SIGSEGV.