### PR TITLE
fix printf-style format mismatches in myst tool

### DIFF
--- a/tools/myst/host/archive.c
+++ b/tools/myst/host/archive.c
@@ -24,7 +24,7 @@ static int _getopt(
     ret = myst_getopt(argc, argv, opt, optarg, err, sizeof(err));
 
     if (ret < 0)
-        _err("%s", err);
+        puterr("%s", err);
 
     return ret;
 }
@@ -49,10 +49,10 @@ void get_archive_options(
         struct stat statbuf;
 
         if (num_pubkeys == max_pubkeys)
-            _err("too many --pubkey options (> %u)", max_pubkeys);
+            puterr("too many --pubkey options (> %zu)", max_pubkeys);
 
         if (stat(pubkey, &statbuf) != 0)
-            _err("no such file for --pubkey options: %s", pubkey);
+            puterr("no such file for --pubkey options: %s", pubkey);
 
         pubkeys[num_pubkeys++] = pubkey;
     }
@@ -62,10 +62,10 @@ void get_archive_options(
         struct stat statbuf;
 
         if (num_roothashes == max_roothashes)
-            _err("too many --roothash options (> %u)", max_roothashes);
+            puterr("too many --roothash options (> %zu)", max_roothashes);
 
         if (stat(roothash, &statbuf) != 0)
-            _err("no such file for --roothash options: %s", roothash);
+            puterr("no such file for --roothash options: %s", roothash);
 
         roothashes[num_roothashes++] = roothash;
     }
