### PR TITLE
Patch musl with missing glibc symbols

### DIFF
--- a/crt/glibc_stub.c
+++ b/crt/glibc_stub.c
@@ -10,6 +10,8 @@
 #define weak_alias(old, new) \
     extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
 
+#define ENOMEM 12
+
 __thread int errno;
 
 const char* const sys_errlist[] = {};
@@ -34,7 +36,7 @@ typedef struct __mbstate_t
 size_t __mbrlen(const char* s, size_t n, mbstate_t* ps)
 {
     assert(0);
-    return 0;
+    return -1;
 }
 weak_alias(__mbrlen, mbrlen);
 
@@ -56,7 +58,7 @@ void _obstack_newchunk(struct obstack* h, int length)
 int __argz_create_sep(const char* string, int delim, char** argz, size_t* len)
 {
     assert(0);
-    return 0;
+    return ENOMEM;
 }
 weak_alias(__argz_create_sep, argz_create_sep);
 
@@ -83,7 +85,7 @@ char* clnt_spcreateerror(const char* msg)
 int __libc_mallopt(int param_number, int value)
 {
     assert(0);
-    return -1;
+    return 0;
 }
 weak_alias(__libc_mallopt, mallopt);
 
@@ -144,7 +146,7 @@ typedef struct XDR
 int xdr_enum(XDR* xdrs, int* ep)
 {
     assert(0);
-    return -1;
+    return false;
 }
 
 typedef int (*xdrproc_t)(XDR*, void*, ...);
@@ -220,5 +222,5 @@ void __explicit_bzero_chk(void* __dest, size_t __len, size_t __destlen)
 int __libc_alloca_cutoff(size_t size)
 {
     assert(0);
-    return -1;
+    return false;
 }

