### PR TITLE
Remove all use of strcpy

### DIFF
--- a/host/regions.c
+++ b/host/regions.c
@@ -5,6 +5,7 @@
 
 #include <myst/eraise.h>
 #include <myst/regions.h>
+#include <myst/strings.h>
 
 #define MAGIC 0xdd131acc5dc846e8
 
@@ -119,7 +120,7 @@ int myst_region_close(
         memset(&trailer, 0, sizeof(trailer));
         trailer.magic = MYST_REGION_MAGIC;
         trailer.index = context->region_index++;
-        strcpy(trailer.name, name);
+        myst_strlcpy(trailer.name, name, sizeof(trailer.name));
         trailer.size = context->vaddr - context->region_start;
 
         ECHECK((*context->add_page)(

--- a/hostfs/hostfs.c
+++ b/hostfs/hostfs.c
@@ -1203,7 +1203,7 @@ int myst_init_hostfs(myst_fs_t** fs_out)
 
     hostfs->magic = HOSTFS_MAGIC;
     hostfs->base = _base;
-    strcpy(hostfs->target, "/");
+    myst_strlcpy(hostfs->target, "/", sizeof(hostfs->target));
 
     *fs_out = &hostfs->base;
     hostfs = NULL;

--- a/json/json.c
+++ b/json/json.c
@@ -779,7 +779,8 @@ json_result_t json_match(json_parser_t* parser, const char* pattern)
         else if (!(ptr = _malloc(parser, pattern_len + 1)))
             RAISE(JSON_OUT_OF_MEMORY);
 
-        strcpy(ptr, pattern);
+        *ptr = '\0';
+        strncat(ptr, pattern, pattern_len);
     }
 
     /* Split the pattern into tokens */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -395,7 +395,7 @@ static int _create_main_thread(
     thread->target_tid = target_tid;
     thread->event = event;
     thread->target_td = myst_get_fsbase();
-    strcpy(thread->name, "main");
+    myst_strlcpy(thread->name, "main", sizeof(thread->name));
 
     thread->uid = MYST_DEFAULT_UID;
     thread->euid = MYST_DEFAULT_UID;

--- a/kernel/libc.c
+++ b/kernel/libc.c
@@ -46,18 +46,6 @@ char* strdup(const char* s)
     return p;
 }
 
-char* strcpy(char* dest, const char* src)
-{
-    char* p = dest;
-
-    while (*src)
-        *p++ = *src++;
-
-    *p = '\0';
-
-    return dest;
-}
-
 char* strncpy(char* dest, const char* src, size_t n)
 {
     size_t i;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -4404,7 +4404,9 @@ static long _syscall(void* args_)
                 if (!arg2)
                     BREAK(_return(n, -EINVAL));
 
-                strcpy(arg2, myst_get_thread_name(myst_thread_self()));
+                // ATTN: Linux requires a 16-byte buffer:
+                const size_t n = 16;
+                myst_strlcpy(arg2, myst_get_thread_name(myst_thread_self()), n);
             }
             else if (option == PR_SET_NAME)
             {

--- a/solutions/sql_ae/app/odbc_helper.c
+++ b/solutions/sql_ae/app/odbc_helper.c
@@ -418,7 +418,8 @@ static int insert_data_to_table(SQLHSTMT stmt)
         0);
     OK_CHECK(
         checkRC(rc, "Binding parameters for insert", stmt, SQL_HANDLE_STMT));
-    strcpy(data, SAMPLE_DATA);
+    *data = '\0';
+    strncat(data, SAMPLE_DATA, sizeof(data) - 1);
     sprintf(buffer, "INSERT INTO %s values (?)", table_name_gen);
     rc = SQLExecDirect(stmt, buffer, SQL_NTS);
     OK_CHECK(checkRC(rc, "Inserting data into table", stmt, SQL_HANDLE_STMT));

--- a/target/shared/crypto.c
+++ b/target/shared/crypto.c
@@ -13,6 +13,7 @@
 #include <myst/crypto.h>
 #include <myst/eraise.h>
 #include <myst/sha256.h>
+#include <myst/strings.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -116,8 +117,10 @@ static int _mbedtls_generate_key_pair(
 
     if (format == MYST_PEM)
     {
-        strcpy((char*)*public_key_out, (const char*)buffer1);
-        strcpy((char*)*private_key_out, (const char*)buffer2);
+        myst_strlcpy(
+            (char*)*public_key_out, (const char*)buffer1, (size_t)len1);
+        myst_strlcpy(
+            (char*)*private_key_out, (const char*)buffer2, (size_t)len2);
     }
     else if (format == MYST_DER)
     {

--- a/tests/elf/main.c
+++ b/tests/elf/main.c
@@ -34,7 +34,8 @@ static char _msg[64];
 static void _callback(const char* msg)
 {
     // printf("=== _callback(): %s\n", msg);
-    strcpy(_msg, msg);
+    *_msg = '\0';
+    strncat(_msg, msg, sizeof(_msg) - 1);
 }
 
 static int _test_image_load(const char* path)

--- a/tests/ext2/plain/ext2.c
+++ b/tests/ext2/plain/ext2.c
@@ -155,7 +155,8 @@ int mock_mount_resolve(
     char suffix[PATH_MAX],
     myst_fs_t** fs_out)
 {
-    strcpy(suffix, path);
+    *suffix = '\0';
+    strncat(suffix, path, PATH_MAX - 1);
     *fs_out = (myst_fs_t*)__ext2;
     return 0;
 }

--- a/tests/sockets/sockets.c
+++ b/tests/sockets/sockets.c
@@ -67,7 +67,8 @@ static void* _srv_thread_func(void* arg)
         struct sockaddr_un addr;
         memset(&addr, 0, sizeof(addr));
         addr.sun_family = AF_UNIX;
-        strcpy(addr.sun_path, args->path);
+        *addr.sun_path = '\0';
+        strncat(addr.sun_path, args->path, sizeof(addr.sun_path) - 1);
 
         struct stat buf;
 
@@ -148,7 +149,8 @@ static void* _cli_thread_func(void* arg)
         struct sockaddr_un addr;
         memset(&addr, 0, sizeof(addr));
         addr.sun_family = AF_UNIX;
-        strcpy(addr.sun_path, args->path);
+        *addr.sun_path = '\0';
+        strncat(addr.sun_path, args->path, sizeof(addr.sun_path) - 1);
         assert(connect(sock, (struct sockaddr*)&addr, sizeof(addr)) >= 0);
     }
     else

--- a/tests/sysinfo/sysinfo.c
+++ b/tests/sysinfo/sysinfo.c
@@ -139,7 +139,8 @@ void test_thread_name()
     assert(prctl(PR_GET_NAME, buf) == 0);
 
     {
-        strcpy(buf, NEWNAME);
+        *buf = '\0';
+        strncat(buf, NEWNAME, sizeof(buf) - 1);
         assert(prctl(PR_SET_NAME, buf) == 0);
 
         char buf2[BUFSIZ];
@@ -150,7 +151,8 @@ void test_thread_name()
 
     // test thread names are atmost 16 bytes, including null byte
     {
-        strcpy(buf, NEWNAMELONG);
+        *buf = '\0';
+        strncat(buf, NEWNAMELONG, sizeof(buf) - 1);
         assert(prctl(PR_SET_NAME, buf) == 0);
 
         char buf2[BUFSIZ];

--- a/tools/myst/host/regions.c
+++ b/tools/myst/host/regions.c
@@ -38,7 +38,7 @@ const region_details* create_region_details_from_package(
 {
     char dir[PATH_MAX];
 
-    strcpy(dir, get_program_file());
+    myst_strlcpy(dir, get_program_file(), sizeof(dir));
     dirname(dir);
 
     if (snprintf(

--- a/tools/myst/host/utils.c
+++ b/tools/myst/host/utils.c
@@ -39,7 +39,7 @@ static int _which(const char* program, char buf[PATH_MAX])
 
         if (access(current, X_OK) == 0)
         {
-            strcpy(buf, current);
+            myst_strlcpy(buf, current, PATH_MAX);
             ret = 0;
             goto done;
         }
@@ -54,7 +54,7 @@ static int _which(const char* program, char buf[PATH_MAX])
         if (!(p = getenv("PATH")) || strlen(p) >= PATH_MAX)
             goto done;
 
-        strcpy(path, p);
+        myst_strlcpy(path, p, sizeof(path));
     }
 
     /* Search the PATH for the program */
@@ -73,7 +73,7 @@ static int _which(const char* program, char buf[PATH_MAX])
 
             if (access(current, X_OK) == 0)
             {
-                strcpy(buf, current);
+                myst_strlcpy(buf, current, PATH_MAX);
                 ret = 0;
                 goto done;
             }


### PR DESCRIPTION
This PR removes all uses of ``strcpy`` from Mystikos code (excluding third-party), replacing each use with ``strncat`` or ``myst_strlcpy``.