### PR TITLE
fix mmap bug

### DIFF
--- a/kernel/mman.c
+++ b/kernel/mman.c
@@ -687,7 +687,10 @@ static int _mmap(
     }
 
     if (!_mman_is_sane(mman))
+    {
+        ret = -EINVAL;
         goto done;
+    }
 
     /* ADDR must be page aligned */
     if (addr && (uintptr_t)addr % PAGE_SIZE)
@@ -797,6 +800,12 @@ static int _mmap(
             goto done;
         }
 
+        if (!addr)
+        {
+            ret = -ENOMEM;
+            goto done;
+        }
+
         *ptr_out = addr;
         goto done;
     }
@@ -854,7 +863,16 @@ static int _mmap(
     }
 
     if (!_mman_is_sane(mman))
+    {
+        ret = -EINVAL;
         goto done;
+    }
+
+    if (!start)
+    {
+        ret = -ENOMEM;
+        goto done;
+    }
 
     *ptr_out = (void*)start;
 

--- a/kernel/mman.c
+++ b/kernel/mman.c
@@ -800,12 +800,6 @@ static int _mmap(
             goto done;
         }
 
-        if (!addr)
-        {
-            ret = -ENOMEM;
-            goto done;
-        }
-
         *ptr_out = addr;
         goto done;
     }
@@ -1516,6 +1510,7 @@ int myst_mman_mremap(
             {
                 _mman_set_err(mman, "mapping failed");
                 ret = -ENOMEM;
+                goto done;
             }
             /* If no W permission, set W permission first before copy */
             if (!(vad->prot & MYST_PROT_WRITE))


### PR DESCRIPTION
This fixes a bug in ``mman.c`` where ``memcpy`` copies onto a null buffer. There was a missing ``goto done`` but there were a couple of other places that did not set errors.