### PR TITLE
Exclude openmp from code coverage pipeline

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -59,7 +59,6 @@ DIRS += tlscert
 DIRS += tlscert2
 DIRS += wake_and_kill
 DIRS += cross_fs_symlinks
-DIRS += openmp
 
 ifndef MYST_SKIP_LTP_TESTS
 DIRS += ltp
@@ -97,6 +96,7 @@ DIRS += clock
 DIRS += pollpipe2
 DIRS += dotnet-proc-maps
 DIRS += dotnet-ubuntu
+DIRS += openmp
 endif
 
 DIRS += msync


### PR DESCRIPTION
Signed-off-by: Xuejun Yang <xuejya@microsoft.com>