### PR TITLE
Fix the bugs in CPUID instr. exception handler and in SYS_sched_getaffinity handler

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -4537,8 +4537,8 @@ static long _syscall(void* args_)
             // for now, make all threads fixed to cpu 0.
             if (mask != NULL)
             {
-                CPU_ZERO(mask);
-                CPU_SET(0, mask);
+                CPU_ZERO_S(cpusetsize, mask);
+                CPU_SET_S(0, cpusetsize, mask);
             }
 
             BREAK(_return(n, cpusetsize));

--- a/tests/cpuid/cpuid.c
+++ b/tests/cpuid/cpuid.c
@@ -5,10 +5,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
-void test_cpuid()
+void test_cpuid(uint32_t leaf, uint32_t subleaf)
 {
-    const uint32_t leaf = 0xC0000000;
-    const uint32_t subleaf = 0;
     uint32_t rax = 0;
     uint32_t rbx = 0;
     uint32_t rcx = 0;
@@ -16,14 +14,34 @@ void test_cpuid()
 
     __cpuid_count(leaf, subleaf, rax, rbx, rcx, rdx);
 
-#if 0
-    printf("rax=%x rbx=%x rcx=%x rdx=%x\n", rax, rbx, rcx, rdx);
-#endif
+    printf(
+        "cpuid(%x, %x): rax=%x rbx=%x rcx=%x rdx=%x\n",
+        leaf,
+        subleaf,
+        rax,
+        rbx,
+        rcx,
+        rdx);
 }
 
 int main(int argc, const char* argv[])
 {
-    test_cpuid();
+    test_cpuid(0, 0);
+    test_cpuid(0x80000001, 0);
+    test_cpuid(1, 0x121);
+    test_cpuid(7, 0);
+    test_cpuid(1, 0);
+    test_cpuid(0, 0);
+    test_cpuid(11, 0);
+    test_cpuid(11, 1);
+    test_cpuid(4, 0);
+    test_cpuid(4, 1);
+    test_cpuid(4, 2);
+    test_cpuid(4, 3);
+    test_cpuid(4, 4);
+    test_cpuid(0x80000000, 0);
+    test_cpuid(2, 4167054552);
+    test_cpuid(1979933441, 0);
 
     printf("=== passed test (%s)\n", argv[0]);
 

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -116,6 +116,9 @@ static uint64_t _vectored_handler(oe_exception_record_t* er)
                 er->context->rcx = rcx;
                 er->context->rdx = rdx;
 
+                /* Skip over the illegal instruction. */
+                er->context->rip += 2;
+
                 return OE_EXCEPTION_CONTINUE_EXECUTION;
                 break;
             }


### PR DESCRIPTION
The CPUID instruction exception handler missed the required RIP advancement. The RAX, RBX, RCX, RDX value returned to the calling code are corrupted in many cases. The fix is simple, just advancing the RIP by 2 to resume execution on the instruction after the cpuid instruction. The test case under tests/cpuid is enhanced to query a handful of CPUID leaves. It can be further enhanced in the future.

The bug in SYS_sched_getaffinity erroneously over-writes the buffer provided. The fix corrects the implementation by honoring the  buffer size info in `cpusetsize`.