### PR TITLE
Specify user and group mappings for /etc/resolv.conf

### DIFF
--- a/tests/curl/Makefile
+++ b/tests/curl/Makefile
@@ -4,12 +4,19 @@ include $(TOP)/defs.mak
 APPDIR=$(CURDIR)/appdir
 APPBUILDER=$(TOP)/scripts/appbuilder
 
+EFFECTIVE_UID = $(shell id -u)
+EFFECTIVE_GID = $(shell id -g)
+ETC_RESOLV_UID=$(shell stat -L /etc/resolv.conf --format "%u")
+ETC_RESOLV_GID=$(shell stat -L /etc/resolv.conf --format "%g")
+OPTS += --host-to-enc-uid-map $(EFFECTIVE_UID):0,$(ETC_RESOLV_UID):$(ETC_RESOLV_UID)
+OPTS += --host-to-enc-gid-map $(EFFECTIVE_GID):0,$(ETC_RESOLV_GID):$(ETC_RESOLV_GID)
+
 ifdef STRACE
-OPTS = --strace
+OPTS += --strace
 endif
 
 ifdef EXPORT
-OPTS = --export-rootfs
+OPTS += --export-rootfs
 endif
 
 all:


### PR DESCRIPTION
Mounting of /etc/resolv.conf is currently failing due to its host user and group not having a valid mapping inside the enclave. This PR adds the mapping for this file explicitly via the `--host-to-enc-[uid|gid]-map` command line options.

If mappings are not provided explicitly, there is a single default mapping: effective user and group on the host mapped to root user and group inside the enclave. 

On ACC VM's the file backing the /etc/resolv.conf symlink is owned by `systemd-resolv` user.
```
$ ls -l /etc/resolv.conf 
lrwxrwxrwx 1 root root 39 Sep 22  2020 /etc/resolv.conf -> ../run/systemd/resolve/stub-resolv.conf

$ stat -L /etc/resolv.conf
  File: /etc/resolv.conf
...
Access: (0644/-rw-r--r--)  Uid: (  101/systemd-resolve)   Gid: (  103/systemd-resolve)
...
```

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>