@@ -88,10 +88,10 @@ void create_archive(
     int fd;
 
     if (!(dirname = mkdtemp(dir_template)))
-        _err("cannot create temporary directory");
+        puterr("cannot create temporary directory");
 
     if ((fd = mkstemp(filename)) < 0)
-        _err("cannot create temporary file");
+        puterr("cannot create temporary file");
 
     /* create the pubkeys directory */
     {
@@ -99,10 +99,10 @@ void create_archive(
         const int n = sizeof(path);
 
         if (snprintf(path, n, "%s/pubkeys", dirname) >= n)
-            _err("path too long");
+            puterr("path too long");
 
         if (mkdir(path, 0700) != 0)
-            _err("failed to create directory: %s", path);
+            puterr("failed to create directory: %s", path);
 
         /* create <dirname>/pubkeys/<pubkey> files */
         for (size_t i = 0; i < num_pubkeys; i++)
@@ -111,10 +111,10 @@ void create_archive(
             const char* basename = myst_basename(pubkey);
 
             if (snprintf(path, n, "%s/pubkeys/%s", dirname, basename) >= n)
-                _err("path too long");
+                puterr("path too long");
 
             if (myst_copy_file(pubkey, path) != 0)
-                _err("failed to copy %s to %s", pubkey, path);
+                puterr("failed to copy %s to %s", pubkey, path);
         }
     }
 
@@ -124,10 +124,10 @@ void create_archive(
         const int n = sizeof(path);
 
         if (snprintf(path, n, "%s/roothashes", dirname) >= n)
-            _err("path too long");
+            puterr("path too long");
 
         if (mkdir(path, 0700) != 0)
-            _err("failed to create directory: %s", path);
+            puterr("failed to create directory: %s", path);
 
         /* create <dirname>/roothashes/<roothash> files */
         for (size_t i = 0; i < num_roothashes; i++)
@@ -137,20 +137,20 @@ void create_archive(
 
             if (snprintf(path, n, "%s/roothashes/%s", dirname, basename) >= n)
             {
-                _err("path too long");
+                puterr("path too long");
             }
 
             if (myst_copy_file(roothash, path) != 0)
-                _err("failed to copy %s to %s", roothash, path);
+                puterr("failed to copy %s to %s", roothash, path);
         }
     }
 
     /* pack the directory into a CPIO archive */
     if (myst_cpio_pack(dirname, filename) != 0)
-        _err("failed to CPIO archive from %s", dirname);
+        puterr("failed to CPIO archive from %s", dirname);
 
     if (remove_recursive(dirname) != 0)
-        _err("failed to remove directory: %s", dirname);
+        puterr("failed to remove directory: %s", dirname);
 
     myst_strlcpy(archive_path, filename, PATH_MAX);
 }

--- a/tools/myst/host/cpio.c
+++ b/tools/myst/host/cpio.c
@@ -53,7 +53,7 @@ int _mkcpio(int argc, const char* argv[])
 
     if (myst_cpio_pack(directory, cpioarchive) != 0)
     {
-        _err(
+        puterr(
             "failed to create CPIO archive from %s: %s",
             directory,
             cpioarchive);
@@ -78,7 +78,7 @@ int _excpio(int argc, const char* argv[])
 
     if (myst_cpio_unpack(cpioarchive, directory) != 0)
     {
-        _err(
+        puterr(
             "failed to extract CPIO archive to %s: %s", directory, cpioarchive);
         return 1;
     }

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -138,15 +138,15 @@ int exec_launch_enclave(
     r = oe_create_myst_enclave(enc_path, type, flags, NULL, 0, &_enclave);
 
     if (r != OE_OK)
-        _err("failed to load enclave: result=%s", oe_result_str(r));
+        puterr("failed to load enclave: result=%s", oe_result_str(r));
 
     /* Serialize the argv[] strings */
     if (myst_buf_pack_strings(&argv_buf, argv, _count_args(argv)) != 0)
-        _err("failed to serialize argv stings");
+        puterr("failed to serialize argv stings");
 
     /* Serialize the argv[] strings */
     if (myst_buf_pack_strings(&envp_buf, envp, _count_args(envp)) != 0)
-        _err("failed to serialize envp stings");
+        puterr("failed to serialize envp stings");
 
     /* Get clock times right before entering the enclave */
     shm_create_clock(&shared_memory, CLOCK_TICK);
@@ -163,12 +163,12 @@ int exec_launch_enclave(
         envp_buf.size,
         (uint64_t)&_event);
     if (r != OE_OK)
-        _err("failed to enter enclave: result=%s", oe_result_str(r));
+        puterr("failed to enter enclave: result=%s", oe_result_str(r));
 
     /* Terminate the enclave */
     r = oe_terminate_enclave(_enclave);
     if (r != OE_OK)
-        _err("failed to terminate enclave: result=%s", oe_result_str(r));
+        puterr("failed to terminate enclave: result=%s", oe_result_str(r));
 
     shm_free_clock(&shared_memory);
 
@@ -280,7 +280,8 @@ int exec_action(int argc, const char* argv[], const char* envp[])
                 if ((myst_expand_size_string_to_ulong(arg, &heap_size) != 0) ||
                     (myst_round_up(heap_size, PAGE_SIZE, &heap_size) != 0))
                 {
-                    _err("%s <size> -- bad suffix (must be k, m, or g)\n", opt);
+                    puterr(
+                        "%s <size> -- bad suffix (must be k, m, or g)\n", opt);
                 }
             }
         }
@@ -324,7 +325,7 @@ int exec_action(int argc, const char* argv[], const char* envp[])
     if (myst_strlcpy(options.rootfs, rootfs, sizeof(options.rootfs)) >=
         sizeof(options.rootfs))
     {
-        _err("<rootfs> command line argument is too long: %s", rootfs);
+        puterr("<rootfs> command line argument is too long: %s", rootfs);
     }
 
     /* if not a CPIO archive, create a zero-filled file with one page */
@@ -334,12 +335,12 @@ int exec_action(int argc, const char* argv[], const char* envp[])
         uint8_t page[PAGE_SIZE];
 
         if ((fd = mkstemp(rootfs_path)) < 0)
-            _err("failed to create temporary file");
+            puterr("failed to create temporary file");
 
         memset(page, 0, sizeof(page));
 
         if (write(fd, page, sizeof(page)) != sizeof(page))
-            _err("failed to create file");
+            puterr("failed to create file");
 
         close(fd);
         rootfs = rootfs_path;
@@ -352,7 +353,7 @@ int exec_action(int argc, const char* argv[], const char* envp[])
              program, rootfs, archive_path, commandline_config, heap_size)) ==
         NULL)
     {
-        _err("Creating region data failed.");
+        puterr("Creating region data failed.");
     }
 
     unlink(archive_path);

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -133,7 +133,7 @@ static void _get_options(int* argc, const char* argv[], struct options* opts)
                 (myst_round_up(opts->heap_size, PAGE_SIZE, &opts->heap_size) !=
                  0))
             {
-                _err("%s <size> -- bad suffix (must be k, m, or g)\n", opt);
+                puterr("%s <size> -- bad suffix (must be k, m, or g)\n", opt);
             }
         }
     }
@@ -149,8 +149,8 @@ static void _get_options(int* argc, const char* argv[], struct options* opts)
             int ret = sscanf(arg, "%d:%d", &enc_uid, &host_uid);
             if (ret != 2)
             {
-                _err("Failed to parse --enc-to-host-uid-map "
-                     "<enc_uid>:<host_uid>");
+                puterr("Failed to parse --enc-to-host-uid-map "
+                       "<enc_uid>:<host_uid>");
             }
             opts->mapping.enc_uid = enc_uid;
             opts->mapping.host_uid = host_uid;
@@ -169,8 +169,8 @@ static void _get_options(int* argc, const char* argv[], struct options* opts)
             int ret = sscanf(arg, "%d:%d", &enc_gid, &host_gid);
             if (ret != 2)
             {
-                _err("Failed to parse --enc-to-host-gid-map "
-                     "<enc_gid>:<host_gid>");
+                puterr("Failed to parse --enc-to-host-gid-map "
+                       "<enc_gid>:<host_gid>");
             }
             opts->mapping.enc_gid = enc_gid;
             opts->mapping.host_gid = host_gid;
@@ -382,7 +382,7 @@ int exec_linux_action(int argc, const char* argv[], const char* envp[])
     if (myst_strlcpy(opts.rootfs, rootfs_arg, sizeof(opts.rootfs)) >=
         sizeof(opts.rootfs))
     {
-        _err("<rootfs> command line argument is too long: %s", rootfs_arg);
+        puterr("<rootfs> command line argument is too long: %s", rootfs_arg);
     }
 
     /* if not a CPIO archive, create a zero-filled file with one page */
