### PR TITLE
fix printf-style formatting errors in myst tool

### DIFF
--- a/tools/myst/host/archive.c
+++ b/tools/myst/host/archive.c
@@ -49,7 +49,7 @@ void get_archive_options(
         struct stat statbuf;
 
         if (num_pubkeys == max_pubkeys)
-            _err("too many --pubkey options (> %u)", max_pubkeys);
+            _err("too many --pubkey options (> %zu)", max_pubkeys);
 
         if (stat(pubkey, &statbuf) != 0)
             _err("no such file for --pubkey options: %s", pubkey);
@@ -62,7 +62,7 @@ void get_archive_options(
         struct stat statbuf;
 
         if (num_roothashes == max_roothashes)
-            _err("too many --roothash options (> %u)", max_roothashes);
+            _err("too many --roothash options (> %zu)", max_roothashes);
 
         if (stat(roothash, &statbuf) != 0)
             _err("no such file for --roothash options: %s", roothash);

--- a/tools/myst/host/mkext2/mkext2.c
+++ b/tools/myst/host/mkext2/mkext2.c
@@ -368,7 +368,7 @@ static void _append_hash_tree(
         image);
 
     if ((n = myst_ascii_to_bin(buf, root_hash->data, sizeof(*root_hash))) < 0)
-        _err("malformed root hash: %s", root_hash);
+        _err("malformed root hash: %s", buf);
 }
 
 static int _sign(
@@ -554,7 +554,7 @@ int mkext2_action(int argc, const char* argv[])
         const size_t min_len = 14;
 
         if (strlen(passphrase) < min_len)
-            _err("--passphrase option length must be >= %u", min_len);
+            _err("--passphrase option length must be >= %zu", min_len);
     }
 
     /* get the --sign option */

--- a/tools/myst/host/utils.h
+++ b/tools/myst/host/utils.h
@@ -13,6 +13,7 @@
 #define DEFAULT_MMAN_SIZE (64 * 1024 * 1024)
 
 // print error and exit process with 1
+MYST_PRINTF_FORMAT(1, 2)
 void _err(const char* fmt, ...);
 
 // sets the program file name of the process


### PR DESCRIPTION
This PR fixes printf-style formatting errors with the use of ``_err()`` in the ``myst`` tool.