--- a/crt/glibc_stub.c
+++ b/crt/glibc_stub.c
@@ -1,0 +1,224 @@
+#include <assert.h>
+#include <bits/alltypes.h>
+#include <resolv.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ucontext.h>
+
+#define weak_alias(old, new) \
+    extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
+
+__thread int errno;
+
+const char* const sys_errlist[] = {};
+const int sys_nerr = 0;
+
+void __makecontext(ucontext_t* ucp, void (*func)(void), int argc, ...)
+{
+    assert(0);
+}
+weak_alias(__makecontext, makecontext);
+
+int setcontext(const ucontext_t* ucp)
+{
+    assert(0);
+    return -1;
+}
+
+typedef struct __mbstate_t
+{
+    unsigned __opaque1, __opaque2;
+} mbstate_t;
+size_t __mbrlen(const char* s, size_t n, mbstate_t* ps)
+{
+    assert(0);
+    return 0;
+}
+weak_alias(__mbrlen, mbrlen);
+
+int __openat_2(int fd, const char* file, int oflag)
+{
+    assert(0);
+    return -1;
+}
+
+struct obstack
+{
+};
+
+void _obstack_newchunk(struct obstack* h, int length)
+{
+    assert(0);
+}
+
+int __argz_create_sep(const char* string, int delim, char** argz, size_t* len)
+{
+    assert(0);
+    return 0;
+}
+weak_alias(__argz_create_sep, argz_create_sep);
+
+struct CLIENT
+{
+};
+
+struct CLIENT* clnt_create(
+    const char* hostname,
+    unsigned long prog,
+    unsigned long vers,
+    const char* proto)
+{
+    assert(0);
+    return NULL;
+}
+
+char* clnt_spcreateerror(const char* msg)
+{
+    assert(0);
+    return NULL;
+}
+
+int __libc_mallopt(int param_number, int value)
+{
+    assert(0);
+    return -1;
+}
+weak_alias(__libc_mallopt, mallopt);
+
+int _IO_obstack_vprintf(
+    struct obstack* obstack,
+    const char* format,
+    va_list args)
+{
+    assert(0);
+    return -1;
+}
+weak_alias(_IO_obstack_vprintf, obstack_vprintf);
+
+int __register_printf_modifier(const wchar_t* str)
+{
+    assert(0);
+    return -1;
+}
+weak_alias(__register_printf_modifier, register_printf_modifier);
+
+struct printf_info
+{
+};
+
+typedef int printf_function(
+    FILE* __stream,
+    const struct printf_info* __info,
+    const void* const* __args);
+
+typedef int printf_arginfo_size_function(
+    const struct printf_info* __info,
+    size_t __n,
+    int* __argtypes,
+    int* __size);
+
+int __register_printf_specifier(
+    int spec,
+    printf_function converter,
+    printf_arginfo_size_function arginfo)
+{
+    assert(0);
+    return -1;
+}
+weak_alias(__register_printf_specifier, register_printf_specifier);
+
+typedef void printf_va_arg_function(void* __mem, va_list* __ap);
+int __register_printf_type(printf_va_arg_function fct)
+{
+    assert(0);
+    return -1;
+}
+weak_alias(__register_printf_type, register_printf_type);
+
+typedef struct XDR
+{
+} XDR;
+
+int xdr_enum(XDR* xdrs, int* ep)
+{
+    assert(0);
+    return -1;
+}
+
+typedef int (*xdrproc_t)(XDR*, void*, ...);
+
+int xdr_pointer(
+    XDR* xdrs,
+    char** objpp,
+    unsigned int obj_size,
+    xdrproc_t xdr_obj)
+{
+    assert(0);
+    return -1;
+}
+
+int xdr_string(XDR* xdrs, char** cpp, unsigned int maxsize)
+{
+    assert(0);
+    return -1;
+}
+
+void __res_iclose(res_state statp, bool free_addr)
+{
+    assert(0);
+}
+
+struct resolv_context
+{
+};
+
+struct resolv_context* __resolv_context_get_preinit(void)
+{
+    assert(0);
+    return NULL;
+}
+
+struct resolv_context* __resolv_context_get_override(struct __res_state* resp)
+{
+    assert(0);
+    return NULL;
+}
+
+struct resolv_context* __resolv_context_get(void)
+{
+    assert(0);
+    return NULL;
+}
+
+void __resolv_context_put(struct resolv_context* ctx)
+{
+    assert(0);
+}
+
+char* inet_nsap_ntoa(int binlen, const unsigned char* binary, char* ascii)
+{
+    assert(0);
+    return NULL;
+}
+
+__thread struct __res_state* __resp = NULL;
+
+void* __libc_reallocarray(void* optr, size_t nmemb, size_t elem_size)
+{
+    assert(0);
+    return NULL;
+}
+weak_alias(__libc_reallocarray, reallocarray);
+
+void __explicit_bzero_chk(void* __dest, size_t __len, size_t __destlen)
+{
+    assert(0);
+}
+
+int __libc_alloca_cutoff(size_t size)
+{
+    assert(0);
+    return -1;
+}

--- a/crt/glibc_stub.c
+++ b/crt/glibc_stub.c
@@ -99,46 +99,6 @@ int _IO_obstack_vprintf(
 }
 weak_alias(_IO_obstack_vprintf, obstack_vprintf);
 
-int __register_printf_modifier(const wchar_t* str)
-{
-    assert(0);
-    return -1;
-}
-weak_alias(__register_printf_modifier, register_printf_modifier);
-
-struct printf_info
-{
-};
-
-typedef int printf_function(
-    FILE* __stream,
-    const struct printf_info* __info,
-    const void* const* __args);
-
-typedef int printf_arginfo_size_function(
-    const struct printf_info* __info,
-    size_t __n,
-    int* __argtypes,
-    int* __size);
-
-int __register_printf_specifier(
-    int spec,
-    printf_function converter,
-    printf_arginfo_size_function arginfo)
-{
-    assert(0);
-    return -1;
-}
-weak_alias(__register_printf_specifier, register_printf_specifier);
-
-typedef void printf_va_arg_function(void* __mem, va_list* __ap);
-int __register_printf_type(printf_va_arg_function fct)
-{
-    assert(0);
-    return -1;
-}
-weak_alias(__register_printf_type, register_printf_type);
-
 typedef struct XDR
 {
 } XDR;
@@ -222,5 +182,6 @@ void __explicit_bzero_chk(void* __dest, size_t __len, size_t __destlen)
 int __libc_alloca_cutoff(size_t size)
 {
     assert(0);
+    abort();
     return false;
 }

--- a/solutions/Makefile
+++ b/solutions/Makefile
@@ -14,6 +14,7 @@ endif
 
 DIRS += msgpack_c
 DIRS += python_webserver