@@ -392,12 +392,12 @@ int exec_linux_action(int argc, const char* argv[], const char* envp[])
         uint8_t page[PAGE_SIZE];
 
         if ((fd = mkstemp(rootfs_path)) < 0)
-            _err("failed to create temporary file");
+            puterr("failed to create temporary file");
 
         memset(page, 0, sizeof(page));
 
         if (write(fd, page, sizeof(page)) != sizeof(page))
-            _err("failed to create file");
+            puterr("failed to create file");
 
         close(fd);
         rootfs_arg = rootfs_path;
@@ -411,13 +411,13 @@ int exec_linux_action(int argc, const char* argv[], const char* envp[])
               opts.app_config_path,
               opts.heap_size)))
     {
-        _err("create_region_details_from_files() failed");
+        puterr("create_region_details_from_files() failed");
     }
 
     /* map the regions onto a flat memory mapping */
     if (map_regions(&mmap_addr, &mmap_length) != 0)
     {
-        _err("map_regions() failed");
+        puterr("map_regions() failed");
     }
 
     unlink(archive_path);
@@ -447,7 +447,7 @@ int exec_linux_action(int argc, const char* argv[], const char* envp[])
             err,
             sizeof(err)) != 0)
     {
-        _err("%s", err);
+        puterr("%s", err);
     }
 
     free_mount_mapping_opts(&opts.mount_mappings);

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -187,12 +187,12 @@ int _package(int argc, const char* argv[])
         const int flags = O_CREAT | O_WRONLY | O_TRUNC;
 
         if ((fd = open(rootfs_file, flags, 0666)) < 0)
-            _err("failed to create temporary file");
+            puterr("failed to create temporary file");
 
         memset(page, 0, sizeof(page));
 
         if (write(fd, page, sizeof(page)) != sizeof(page))
-            _err("failed to create file: %s", rootfs_file);
+            puterr("failed to create file: %s", rootfs_file);
 
         close(fd);
     }

--- a/tools/myst/host/regions.c
+++ b/tools/myst/host/regions.c
@@ -46,7 +46,7 @@ const region_details* create_region_details_from_package(
             sizeof(_details.enc.path),
             "%s/lib/openenclave/mystenc.so",
             dir) >= sizeof(_details.enc.path))
-        _err("buffer overflow when forming mystenc.so path");
+        puterr("buffer overflow when forming mystenc.so path");
 
     // Load CRT
     if (elf_image_from_section(
@@ -56,7 +56,7 @@ const region_details* create_region_details_from_package(
             (const void**)&_details.crt.buffer,
             &_details.crt.buffer_size) != 0)
     {
-        _err("failed to extract CRT section from : %s", get_program_file());
+        puterr("failed to extract CRT section from : %s", get_program_file());
     }
     _details.crt.status = REGION_ITEM_BORROWED;
 
@@ -68,7 +68,8 @@ const region_details* create_region_details_from_package(
             (const void**)&_details.kernel.buffer,
             &_details.kernel.buffer_size) != 0)
     {
-        _err("failed to extract kernel section from : %s", get_program_file());
+        puterr(
+            "failed to extract kernel section from : %s", get_program_file());
     }
     _details.kernel.status = REGION_ITEM_BORROWED;
 
@@ -79,7 +80,7 @@ const region_details* create_region_details_from_package(
             (unsigned char**)&_details.rootfs.buffer,
             &_details.rootfs.buffer_size) != 0)
     {
-        _err("Failed to extract rootfs from %s.", get_program_file());
+        puterr("Failed to extract rootfs from %s.", get_program_file());
     }
     _details.rootfs.status = REGION_ITEM_BORROWED;
 
@@ -90,7 +91,7 @@ const region_details* create_region_details_from_package(
             (unsigned char**)&_details.archive.buffer,
             &_details.archive.buffer_size) != 0)
     {
-        _err("Failed to extract archive from %s.", get_program_file());
+        puterr("Failed to extract archive from %s.", get_program_file());
     }
     _details.archive.status = REGION_ITEM_BORROWED;
 
@@ -113,11 +114,11 @@ const region_details* create_region_details_from_package(
                 free_config(&parsed_data);
             }
             else
-                _err("Failed to parse config we extracted from enclave");
+                puterr("Failed to parse config we extracted from enclave");
         }
     }
     else
-        _err("Failed to extract config data from %s.", get_program_file());
+        puterr("Failed to extract config data from %s.", get_program_file());
 
     _details.config.status = REGION_ITEM_BORROWED;
 
@@ -145,7 +146,7 @@ const region_details* create_region_details_from_files(
             rootfs_path,
             &_details.rootfs.buffer,
             &_details.rootfs.buffer_size) != 0)
-        _err("failed to load rootfs: %s", rootfs_path);
+        puterr("failed to load rootfs: %s", rootfs_path);
     _details.rootfs.status = REGION_ITEM_OWNED;
 
     /* load archive file */
