### PR TITLE
python_webserver/client synchronization

### DIFF
--- a/solutions/aspnet/Makefile
+++ b/solutions/aspnet/Makefile
@@ -12,17 +12,16 @@ OPTS += --memory-size=1024m
 
 all: appdir private.pem
 
+TIMEOUT=120s
+
 run: appdir private.pem
 	# Kill the server from a previous run if it wasn't shut down properly.
 	test -f server.pid && kill -9 `cat server.pid` || true
 	$(MYST) package appdir private.pem config.json
-	myst/bin/$(APPNAME) $(OPTS) & echo $$! > server.pid
-	sleep 60
-	# Request 3 times from the client to make sure the server is robust.
-	curl 127.0.0.1:5050
-	curl 127.0.0.1:5050
-	curl 127.0.0.1:5050
+	myst/bin/$(APPNAME) $(OPTS) > server.output & echo $$! > server.pid
+	timeout $(TIMEOUT) tail -f server.output | ./client.sh
 	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
+	test -f client.output
 
 # run the server in the foreground:
 server:
@@ -66,4 +65,4 @@ private.pem:
 
 clean:
 	test -f server.pid && kill -9 `cat server.pid` || true
-	sudo rm -fr appdir rootfs build obj bin myst private.pem server.pid
+	sudo rm -fr appdir rootfs build obj bin myst private.pem server.pid server.output client.output

--- a/solutions/python_webserver/Makefile
+++ b/solutions/python_webserver/Makefile
@@ -17,13 +17,15 @@ rootfs: appdir
 appdir:
 	$(APPBUILDER) Dockerfile
 
+TIMEOUT=60s
+
 run:
 	test -f server.pid && kill -9 `cat server.pid` || true
-	$(MYST_EXEC) $(OPTS) rootfs /usr/local/bin/python3 /app/hello_server.py & echo $$! > server.pid
-	sleep 20
-	curl 127.0.0.1:8000
+	$(MYST_EXEC) $(OPTS) rootfs /usr/local/bin/python3 /app/hello_server.py > server.output & echo $$! > server.pid
+	timeout $(TIMEOUT) tail -f server.output | ./client.sh
 	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
+	test -f client.output
 
 clean:
 	test -f server.pid && kill -9 `cat server.pid` || true
-	rm -rf rootfs appdir server.pid
+	rm -rf rootfs appdir server.output server.pid client.output

--- a/solutions/python_webserver/client.sh
+++ b/solutions/python_webserver/client.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+rm -f client.output
+
+# wait for the server to launch and then run client command
+while read -r line; do
+  echo $line
+  if echo $line | grep -q 'launching server...'; then
+    curl 127.0.0.1:8000
+    touch client.output
+    exit 0
+  fi
+done

--- a/solutions/python_webserver/client.sh
+++ b/solutions/python_webserver/client.sh
@@ -5,7 +5,7 @@ rm -f client.output
 while read -r line; do
   echo $line
   if echo $line | grep -q 'launching server...'; then
-    curl 127.0.0.1:8000
+    curl 127.0.0.1:8000 || exit 1
     touch client.output
     exit 0
   fi


### PR DESCRIPTION
This PR modifies the ``python_webserver`` solution to run the client as soon as "launching server..." is seen by the the ``client.sh`` script.

The client times out after 60 seconds (not needed in success case).