+DIRS += python_app
 
 ifndef MYST_ENABLE_GCOV
 DIRS += dotnet

--- a/solutions/python_app/Dockerfile
+++ b/solutions/python_app/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+
+RUN apt update && apt install -y curl gnupg2 &&\
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - &&\
+    curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list &&\
+    apt update && \
+    apt install -y wget &&\
+    ACCEPT_EULA=Y apt install -y msodbcsql17 &&\
+    wget -q https://repo.continuum.io/miniconda/Miniconda3-py38_4.8.2-Linux-x86_64.sh &&\
+    chmod 755 Miniconda3-py38_4.8.2-Linux-x86_64.sh &&\
+    ./Miniconda3-py38_4.8.2-Linux-x86_64.sh -b -p /miniconda &&\
+    /miniconda/bin/pip install numpy logzero &&\
+    /miniconda/bin/conda install -y -c miniconda pyodbc pandas pycrypto pycurl pyjwt &&\
+    /miniconda/bin/python3 --version
+
+WORKDIR /app
+COPY ./app.py .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["/miniconda/bin/python3", "/app/app.py"]

--- a/solutions/python_app/Makefile
+++ b/solutions/python_app/Makefile
@@ -1,0 +1,26 @@
+TOP = $(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+APPNAME=python3
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+all: myst/bin/$(APPNAME)
+
+appdir:
+	$(APPBUILDER) Dockerfile
+
+myst/bin/$(APPNAME): appdir private.pem
+	$(MYST) package appdir private.pem config.json
+
+run: myst/bin/$(APPNAME)
+	myst/bin/$(APPNAME) $(OPTS)
+
+private.pem:
+	openssl genrsa -out private.pem -3 3072
+
+clean:
+	rm -rf rootfs appdir myst private.pem

--- a/solutions/python_app/app.py
+++ b/solutions/python_app/app.py
@@ -1,0 +1,78 @@
+import pyodbc
+import jwt
+import os
+import numpy as np
+import pandas as pd
+import pycurl
+from logzero import logger
+from Crypto.Cipher import AES
+
+def test_pyodbc(server: str, database: str, driver: str, query: str):
+    connstr = "Driver=" + driver
+    connstr += ";Server=" + server
+    connstr += ";Database=" + database
+    connstr += ";Authentication=ActiveDirectoryMsi"
+
+    conn = pyodbc.connect(connstr)
+
+    logger.info("Successful connected to database")
+
+    cursor = conn.cursor()
+    cursor.execute(query)
+    row = cursor.fetchone()
+    print(row)
+
+def test_pandas():
+    dates = pd.date_range("20210101", periods=6)
+    df = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list("ABCD"))
+    print(df)
+
+    df2 = pd.DataFrame(np.random.randn(10, 4))
+    print(df2)
+    logger.info("test_pandas passed")
+
+def test_pycrypto():
+    key = AES.new('This is a key123', AES.MODE_CBC, 'This is an IV456')
+    message = "abcdefghijklmnop"
+    ciphertext = key.encrypt(message)
+    print(ciphertext)
+
+    cleartext = key.decrypt(ciphertext)
+    print(cleartext)
+    logger.info("test_pycrypto passed")
+
+def test_pycurl():
+    with open('pycurl.html', 'wb') as f:
+        c = pycurl.Curl()
+        c.setopt(c.URL, 'http://pycurl.io/')
+        c.setopt(c.WRITEDATA, f)
+        c.perform()
+        c.close()
+    f = open('pycurl.html', 'r')
+    print(f.read(100))
+    logger.info("test_pycurl passed")
+
+def test_jwt():
+    key = "secret"
+    encoded = jwt.encode({"some": "payload"}, key, algorithm="HS256")
+    print(encoded)
+
+    clear = jwt.decode(encoded, key, algorithms="HS256")
+    print(clear)
+    logger.info("test_jwt passed")
+
+if __name__ == "__main__":
+
+    test_pyodbc(
+        server=os.getenv("DB_SERVER_NAME"),
+        database=os.getenv("DB_NAME"),
+        driver="{ODBC Driver 17 for SQL Server}",
+        query="SELECT USER_NAME()")
+
+    test_pandas()
+
+    test_pycrypto()
+
+    test_pycurl()
+
+    test_jwt()