@@ -155,7 +156,7 @@ const region_details* create_region_details_from_files(
                 (void**)&_details.archive.buffer,
                 &_details.archive.buffer_size) != 0)
         {
-            _err("failed to load archive: %s", archive_path);
+            puterr("failed to load archive: %s", archive_path);
         }
 
         _details.archive.status = REGION_ITEM_OWNED;
@@ -163,7 +164,7 @@ const region_details* create_region_details_from_files(
 
     if (program_path[0] != '/')
     {
-        _err(
+        puterr(
             "program must be an absolute path within the rootfs: %s",
             program_path);
     }
@@ -171,33 +172,33 @@ const region_details* create_region_details_from_files(
     /* Find mystenc.so, libmystcrt.so, and libmystkernel.so */
     {
         if (format_mystenc(_details.enc.path, sizeof(_details.enc.path)) != 0)
-            _err("buffer overflow when forming mystenc.so path");
+            puterr("buffer overflow when forming mystenc.so path");
 
         if (format_libmystcrt(_details.crt.path, sizeof(_details.crt.path)) !=
             0)
-            _err("buffer overflow when forming libmystcrt.so path");
+            puterr("buffer overflow when forming libmystcrt.so path");
 
         if (format_libmystkernel(
                 _details.kernel.path, sizeof(_details.kernel.path)) != 0)
-            _err("buffer overflow when forming libmystcrt.so path");
+            puterr("buffer overflow when forming libmystcrt.so path");
 
         if (access(_details.enc.path, R_OK) != 0)
-            _err("cannot find: %s", _details.enc.path);
+            puterr("cannot find: %s", _details.enc.path);
 
         if (access(_details.crt.path, R_OK) != 0)
-            _err("cannot find: %s", _details.crt.path);
+            puterr("cannot find: %s", _details.crt.path);
 
         if (access(_details.kernel.path, R_OK) != 0)
-            _err("cannot find: %s", _details.kernel.path);
+            puterr("cannot find: %s", _details.kernel.path);
     }
 
     /* Load the C runtime and kernel ELF image into memory */
     if (elf_image_load(_details.crt.path, &_details.crt.image) != 0)
-        _err("failed to load C runtime image: %s", _details.crt.path);
+        puterr("failed to load C runtime image: %s", _details.crt.path);
     _details.crt.status = REGION_ITEM_OWNED;
 
     if (elf_image_load(_details.kernel.path, &_details.kernel.image) != 0)
-        _err("failed to load kernel image: %s", _details.kernel.path);
+        puterr("failed to load kernel image: %s", _details.kernel.path);
     _details.kernel.status = REGION_ITEM_OWNED;
 
     // We need to prioritize enclave resident config before falling back. That
@@ -206,7 +207,7 @@ const region_details* create_region_details_from_files(
     elf_t enc_elf = {0};
 
     if (elf_load(_details.enc.path, &enc_elf) != 0)
-        _err("failed to load enclave image: %s", _details.enc.path);
+        puterr("failed to load enclave image: %s", _details.enc.path);
 
     unsigned char* temp_buf;
     size_t temp_size;
@@ -216,7 +217,7 @@ const region_details* create_region_details_from_files(
         // the enclave image
         _details.config.buffer = malloc(temp_size);
         if (_details.config.buffer == NULL)
-            _err("out of memory");
+            puterr("out of memory");
         memcpy(_details.config.buffer, temp_buf, temp_size);
         _details.config.buffer_size = temp_size;
         _details.config.status = REGION_ITEM_OWNED;
@@ -233,7 +234,7 @@ const region_details* create_region_details_from_files(
         }
         else
         {
-            _err("Failed to parse configuration stored in enclave");
+            puterr("Failed to parse configuration stored in enclave");
         }
     }
     else if (config_path)
@@ -259,13 +260,13 @@ const region_details* create_region_details_from_files(
             }
             else
             {
-                _err(
+                puterr(
                     "Failed to parse config from specified config path %s",
                     config_path);
             }
         }
         else
-            _err("failed to load config: %s", config_path);
+            puterr("failed to load config: %s", config_path);
         _details.config.status = REGION_ITEM_OWNED;
     }
 
@@ -812,52 +813,52 @@ int add_regions(void* arg, uint64_t baseaddr, myst_add_page_t add_page)
     uint64_t vaddr = 0;
 
     if (myst_region_init(add_page, arg, &context) != 0)
-        _err("myst_region_init() failed");
+        puterr("myst_region_init() failed");
 
     if (_add_kernel_stacks_region(context, baseaddr, &vaddr) != 0)
-        _err("_add_kernel_stacks_region() failed");
+        puterr("_add_kernel_stacks_region() failed");
 
     if (_add_kernel_region(context, baseaddr, &vaddr) != 0)
-        _err("_add_kernel_region() failed");
+        puterr("_add_kernel_region() failed");
 
     if (_add_kernel_reloc_region(context, &vaddr) != 0)
-        _err("_add_kernel_reloc_region() failed");
+        puterr("_add_kernel_reloc_region() failed");
 
     if (_add_kernel_symtab_region(context, &vaddr) != 0)
-        _err("_add_kernel_symtab_region() failed");
+        puterr("_add_kernel_symtab_region() failed");
 
     if (_add_kernel_dynsym_region(context, &vaddr) != 0)
-        _err("_add_kernel_dynsym_region() failed");
+        puterr("_add_kernel_dynsym_region() failed");
 
     if (_add_kernel_strtab_region(context, &vaddr) != 0)
-        _err("_add_kernel_strtab_region() failed");
+        puterr("_add_kernel_strtab_region() failed");
 
     if (_add_kernel_dynstr_region(context, &vaddr) != 0)
-        _err("_add_kernel_dynstr_region() failed");
+        puterr("_add_kernel_dynstr_region() failed");
 
     if (_add_crt_region(context, &vaddr) != 0)
-        _err("_add_crt_region() failed");
+        puterr("_add_crt_region() failed");
 
     if (_add_crt_reloc_region(context, &vaddr) != 0)
-        _err("_add_crt_reloc_region() failed");
+        puterr("_add_crt_reloc_region() failed");
 
     if (_add_rootfs_region(context, &vaddr) != 0)
-        _err("_add_rootfs_region() failed");
+        puterr("_add_rootfs_region() failed");
 
     if (_add_archive_region(context, &vaddr) != 0)
-        _err("_add_archive_region() failed");
+        puterr("_add_archive_region() failed");
 
     if (_add_mman_region(context, &vaddr) != 0)
-        _err("_add_mman_region() failed");
+        puterr("_add_mman_region() failed");
 
     if (_add_config_region(context, &vaddr) != 0)
-        _err("_add_config_region() failed");
+        puterr("_add_config_region() failed");
 
     if (_add_kernel_entry_stack_region(context, baseaddr, &vaddr) != 0)
-        _err("_add_kernel_entry_stack_region() failed");
+        puterr("_add_kernel_entry_stack_region() failed");
 
     if (myst_region_release(context) != 0)
-        _err("myst_region_release() failed");
+        puterr("myst_region_release() failed");
 
     return 0;
 }

--- a/tools/myst/host/regions_linux.c
+++ b/tools/myst/host/regions_linux.c
@@ -23,7 +23,7 @@ static int _add_page(void* arg_, uint64_t vaddr, const void* page, int flags)
     struct arg* arg = (struct arg*)arg_;
 
     if (vaddr < arg->vaddr)
-        _err("_add_page() failed");
+        puterr("_add_page() failed");
 
     if (arg->baseaddr != 0)
     {
@@ -33,7 +33,7 @@ static int _add_page(void* arg_, uint64_t vaddr, const void* page, int flags)
         memcpy(addr, page, PAGE_SIZE);
 
         if (mprotect(addr, PAGE_SIZE, prot) != 0)
-            _err("failed to protect memory region");
+            puterr("failed to protect memory region");
     }
 
     arg->vaddr = vaddr + PAGE_SIZE;
@@ -80,7 +80,7 @@ int map_regions(void** addr_out, size_t* length_out)
         int flags = MAP_ANONYMOUS | MAP_PRIVATE;
 
         if ((addr = mmap(NULL, length, prot, flags, -1, 0)) == MAP_FAILED)
-            _err("failed to map %zu bytes of memory", length);
+            puterr("failed to map %zu bytes of memory", length);
     }
 
     /* map the regions onto the memory mapping */
@@ -96,7 +96,7 @@ int map_regions(void** addr_out, size_t* length_out)
         }
 
         if (arg.vaddr != length)
-            _err("unexpected mismatch in memory mapping");
+            puterr("unexpected mismatch in memory mapping");
     }
 
     *addr_out = addr;

--- a/tools/myst/host/regions_sgx.c
+++ b/tools/myst/host/regions_sgx.c
@@ -28,7 +28,7 @@ static int _add_page(void* arg, uint64_t vaddr, const void* page, int flags)
 
     if (oe_load_extra_enclave_data(arg, vaddr, page, oe_flags, extend) != OE_OK)
     {
-        _err("oe_load_extra_enclave_data() failed: vaddr=%lu", vaddr);
+        puterr("oe_load_extra_enclave_data() failed: vaddr=%lu", vaddr);
         return -EINVAL;
     }
 

--- a/tools/myst/host/sign.c
+++ b/tools/myst/host/sign.c
@@ -75,42 +75,42 @@ int copy_files_to_signing_directory(
     // create bin directory
     if (snprintf(scratch_path, PATH_MAX, "%s/bin", sign_dir) >= PATH_MAX)
     {
-        _err("File path to long: %s/bin", sign_dir);
+        puterr("File path to long: %s/bin", sign_dir);
     }
     if ((mkdir(scratch_path, mode) != 0) && (errno != EEXIST))
     {
-        _err("Failed to create directory \"%s\".", scratch_path);
+        puterr("Failed to create directory \"%s\".", scratch_path);
     }
 
     // create an enclave directory
     if (snprintf(scratch_path, PATH_MAX, "%s/lib", sign_dir) >= PATH_MAX)
     {
-        _err("File path to long: %s/lib", sign_dir);
+        puterr("File path to long: %s/lib", sign_dir);
     }
     if ((mkdir(scratch_path, mode) != 0) && (errno != EEXIST))
     {
-        _err("Failed to create directory \"%s\".", scratch_path);
+        puterr("Failed to create directory \"%s\".", scratch_path);
     }
     // create an enclave directory
     if (snprintf(scratch_path, PATH_MAX, "%s/lib/openenclave", sign_dir) >=
         PATH_MAX)
     {
-        _err("File path to long: %s/lib/openenclave", sign_dir);
+        puterr("File path to long: %s/lib/openenclave", sign_dir);
     }
     if ((mkdir(scratch_path, mode) != 0) && (errno != EEXIST))
     {
-        _err("Failed to create directory \"%s\".", scratch_path);
+        puterr("Failed to create directory \"%s\".", scratch_path);
     }
 
     // Copy crt into signing enc directory
     if (snprintf(scratch_path, PATH_MAX, "%s/lib/libmystcrt.so", sign_dir) >=
         PATH_MAX)
     {
-        _err("File path to long: %s/lib/libmystcrt.so", sign_dir);
+        puterr("File path to long: %s/lib/libmystcrt.so", sign_dir);
     }
     if (myst_copy_file(details->crt.path, scratch_path) != 0)
     {
-        _err(
+        puterr(
             "Failed to copy \"%s\" to \"%s\"", details->crt.path, scratch_path);
     }
 
@@ -118,57 +118,58 @@ int copy_files_to_signing_directory(
     if (snprintf(scratch_path, PATH_MAX, "%s/lib/libmystkernel.so", sign_dir) >=
         PATH_MAX)
     {
-        _err("File path to long: %s/lib/libmystkernel.so", sign_dir);
+        puterr("File path to long: %s/lib/libmystkernel.so", sign_dir);
     }
     if (myst_copy_file(details->kernel.path, scratch_path) != 0)
     {
-        _err(
+        puterr(
             "Failed to copy \"%s\" to \"%s\"", details->crt.path, scratch_path);
     }
 
     // Copy myst tool into signing directory
     if (snprintf(scratch_path, PATH_MAX, "%s/bin/myst", sign_dir) >= PATH_MAX)
     {
-        _err("File path to long: %s/bin/myst", sign_dir);
+        puterr("File path to long: %s/bin/myst", sign_dir);
     }
     if (myst_copy_file(program_file, scratch_path) != 0)
     {
-        _err("Failed to copy \"%s\" to \"%s\"", program_file, scratch_path);
+        puterr("Failed to copy \"%s\" to \"%s\"", program_file, scratch_path);
     }
     if (chmod(scratch_path, mode) != 0)
     {
-        _err("Failed to change executable permissions on \"%s\"", scratch_path);
+        puterr(
+            "Failed to change executable permissions on \"%s\"", scratch_path);
     }
 
     // Copy rootfs into signing directory
     if (snprintf(scratch_path, PATH_MAX, "%s/rootfs", sign_dir) >= PATH_MAX)
     {
-        _err("File path to long: %s/rootfs", sign_dir);
+        puterr("File path to long: %s/rootfs", sign_dir);
     }
     if (myst_copy_file(rootfs_file, scratch_path) != 0)
     {
-        _err("Failed to copy \"%s\" to \"%s\"", rootfs_file, scratch_path);
+        puterr("Failed to copy \"%s\" to \"%s\"", rootfs_file, scratch_path);
     }
 
     // Copy archive into signing directory
     if (snprintf(scratch_path, PATH_MAX, "%s/archive", sign_dir) >= PATH_MAX)
     {
-        _err("File path to long: %s/archive", sign_dir);
+        puterr("File path to long: %s/archive", sign_dir);
     }
     if (myst_copy_file(archive_file, scratch_path) != 0)
     {
-        _err("Failed to copy \"%s\" to \"%s\"", archive_file, scratch_path);
+        puterr("Failed to copy \"%s\" to \"%s\"", archive_file, scratch_path);
     }
 
     // Copy configuration into signing directory
     if (snprintf(scratch_path, PATH_MAX, "%s/config.json", sign_dir) >=
         PATH_MAX)
     {
-        _err("File path to long: %s/config.json", sign_dir);
+        puterr("File path to long: %s/config.json", sign_dir);
     }
     if (myst_copy_file(config_file, scratch_path) != 0)
     {
-        _err("Failed to copy \"%s\" to \"%s\"", config_file, scratch_path);
+        puterr("Failed to copy \"%s\" to \"%s\"", config_file, scratch_path);
     }
 
     // Copy enclave shared library to signing enclave directory
@@ -178,11 +179,11 @@ int copy_files_to_signing_directory(
             "%s/lib/openenclave/mystenc.so",
             sign_dir) >= PATH_MAX)
     {
-        _err("File path to long: %s/lib/openenclave/mystenc.so", sign_dir);
+        puterr("File path to long: %s/lib/openenclave/mystenc.so", sign_dir);
     }
     if (myst_copy_file(details->enc.path, scratch_path) != 0)
     {
-        _err(
+        puterr(
             "Failed to copy \"%s\" to \"%s\"", details->enc.path, scratch_path);
     }
 
@@ -197,7 +198,7 @@ int add_config_to_enclave(const char* sign_dir, const char* config_path)
     size_t config_size;
     if (myst_load_file(config_path, &config_data, &config_size) != 0)
     {
-        _err("Failed to load config file %s", config_path);
+        puterr("Failed to load config file %s", config_path);
     }
 
     if (snprintf(
@@ -206,21 +207,21 @@ int add_config_to_enclave(const char* sign_dir, const char* config_path)
             "%s/lib/openenclave/mystenc.so",
             sign_dir) >= PATH_MAX)
     {
-        _err("File path to long: %s/lib/openenclave/mystenc.so", sign_dir);
+        puterr("File path to long: %s/lib/openenclave/mystenc.so", sign_dir);
     }
 
     if (elf_load(scratch_path, &elf) != 0)
     {
-        _err("Failed to load ELF image %s", scratch_path);
+        puterr("Failed to load ELF image %s", scratch_path);
     }
     if (elf_add_section(
             &elf, ".mystconfig", SHT_PROGBITS, config_data, config_size) != 0)
     {
-        _err("Failed to add configuration to enclave elf image");
+        puterr("Failed to add configuration to enclave elf image");
     }
     if (myst_write_file(scratch_path, elf.data, elf.size) != 0)
     {
-        _err("File to save final signed image: %s", scratch_path);
+        puterr("File to save final signed image: %s", scratch_path);
     }
 
     elf_unload(&elf);
@@ -241,7 +242,7 @@ static int _getopt(
     ret = myst_getopt(argc, argv, opt, optarg, err, sizeof(err));
 
     if (ret < 0)
-        _err("%s", err);
+        puterr("%s", err);
 
     return ret;
 }
@@ -305,7 +306,7 @@ int _sign(int argc, const char* argv[])
     // Load the configuration file and generate oe config file
     if (parse_config_from_file(config_file, &parsed_data) != 0)
     {
-        _err(
+        puterr(
             "Failed to parse configuration file from Mystikos configuration "
             "file %s",
             config_file);
@@ -314,19 +315,19 @@ int _sign(int argc, const char* argv[])
     target = parsed_data.application_path;
     if ((target == NULL) || (target[0] != '/'))
     {
-        _err(
+        puterr(
             "target in config file must be fully qualified path within rootfs");
     }
 
     appname = strrchr(target, '/');
     if (appname == NULL)
     {
-        _err("Failed to get appname from target path");
+        puterr("Failed to get appname from target path");
     }
     appname++;
     if (*appname == '\0')
     {
-        _err("Failed to get appname from target path");
+        puterr("Failed to get appname from target path");
     }
 
     // Do we need to create our own signing directory?
@@ -334,18 +335,18 @@ int _sign(int argc, const char* argv[])
     {
         if (snprintf(sign_dir, PATH_MAX, "%s.signed", appname) >= PATH_MAX)
         {
-            _err("Signing directory path to long: %s.signed", appname);
+            puterr("Signing directory path to long: %s.signed", appname);
         }
         if (mkdir(sign_dir, 0777) != 0)
         {
-            _err("Failed to create signing directory: %s", sign_dir);
+            puterr("Failed to create signing directory: %s", sign_dir);
         }
     }
     else
     {
         if (snprintf(sign_dir, PATH_MAX, "%s", user_sign_dir) >= PATH_MAX)
         {
-            _err("Signing directory path to long: %s", sign_dir);
+            puterr("Signing directory path to long: %s", sign_dir);
         }
     }
 
@@ -353,18 +354,18 @@ int _sign(int argc, const char* argv[])
             temp_oeconfig_file, PATH_MAX, "%s/oeconfig-XXXXXX", sign_dir) >=
         PATH_MAX)
     {
-        _err("OE config file path to long: %s/oeconfig-XXXXXX", sign_dir);
+        puterr("OE config file path to long: %s/oeconfig-XXXXXX", sign_dir);
     }
 
     int fd = mkstemp(temp_oeconfig_file);
     if (fd < 0)
-        _err("Failed to create temporary file for OE configuration");
+        puterr("Failed to create temporary file for OE configuration");
 
     if (write_oe_config_fd(fd, &parsed_data) != 0)
     {
         unlink(temp_oeconfig_file);
         close(fd);
-        _err(
+        puterr(
             "Failed to generate OE configuration file from Mystikos "
             "configuration "
             "file %s",
@@ -388,7 +389,7 @@ int _sign(int argc, const char* argv[])
              parsed_data.heap_pages)) == NULL)
     {
         unlink(temp_oeconfig_file);
-        _err("Creating region data failed.");
+        puterr("Creating region data failed.");
     }
 
     if (copy_files_to_signing_directory(
@@ -400,13 +401,13 @@ int _sign(int argc, const char* argv[])
             details) != 0)
     {
         unlink(temp_oeconfig_file);
-        _err("Failed to copy files to signing directory");
+        puterr("Failed to copy files to signing directory");
     }
 
     if (add_config_to_enclave(sign_dir, config_file) != 0)
     {
         unlink(temp_oeconfig_file);
-        _err("Failed to add configuration to enclave");
+        puterr("Failed to add configuration to enclave");
     }
 
     // Initiate signing with extracted parameters
@@ -418,7 +419,7 @@ int _sign(int argc, const char* argv[])
             sign_dir) >= PATH_MAX)
     {
         unlink(temp_oeconfig_file);
-        _err("File path to long: %s/lib/openenclave/mystenc.so", sign_dir);
+        puterr("File path to long: %s/lib/openenclave/mystenc.so", sign_dir);
     }
 
     if (oesign(
@@ -432,19 +433,19 @@ int _sign(int argc, const char* argv[])
             NULL) != 0)
     {
         unlink(temp_oeconfig_file);
-        _err("Failed to sign \"%s\"", scratch_path);
+        puterr("Failed to sign \"%s\"", scratch_path);
     }
 
     // delete temporary oe config file
     if (unlink(temp_oeconfig_file) != 0)
     {
-        _err("Failed to remove temporary OE config file");
+        puterr("Failed to remove temporary OE config file");
     }
 
     // Delete the unsigned enclave file
     if (unlink(scratch_path) != 0)
     {
-        _err("Failed to delete \"%s\"", scratch_path);
+        puterr("Failed to delete \"%s\"", scratch_path);
     }
 
     if (snprintf(
@@ -453,13 +454,14 @@ int _sign(int argc, const char* argv[])
             "%s/lib/openenclave/mystenc.so.signed",
             sign_dir) >= PATH_MAX)
     {
-        _err(
+        puterr(
             "File path to long: %s/lib/openenclave/mystenc.so.signed",
             sign_dir);
     }
     if (rename(scratch_path2, scratch_path) != 0)
     {
-        _err("Failed to rename \"%s\" to \"%s\"", scratch_path2, scratch_path);
+        puterr(
+            "Failed to rename \"%s\" to \"%s\"", scratch_path2, scratch_path);
     }
 
     return 0;

--- a/tools/myst/host/utils.c
+++ b/tools/myst/host/utils.c
@@ -156,7 +156,7 @@ const int format_libmystkernel(char* path, size_t size)
     return _format_lib(path, size, "lib/libmystkernel.so");
 }
 
-__attribute__((format(printf, 1, 2))) void _err(const char* fmt, ...)
+__attribute__((format(printf, 1, 2))) void puterr(const char* fmt, ...)
 {
     va_list ap;
 
@@ -202,7 +202,7 @@ int cli_getopt(
     ret = myst_getopt(argc, argv, opt, optarg, err, sizeof(err));
 
     if (ret < 0)
-        _err("%s", err);
+        puterr("%s", err);
 
     return ret;
 }
@@ -220,8 +220,8 @@ int cli_get_mapping_opts(
             int ret = sscanf(arg, "%d:%d", &enc_uid, &host_uid);
             if (ret != 2)
             {
-                _err("Failed to parse --enc-to-host-uid-map "
-                     "<enc_uid>:<host_uid>");
+                puterr("Failed to parse --enc-to-host-uid-map "
+                       "<enc_uid>:<host_uid>");
             }
             mappings->enc_uid = enc_uid;
             mappings->host_uid = host_uid;
@@ -240,8 +240,8 @@ int cli_get_mapping_opts(
             int ret = sscanf(arg, "%d:%d", &enc_gid, &host_gid);
             if (ret != 2)
             {
-                _err("Failed to parse --enc-to-host-gid-map "
-                     "<enc_gid>:<host_gid>");
+                puterr("Failed to parse --enc-to-host-gid-map "
+                       "<enc_gid>:<host_gid>");
             }
             mappings->enc_gid = enc_gid;
             mappings->host_gid = host_gid;
@@ -273,7 +273,7 @@ int cli_get_mount_mapping_opts(
             {
                 mappings->mounts = calloc(1, sizeof(char*));
                 if (mappings->mounts == NULL)
-                    _err("Out of memory\n");
+                    puterr("Out of memory\n");
             }
             else
             {
@@ -282,7 +282,7 @@ int cli_get_mount_mapping_opts(
                     mappings->mounts_count + 1,
                     sizeof(char*));
                 if (tmp == NULL)
-                    _err("Out of memory\n");
+                    puterr("Out of memory\n");
                 mappings->mounts = tmp;
             }
             mappings->mounts[mappings->mounts_count] = strdup(arg);

--- a/tools/myst/host/utils.h
+++ b/tools/myst/host/utils.h
@@ -13,7 +13,8 @@
 #define DEFAULT_MMAN_SIZE (64 * 1024 * 1024)
 
 // print error and exit process with 1
-void _err(const char* fmt, ...);
+MYST_PRINTF_FORMAT(1, 2)
+void puterr(const char* fmt, ...);
 
 // sets the program file name of the process
 const char* set_program_file(const char* program);


### PR DESCRIPTION
This PR fixes format errors associated with the ``_err()`` function used in the ``myst`` tool. It also renames the function to ``puterr()``.