--- a/solutions/python_app/config.json
+++ b/solutions/python_app/config.json
@@ -1,0 +1,23 @@
+{
+    // OpenEnclave specific values
+
+    // Whether we are running myst+OE+app in debug mode
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+
+    // The heap size of the user application. Increase this setting if your app experienced OOM.
+    "MemorySize": "2g",
+    // The path to the entry point application in rootfs
+    "ApplicationPath": "/miniconda/bin/python3",
+    // The parameters to the entry point application
+    "ApplicationParameters": ["/app/app.py"],
+    // Whether we allow "ApplicationParameters" to be overridden by command line options of "myst exec"
+    "HostApplicationParameters": false,
+    // The environment variables accessible inside the enclave.
+    "EnvironmentVariables": [""],
+    // The environment variables we get from the host
+    "HostEnvironmentVariables": ["DB_SERVER_NAME", "DB_NAME", "MAA_ENDPOINT"]
+}

--- a/solutions/python_webserver/Dockerfile
+++ b/solutions/python_webserver/Dockerfile
@@ -1,22 +1,18 @@
 FROM ubuntu:18.04
 
-# Build Python from source. The packaged Python executable is non-PIE.
+# Install Python with miniconda. The Ubuntu Python package is non-PIE.
 # See issue https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1452115
 RUN apt update && \
-    apt install -y git build-essential libssl-dev libffi-dev zlib1g-dev  &&\
-    rm -rf /var/lib/apt/lists/* &&\
-    git clone https://github.com/python/cpython.git --branch 3.6 &&\
-    cd cpython &&\
-    ./configure && make -j 4 && make install &&\
-    cd .. && rm -rf cpython &&\
-    apt remove -y git build-essential libffi-dev zlib1g-dev &&\
-    apt -y autoremove &&\
-    pip3 install numpy &&\
-    python3 --version
+    apt install -y wget &&\
+    wget -q https://repo.continuum.io/miniconda/Miniconda3-py38_4.8.2-Linux-x86_64.sh &&\
+    chmod 755 Miniconda3-py38_4.8.2-Linux-x86_64.sh &&\
+    ./Miniconda3-py38_4.8.2-Linux-x86_64.sh -b -p /miniconda &&\
+    /miniconda/bin/pip install numpy &&\
+    /miniconda/bin/python3 --version
 
 WORKDIR /app
 COPY ./hello_server.py .
 
 ENV PYTHONUNBUFFERED=1
 
-CMD ["python3", "/app/hello_server.py"]
+CMD ["/miniconda/bin/python3", "/app/hello_server.py"]

--- a/solutions/python_webserver/Makefile
+++ b/solutions/python_webserver/Makefile
@@ -21,7 +21,7 @@ TIMEOUT=60s
 
 run:
 	test -f server.pid && kill -9 `cat server.pid` || true
-	$(MYST_EXEC) $(OPTS) rootfs /usr/local/bin/python3 /app/hello_server.py > server.output & echo $$! > server.pid
+	$(MYST_EXEC) $(OPTS) rootfs /miniconda/bin/python3 /app/hello_server.py > server.output & echo $$! > server.pid
 	timeout $(TIMEOUT) tail -f server.output | ./client.sh
 	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
 	test -f client.output

--- a/third_party/musl/crt/Makefile
+++ b/third_party/musl/crt/Makefile
@@ -82,6 +82,8 @@ NEWFILES =
 NEWFILES += src/internal/__popcountdi2.c
 NEWFILES += src/stdio/__fprintf_chk.c
 NEWFILES += src/stdio/__vfprintf_chk.c
+NEWFILES += src/unistd/preadv2.c
+NEWFILES += src/unistd/pwritev2.c
 
 musl:
 	mkdir -p $(BUILDDIR)

--- a/third_party/musl/crt/Makefile
+++ b/third_party/musl/crt/Makefile
@@ -84,6 +84,7 @@ NEWFILES += src/stdio/__fprintf_chk.c
 NEWFILES += src/stdio/__vfprintf_chk.c
 NEWFILES += src/unistd/preadv2.c
 NEWFILES += src/unistd/pwritev2.c
+NEWFILES += src/stdio/register_printf.c
 
 musl:
 	mkdir -p $(BUILDDIR)

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -306,6 +306,15 @@ index afec985a..5435b9b5 100644
  	return p;
  }
  
+diff --git a/src/fcntl/open.c b/src/fcntl/open.c
+index 1d817a2d..a36ba05e 100644
+--- a/src/fcntl/open.c
++++ b/src/fcntl/open.c
+@@ -21,3 +21,4 @@ int open(const char *filename, int flags, ...)
+ }
+ 
+ weak_alias(open, open64);
++weak_alias(open, __open_nocancel);
 diff --git a/src/fenv/feupdateenv.c b/src/fenv/feupdateenv.c
 index 50cef8e5..803a7f8d 100644
 --- a/src/fenv/feupdateenv.c
@@ -339,12 +348,31 @@ index 7167d3e1..9deca8e7 100644
  hidden int __pthread_rwlock_rdlock(pthread_rwlock_t *);
  hidden int __pthread_rwlock_tryrdlock(pthread_rwlock_t *);
  hidden int __pthread_rwlock_timedrdlock(pthread_rwlock_t *__restrict, const struct timespec *__restrict);
+diff --git a/src/include/string.h b/src/include/string.h
+index 2133b5c1..cfa2044d 100644
+--- a/src/include/string.h
++++ b/src/include/string.h
+@@ -4,8 +4,8 @@
+ #include "../../include/string.h"
+ 
+ hidden void *__memrchr(const void *, int, size_t);
+-hidden char *__stpcpy(char *, const char *);
+-hidden char *__stpncpy(char *, const char *, size_t);
++char *__stpcpy(char *, const char *);
++char *__stpncpy(char *, const char *, size_t);
+ hidden char *__strchrnul(const char *, int);
+ 
+ #endif
 diff --git a/src/include/time.h b/src/include/time.h
-index cbabde47..4f94bc39 100644
+index cbabde47..60c64312 100644
 --- a/src/include/time.h
 +++ b/src/include/time.h
-@@ -10,6 +10,6 @@ hidden char *__asctime_r(const struct tm *, char *);
- hidden struct tm *__gmtime_r(const time_t *restrict, struct tm *restrict);
+@@ -7,9 +7,9 @@ hidden int __clock_gettime(clockid_t, struct timespec *);
+ hidden int __clock_nanosleep(clockid_t, int, const struct timespec *, struct timespec *);
+ 
+ hidden char *__asctime_r(const struct tm *, char *);
+-hidden struct tm *__gmtime_r(const time_t *restrict, struct tm *restrict);
++struct tm *__gmtime_r(const time_t *restrict, struct tm *restrict);
  hidden struct tm *__localtime_r(const time_t *restrict, struct tm *restrict);
  
 -hidden size_t __strftime_l(char *restrict, size_t, const char *restrict, const struct tm *restrict, locale_t);
@@ -499,6 +527,26 @@ index 6f3ef656..614121c3 100644
 +
 +    return myst_syscall(n, params);
 +}
+diff --git a/src/network/h_errno.c b/src/network/h_errno.c
+index 4f700cea..4306ade2 100644
+--- a/src/network/h_errno.c
++++ b/src/network/h_errno.c
+@@ -1,9 +1,9 @@
+ #include <netdb.h>
+ 
+-#undef h_errno
+-int h_errno;
+-
++#undef __h_errno
++int __h_errno;
++ 
+ int *__h_errno_location(void)
+ {
+-	return &h_errno;
+-}
++	return &__h_errno;
++}
+\ No newline at end of file
 diff --git a/src/network/res_init.c b/src/network/res_init.c
 index 5dba9dfc..9b595a19 100644
 --- a/src/network/res_init.c
@@ -510,6 +558,15 @@ index 5dba9dfc..9b595a19 100644
 +
 +weak_alias(res_init, __res_init);
 \ No newline at end of file
+diff --git a/src/network/sendmmsg.c b/src/network/sendmmsg.c
+index eeae1d0a..7e13faa8 100644
+--- a/src/network/sendmmsg.c
++++ b/src/network/sendmmsg.c
+@@ -28,3 +28,4 @@ error:
+ 	return syscall_cp(SYS_sendmmsg, fd, msgvec, vlen, flags);
+ #endif
+ }
++weak_alias (sendmmsg, __sendmmsg);
 diff --git a/src/sched/affinity.c b/src/sched/affinity.c
 index 948ece41..fd7e7801 100644
 --- a/src/sched/affinity.c
@@ -565,6 +622,25 @@ index 948ece41..fd7e7801 100644
 +	return 0;
 +}
 \ No newline at end of file
+diff --git a/src/select/poll.c b/src/select/poll.c
+index c84c8a99..a5f561bd 100644
+--- a/src/select/poll.c
++++ b/src/select/poll.c
+@@ -13,3 +13,4 @@ int poll(struct pollfd *fds, nfds_t n, int timeout)
+ 		.tv_nsec = timeout%1000*1000000 }) : 0, 0, _NSIG/8);
+ #endif
+ }
++weak_alias (poll, __poll);
+diff --git a/src/stdio/snprintf.c b/src/stdio/snprintf.c
+index 771503b2..8a8529b1 100644
+--- a/src/stdio/snprintf.c
++++ b/src/stdio/snprintf.c
+@@ -10,4 +10,4 @@ int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...)
+ 	va_end(ap);
+ 	return ret;
+ }
+-
++weak_alias (snprintf, __snprintf);
 diff --git a/src/thread/__unmapself.c b/src/thread/__unmapself.c
 index 31d94e67..e34cca2e 100644
 --- a/src/thread/__unmapself.c
@@ -956,6 +1032,33 @@ index 4f101716..c6091da5 100644
  __cp_end:
  	ret
  __cp_cancel:
+diff --git a/src/unistd/close.c b/src/unistd/close.c
+index 5b38e019..e80418e6 100644
+--- a/src/unistd/close.c
++++ b/src/unistd/close.c
+@@ -16,3 +16,4 @@ int close(int fd)
+ 	if (r == -EINTR) r = 0;
+ 	return __syscall_ret(r);
+ }
++weak_alias(close, __close_nocancel);
+diff --git a/src/unistd/read.c b/src/unistd/read.c
+index f3589c05..12e46040 100644
+--- a/src/unistd/read.c
++++ b/src/unistd/read.c
+@@ -5,3 +5,4 @@ ssize_t read(int fd, void *buf, size_t count)
+ {
+ 	return syscall_cp(SYS_read, fd, buf, count);
+ }
++weak_alias(read, __read_nocancel);
+diff --git a/src/unistd/write.c b/src/unistd/write.c
+index 8fd5bc5c..38bfbbd8 100644
+--- a/src/unistd/write.c
++++ b/src/unistd/write.c
+@@ -5,3 +5,4 @@ ssize_t write(int fd, const void *buf, size_t count)
+ {
+ 	return syscall_cp(SYS_write, fd, buf, count);
+ }
++weak_alias(write, __write_nocancel);
 diff --git a/src/internal/__popcountdi2.c b/src/internal/__popcountdi2.c
 new file mode 100644
 index 00000000..b4b374a1

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -125,6 +125,23 @@ index 92d5c179..e94deece 100644
  }
  
  #define VDSO_USEFUL
+diff --git a/include/math.h b/include/math.h
+index 14f28ec8..09b5790d 100644
+--- a/include/math.h
++++ b/include/math.h
+@@ -413,10 +413,12 @@ float       lgammaf_r(float, int*);
+ float       j0f(float);
+ float       j1f(float);
+ float       jnf(int, float);
++double      jnl(int n, double x);
+ 
+ float       y0f(float);
+ float       y1f(float);
+ float       ynf(int, float);
++double      ynl(int n, double x);
+ #endif
+ 
+ #ifdef _GNU_SOURCE
 diff --git a/include/pthread.h b/include/pthread.h
 index 984db680..9adecf2b 100644
 --- a/include/pthread.h
@@ -472,6 +489,24 @@ index deff5b10..fd66b82a 100644
  	return epoll_create1(0);
  }
  
+diff --git a/src/math/jnf.c b/src/math/jnf.c
+index f63c062f..50311758 100644
+--- a/src/math/jnf.c
++++ b/src/math/jnf.c
+@@ -200,3 +200,13 @@ float ynf(int n, float x)
+ 	}
+ 	return sign ? -b : b;
+ }
++
++double jnl (int n, double x)
++{
++	return (double)jnf(n, x);
++}
++
++double ynl (int n, double x)
++{
++	return (double)yn(n, x);
++}
 diff --git a/src/misc/setrlimit.c b/src/misc/setrlimit.c
 index 7a66ab29..b6a2143b 100644
 --- a/src/misc/setrlimit.c
@@ -1127,6 +1162,208 @@ index 00000000..5493e453
 +    (void)flag;
 +    return vfprintf(stream, format, ap);
 +}
+diff --git a/src/stdio/register_printf.c b/src/stdio/register_printf.c
+new file mode 100644
+index 00000000..d2226f33
+--- /dev/null
++++ b/src/stdio/register_printf.c
+@@ -0,0 +1,196 @@
++#include "stdio_impl.h"
++#include "lock.h"
++#include <errno.h>
++#include <limits.h>
++#include <stdlib.h>
++#include <wchar.h>
++
++#define MAX_VA_ARG_TABLE_SIZE 32
++#define MAX_ARGINFO_TABLE_SIZE 52
++#define MAX_MODIFIER_BIT 32
++#define FIRST_PRINTF_USER_TYPE 8
++
++struct printf_info
++{
++};
++
++struct printf_modifier_record
++{
++    struct printf_modifier_record *next;
++    int bit;
++    wchar_t str[0];
++};
++
++typedef void printf_va_arg_fn(void *mem, va_list *va);
++typedef int printf_arginfo_fn(const struct printf_info *info, size_t n, int *argtypes, int *size);
++typedef int printf_convert_fn(FILE *stream, const struct printf_info *info, const void *const *args);
++
++/* Array of printf_modifier_record lists indexed by the
++   first char of the modifier. */
++static struct printf_modifier_record **_printf_modifier_table = NULL;
++
++/* Array of functions indexed by id.  */
++static printf_va_arg_fn **_printf_va_arg_fn_table = NULL;
++
++/* Array of functions indexed by format character.  */
++static printf_arginfo_fn **_printf_arginfo_fn_table = NULL;
++
++/* Array of functions indexed by format character.  */
++static printf_convert_fn **_printf_convert_fn_table = NULL;
++
++static volatile int lock[1];
++static int _atexit_initialized = 0;
++
++static void _free_printf_tables()
++{
++    free(_printf_va_arg_fn_table);
++    free(_printf_arginfo_fn_table);
++    if (_printf_modifier_table)
++    {
++        for (size_t i=0; i<UCHAR_MAX; i++)
++        {
++            struct printf_modifier_record *tmp = _printf_modifier_table[i];
++            for (; tmp != NULL;)
++            {
++                struct printf_modifier_record *next = tmp->next;
++                free(tmp);
++                tmp = next;
++            }
++        }
++        free(_printf_modifier_table);
++    }
++}
++
++/* Register a printf type with its va_args function */
++int __register_printf_type (printf_va_arg_fn fn)
++{
++    static _Atomic int _next_type = FIRST_PRINTF_USER_TYPE;
++    int result = -1;
++
++    LOCK(lock);
++    if (!_atexit_initialized)
++    {
++        atexit(_free_printf_tables);
++        _atexit_initialized = 1;
++    }
++
++    if (_printf_va_arg_fn_table == NULL)
++    {
++        _printf_va_arg_fn_table = calloc(MAX_VA_ARG_TABLE_SIZE, sizeof(*_printf_va_arg_fn_table));
++        if (_printf_va_arg_fn_table == NULL)
++        {
++            errno = ENOMEM;
++            UNLOCK(lock);
++            return -1;
++        }
++    }
++    UNLOCK(lock);
++
++    if (_next_type == MAX_VA_ARG_TABLE_SIZE + FIRST_PRINTF_USER_TYPE)
++    {
++        errno = ENOSPC;
++        return -1;
++    }
++
++    result = _next_type++;
++    _printf_va_arg_fn_table[result - FIRST_PRINTF_USER_TYPE] = fn;
++
++    return result;
++}
++weak_alias(__register_printf_type, register_printf_type);
++
++/* Register functions to be called to format SPEC specifiers.  */
++int __register_printf_specifier (int spec, printf_convert_fn convert_fn, printf_arginfo_fn arginfo_fn)
++{
++    int index = -1;
++    if (spec >= 'a' && spec <= 'z')
++        index = spec - 'a' + 26;
++    else if (spec >= 'A' && spec <= 'Z')
++        index = spec - 'A';
++    else
++    {
++        errno = EINVAL;
++        return -1;
++    }
++
++    LOCK(lock);
++    if (_printf_arginfo_fn_table == NULL)
++    {
++        _printf_arginfo_fn_table = calloc(MAX_ARGINFO_TABLE_SIZE, sizeof(void*)*2);
++        if (_printf_arginfo_fn_table == NULL)
++        {
++            errno = ENOMEM;
++            goto done;
++        }
++        _printf_convert_fn_table = (printf_convert_fn **)_printf_arginfo_fn_table + MAX_ARGINFO_TABLE_SIZE;
++    }
++    _printf_arginfo_fn_table[index] = arginfo_fn;
++    _printf_convert_fn_table[index] = convert_fn;
++
++done:
++    UNLOCK(lock);
++    return 0;
++}
++weak_alias (__register_printf_specifier, register_printf_specifier);
++
++int __register_printf_modifier (const wchar_t *str)
++{
++    /* Bits to hand out for modifiers.  */
++    static int next_bit = 0;
++
++    if (str[0] == L'\0')
++    {
++        errno = EINVAL;
++        return -1;
++    }
++
++    const wchar_t *wc = str;
++    for (; *wc != L'\0'; ++wc)
++    {
++        if (*wc < 0 || *wc > (wchar_t) UCHAR_MAX)
++        {
++            errno = EINVAL;
++            return -1;
++        }
++    }
++
++    if (next_bit == MAX_MODIFIER_BIT)
++    {
++        errno = ENOSPC;
++        return -1;
++    }
++
++    int result = -1;
++    unsigned char firstchar = (unsigned char)*str;
++    LOCK(lock);
++
++    if (_printf_modifier_table == NULL)
++    {
++        _printf_modifier_table = calloc (UCHAR_MAX, sizeof (*_printf_modifier_table));
++        if (_printf_modifier_table == NULL)
++        {
++            errno = ENOMEM;
++            goto done;
++        }
++    }
++
++    struct printf_modifier_record *newp = malloc (sizeof (*newp) + ((wc - str) * sizeof (wchar_t)));
++    if (newp == NULL)
++    {
++        errno = ENOMEM;
++        goto done;
++    }
++
++    newp->next = _printf_modifier_table[firstchar];
++    newp->bit = 1 << next_bit++;
++    wmemcpy (newp->str, str + 1, wc - str);
++
++    _printf_modifier_table[firstchar] = newp;
++
++    result = newp->bit;
++
++done:
++    UNLOCK(lock);
++    return result;
++}
++weak_alias (__register_printf_modifier, register_printf_modifier);
 diff --git a/src/unistd/preadv2.c b/src/unistd/preadv2.c
 new file mode 100644
 index 00000000..b58c73ab


### PR DESCRIPTION
Signed-off-by: Xuejun Yang <xuejya@microsoft.com>

This PR patches the following missing symbols required by various Python packages and Azure SDK in C++ that were built targeting glibc:

**__mbrlen**
**__openat_2**
**_obstack_newchunk**
**argz_create_sep**
**clnt_create**
**clnt_spcreateerror**
**makecontext**
**mallopt**
**obstack_vprintf**
**register_printf_modifier**
**register_printf_specifier**
**register_printf_type**
**setcontext**
**xdr_enum**
**xdr_pointer**
**xdr_string**
**__res_iclose**
**__resolv_context_get_preinit**
**__resolv_context_get_override**
**__resolv_context_get**
**__resolv_context_put**
**inet_nsap_ntoa**
**reallocarray**
**__resp**
**__explicit_bzero_chk**
**__libc_alloca_cutoff**

For the above symbols, this PR doesn't provide the actual implementation. Any invocation from the user application should trigger assertion failures. But at least now we can launch the application.

sys_errlist
sys_nerr
_poll
__gmtime_r
__sendmmsg
errno
__h_errno
_stpncpy
__open_nocancel
__read_nocancel
__snprintf
__close_nocancel

For the above symbols, this PR provides the actual implementation by aliasing to or unhiding existing MUSL functions. Any invocation from the user application should succeed.