### PR TITLE
SOS debugger extension support

### DIFF
--- a/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
@@ -29,7 +29,7 @@ jobs:
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
         sudo apt-get update
-        sudo apt-get install build-essential lcov python3-setuptools python3-pip llvm-7 libmbedtls-dev docker-ce -y 
+        sudo apt-get install build-essential lcov python3-setuptools python3-pip llvm-7 libmbedtls-dev docker-ce lldb-10 -y
         sudo chmod 666 /var/run/docker.sock
         sudo pip3 install lcov_cobertura
       displayName: 'minimum init config'

--- a/.azure_pipelines/ci-pipeline-makefile-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-makefile-nightly.yml
@@ -29,7 +29,7 @@ jobs:
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
         sudo apt-get update
-        sudo apt-get install build-essential python3-setuptools python3-pip llvm-7 libmbedtls-dev docker-ce -y 
+        sudo apt-get install build-essential python3-setuptools python3-pip llvm-7 libmbedtls-dev docker-ce lldb-10 -y
         sudo chmod 666 /var/run/docker.sock
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
         docker system prune -a -f

--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -48,7 +48,7 @@ jobs:
           # remove all untracked files and directories in the git repository
           sudo rm -rf `git ls-files --others --directory`
           make distclean
-          sudo rm -rf third_party/openenclave/openenclave
+          make distclean -C third_party/openenclave/
           make -j
         displayName: 'build repo source'
         workingDirectory: $(Build.SourcesDirectory)

--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -48,7 +48,7 @@ jobs:
           # remove all untracked files and directories in the git repository
           sudo rm -rf `git ls-files --others --directory`
           make distclean
-          make distclean -C third_party/openenclave/
+          sudo rm -rf third_party/openenclave/openenclave
           make -j
         displayName: 'build repo source'
         workingDirectory: $(Build.SourcesDirectory)

--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -39,7 +39,7 @@ jobs:
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
           sudo apt-get update
           while sudo lsof /var/lib/dpkg/lock-frontend | grep dpkg; do sleep 3; done
-          sudo apt-get install build-essential python3-setuptools libmbedtls-dev docker-ce -y 
+          sudo apt-get install build-essential python3-setuptools libmbedtls-dev docker-ce lldb-10 -y
           sudo chmod 666 /var/run/docker.sock
         displayName: 'minimum init config'
 

--- a/.azure_pipelines/ci-pipeline-release.yml
+++ b/.azure_pipelines/ci-pipeline-release.yml
@@ -30,7 +30,7 @@ jobs:
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
           sudo apt-get update
-          sudo apt-get install build-essential python3-setuptools libmbedtls-dev docker-ce -y 
+          sudo apt-get install build-essential python3-setuptools libmbedtls-dev docker-ce lldb-10 -y 
           sudo chmod 666 /var/run/docker.sock
         displayName: 'minimum init config'
 

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -5,11 +5,11 @@
 #define _MYST_KERNEL_H
 
 #include <limits.h>
-#include <signal.h>
 #include <myst/kstack.h>
 #include <myst/tcall.h>
 #include <myst/types.h>
 #include <myst/uid_gid.h>
+#include <signal.h>
 
 /* Information used for a specific automatic mount point that is mounted on
  * start. flags, public_keys and roothash are currently not used, but are
@@ -147,6 +147,9 @@ typedef struct myst_kernel_args
 
     /* true if --memcheck option present */
     bool memcheck;
+
+    /* true if --report-native-tids is present */
+    bool report_native_tids;
 
     // From the --max-affinity-cpus=<num> option. This setting limits the
     // CPUs reported by sched_getaffinity().

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -23,6 +23,7 @@ typedef struct myst_options
     bool export_ramfs;
     bool shell_mode;
     bool memcheck;
+    bool report_native_tids;
     size_t max_affinity_cpus;
     char rootfs[PATH_MAX];
 

--- a/include/myst/strings.h
+++ b/include/myst/strings.h
@@ -46,4 +46,7 @@ int myst_str2int(const char* s, int* x);
 // equal to c or null if not found.
 void* myst_memcchr(const void* b, int c, size_t len);
 
+/* returns -ERANGE if overflow detected, otherwise 0 */
+int myst_snprintf(char* str, size_t size, const char* format, ...);
+
 #endif /* _MYST_STRINGS_H */

--- a/include/myst/tcall.h
+++ b/include/myst/tcall.h
@@ -55,8 +55,8 @@ typedef enum myst_tcall_number
     MYST_TCALL_LOAD_FSSIG,
     MYST_TCALL_CLOCK_GETRES,
     MYST_TCALL_GCOV,
-    MYST_TCALL_CPUINFO_SIZE,
-    MYST_TCALL_GET_CPUINFO,
+    MYST_TCALL_GET_FILE_SIZE,
+    MYST_TCALL_READ_FILE,
 } myst_tcall_number_t;
 
 long myst_tcall(long n, long params[6]);
@@ -159,8 +159,8 @@ int myst_tcall_mprotect(void* addr, size_t len, int prot);
 
 long myst_gcov(const char* func, long params[6]);
 
-int myst_tcall_cpuinfo_size(void);
+int myst_tcall_get_file_size(const char* pathname);
 
-int myst_tcall_get_cpuinfo(char* buf, size_t size);
+int myst_tcall_read_file(const char* pathname, char* buf, size_t size);
 
 #endif /* _MYST_TCALL_H */

--- a/include/myst/tcall.h
+++ b/include/myst/tcall.h
@@ -94,7 +94,8 @@ long myst_tcall_add_symbol_file(
     const void* file_data,
     size_t file_size,
     const void* text_data,
-    size_t text_size);
+    size_t text_size,
+    const char* enclave_rootfs_path);
 
 long myst_tcall_load_symbols(void);
 

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -588,6 +588,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     __options.trace_syscalls = args->trace_syscalls;
     __options.have_syscall_instruction = args->have_syscall_instruction;
     __options.export_ramfs = args->export_ramfs;
+    __options.report_native_tids = args->report_native_tids;
 
 #if !defined(MYST_RELEASE)
     /* enable memcheck if options present and in TEE debug mode */

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -5935,6 +5935,7 @@ long myst_syscall_add_symbol_file(
     params[1] = (long)file_size;
     params[2] = (long)text;
     params[3] = (long)text_size;
+    params[4] = (long)path;
 
     ECHECK(myst_tcall(MYST_TCALL_ADD_SYMBOL_FILE, params));
 

--- a/kernel/tcall.c
+++ b/kernel/tcall.c
@@ -251,14 +251,14 @@ long myst_gcov(const char* func, long gcov_params[6])
 }
 #endif
 
-int myst_tcall_cpuinfo_size(void)
+int myst_tcall_get_file_size(const char* pathname)
 {
-    long params[6] = {0};
-    return myst_tcall(MYST_TCALL_CPUINFO_SIZE, params);
+    long params[6] = {(long)pathname};
+    return myst_tcall(MYST_TCALL_GET_FILE_SIZE, params);
 }
 
-int myst_tcall_get_cpuinfo(char* data, size_t size)
+int myst_tcall_read_file(const char* pathname, char* data, size_t size)
 {
-    long params[6] = {(long)data, (long)size};
-    return myst_tcall(MYST_TCALL_GET_CPUINFO, params);
+    long params[6] = {(long)pathname, (long)data, (long)size};
+    return myst_tcall(MYST_TCALL_READ_FILE, params);
 }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -881,6 +881,8 @@ long myst_syscall_clone(
 
 pid_t myst_gettid(void)
 {
+    if (__options.report_native_tids)
+        return myst_thread_self()->target_tid;
     return myst_thread_self()->tid;
 }
 

--- a/target/linux/Makefile
+++ b/target/linux/Makefile
@@ -16,7 +16,7 @@ SOURCES += ../shared/poll.c
 SOURCES += ../shared/luks.c
 SOURCES += ../shared/sha256.c
 SOURCES += ../shared/verify.c
-SOURCES += ../shared/cpuinfo.c
+SOURCES += ../shared/copyhostfile.c
 
 CFLAGS = $(DEFAULT_CFLAGS)
 

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -111,12 +111,14 @@ long myst_tcall_add_symbol_file(
     const void* file_data,
     size_t file_size,
     const void* text,
-    size_t text_size)
+    size_t text_size,
+    const char* enclave_rootfs_path)
 {
     (void)file_data;
     (void)file_size;
     (void)text;
     (void)text_size;
+    (void)enclave_rootfs_path;
     assert("linux: unimplemented: implement in enclave" == NULL);
     return -ENOTSUP;
 }
@@ -356,8 +358,9 @@ long myst_tcall(long n, long params[6])
             size_t file_size = (size_t)x2;
             const void* text = (const void*)x3;
             size_t text_size = (size_t)x4;
+            const char* enclave_rootfs_path = (const char*)x5;
             return myst_tcall_add_symbol_file(
-                file_data, file_size, text, text_size);
+                file_data, file_size, text, text_size, enclave_rootfs_path);
         }
         case MYST_TCALL_LOAD_SYMBOLS:
         {

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -520,13 +520,13 @@ long myst_tcall(long n, long params[6])
             return myst_gcov(func, gcov_params);
         }
 #endif
-        case MYST_TCALL_CPUINFO_SIZE:
+        case MYST_TCALL_GET_FILE_SIZE:
         {
-            return myst_tcall_cpuinfo_size();
+            return myst_tcall_get_file_size((const char*)x1);
         }
-        case MYST_TCALL_GET_CPUINFO:
+        case MYST_TCALL_READ_FILE:
         {
-            return myst_tcall_get_cpuinfo((void*)x1, (size_t)x2);
+            return myst_tcall_read_file((const char*)x1, (void*)x2, (size_t)x3);
         }
         case SYS_ioctl:
         {

--- a/target/sgx/enclave/Makefile
+++ b/target/sgx/enclave/Makefile
@@ -15,7 +15,7 @@ SOURCES += ../../shared/luks.c
 SOURCES += ../../shared/crypto.c
 SOURCES += ../../shared/sha256.c
 SOURCES += ../../shared/verify.c
-SOURCES += ../../shared/cpuinfo.c
+SOURCES += ../../shared/copyhostfile.c
 
 CFLAGS = $(OEENCLAVE_CFLAGS)
 

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -130,12 +130,14 @@ long myst_tcall_add_symbol_file(
     const void* file_data,
     size_t file_size,
     const void* text,
-    size_t text_size)
+    size_t text_size,
+    const char* enclave_rootfs_path)
 {
     (void)file_data;
     (void)file_size;
     (void)text;
     (void)text_size;
+    (void)enclave_rootfs_path;
     assert("sgx: unimplemented: implement in enclave" == NULL);
     return -ENOTSUP;
 }
@@ -421,8 +423,9 @@ long myst_tcall(long n, long params[6])
             size_t file_size = (size_t)x2;
             const void* text = (const void*)x3;
             size_t text_size = (size_t)x4;
+            const char* enclave_rootfs_path = (const char*)x5;
             return myst_tcall_add_symbol_file(
-                file_data, file_size, text, text_size);
+                file_data, file_size, text, text_size, enclave_rootfs_path);
         }
         case MYST_TCALL_LOAD_SYMBOLS:
         {

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -588,13 +588,13 @@ long myst_tcall(long n, long params[6])
             return myst_gcov(func, gcov_params);
         }
 #endif
-        case MYST_TCALL_CPUINFO_SIZE:
+        case MYST_TCALL_GET_FILE_SIZE:
         {
-            return myst_tcall_cpuinfo_size();
+            return myst_tcall_get_file_size((const char*)x1);
         }
-        case MYST_TCALL_GET_CPUINFO:
+        case MYST_TCALL_READ_FILE:
         {
-            return myst_tcall_get_cpuinfo((void*)x1, (size_t)x2);
+            return myst_tcall_read_file((const char*)x1, (void*)x2, (size_t)x3);
         }
         case SYS_read:
         case SYS_write:

--- a/target/shared/copyhostfile.c
+++ b/target/shared/copyhostfile.c
@@ -6,12 +6,12 @@
 #include <myst/tcall.h>
 #include <string.h>
 
-int myst_tcall_cpuinfo_size()
+int myst_tcall_get_file_size(const char* pathname)
 {
     int fd, nbytes, size = 0;
     char buf[1024];
 
-    fd = open("/proc/cpuinfo", O_RDONLY);
+    fd = open(pathname, O_RDONLY);
     if (fd < 0)
         return errno;
 
@@ -22,9 +22,9 @@ int myst_tcall_cpuinfo_size()
     return size;
 }
 
-int myst_tcall_get_cpuinfo(char* buf, size_t size)
+int myst_tcall_read_file(const char* pathname, char* buf, size_t size)
 {
-    int fd = open("/proc/cpuinfo", O_RDONLY);
+    int fd = open(pathname, O_RDONLY);
 
     if (fd < 0)
         return errno;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -106,6 +106,7 @@ DIRS += mutex
 DIRS += mprotect
 DIRS += eventfd
 DIRS += polleventfd
+DIRS += dotnet-sos
 
 .PHONY: $(DIRS)
 

--- a/tests/dotnet-sos/.gitignore
+++ b/tests/dotnet-sos/.gitignore
@@ -1,3 +1,4 @@
 ext2fs
 roothash
 oelldb
+stdouterr.txt

--- a/tests/dotnet-sos/.gitignore
+++ b/tests/dotnet-sos/.gitignore
@@ -1,0 +1,3 @@
+ext2fs
+roothash
+oelldb

--- a/tests/dotnet-sos/Dockerfile
+++ b/tests/dotnet-sos/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
+WORKDIR /src
+COPY ["hello", "hello/"]
+WORKDIR "/src/hello"
+RUN dotnet build "hello.csproj" -c Debug -r alpine-x64
+

--- a/tests/dotnet-sos/Dockerfile
+++ b/tests/dotnet-sos/Dockerfile
@@ -1,6 +1,10 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["hello", "hello/"]
 WORKDIR "/src/hello"
-RUN dotnet build "hello.csproj" -c Debug -r alpine-x64
+RUN dotnet publish -o /app/build --self-contained true -r linux-x64
 
+FROM mcr.microsoft.com/dotnet/runtime:5.0
+
+WORKDIR /app
+COPY --from=build /app/build .

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -26,13 +26,14 @@ oelldb:
 	git clone --branch working https://github.com/vtikoo/oelldb
 
 dotnet-sos:
-	sudo apt install -y dotnet-sdk-5.0
-	ls $(HOME)/.dotnet/tools/
-	dotnet tool install -g dotnet-sos && $(HOME)/.dotnet/tools/dotnet-sos install || true
+	sudo apt install -y dotnet-sdk-5.0 && \
+	dotnet tool install -g dotnet-sos \
+	&& $(HOME)/.dotnet/tools/dotnet-sos install || true
 
 clean:
 	sudo rm -fr appdir ext2fs rootfs roothash oelldb /tmp/myst*
 	$(HOME)/.dotnet/tools/dotnet-sos uninstall
+	sudo rm -rf ~/.dotnet
 	sudo apt remove -y dotnet-sdk-5.0
 
 tests:

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -41,7 +41,7 @@ run-ext2:
 	/src/hello/bin/Debug/net5.0/alpine-x64/hello.dll
 
 run-ext2-lldb:
-	/mnt/oelldb/oelldb -- $(MYST) exec ext2fs \
+	/mnt/oelldb/oelldb -- $(MYST) exec $(OPTS) ext2fs \
 	--roothash=roothash \
 	--memory-size $(HEAP_SIZE) \
 	/usr/share/dotnet/dotnet \

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -4,48 +4,58 @@ include $(TOP)/defs.mak
 APPBUILDER=$(TOP)/scripts/appbuilder
 HEAP_SIZE="768M"
 
+MYST_LLDB = ./oelldb/oelldb
+
+OPTS = --report-native-tids
+
 ifdef STRACE
 OPTS += --strace
 endif
 
-all: appdir rootfs ext2fs
+all: ext2fs oelldb dotnet-sos
 
 appdir:
-	$(APPBUILDER)
+	$(APPBUILDER) Dockerfile
 
-rootfs:
-	rm -rf appdir/tmp/clr-debug-pipe*
-	$(MYST) mkcpio appdir rootfs
-
-ext2fs:
+ext2fs: appdir
 	rm -rf appdir/tmp/clr-debug-pipe*
 	sudo $(MYST) mkext2 appdir ext2fs
 	$(MYST) fssig --roothash ext2fs > roothash
 
+oelldb:
+	git clone --branch working https://github.com/vtikoo/oelldb
+
+dotnet-sos:
+	sudo apt install -y dotnet-sdk-5.0
+	dotnet tool install -g dotnet-sos && dotnet-sos install
+
 clean:
-	sudo rm -fr appdir ext2fs rootfs roothash /tmp/myst*
+	sudo rm -fr appdir ext2fs rootfs roothash oelldb /tmp/myst*
+	sudo apt remove -y dotnet-sdk-5.0
+
+tests:
+	$(MYST_LLDB) -b \
+	-o "command script import sos_test" \
+	-o "quit" \
+	-- $(MYST) exec $(OPTS) ext2fs \
+	--roothash=roothash \
+	--memory-size $(HEAP_SIZE) \
+	/app/hello
 
 ##################################
 #			dev targets			 #
 ##################################
-run-cpio:
-	$(MYST) exec rootfs \
-	--memory-size $(HEAP_SIZE) \
-	/usr/share/dotnet/dotnet \
-	/src/hello/bin/Debug/net5.0/alpine-x64/hello.dll
-
 run-ext2:
 	$(MYST) exec ext2fs --roothash=roothash \
 	--memory-size $(HEAP_SIZE) \
-	/usr/share/dotnet/dotnet \
-	/src/hello/bin/Debug/net5.0/alpine-x64/hello.dll
+	/app/hello
 
 run-ext2-lldb:
-	/mnt/oelldb/oelldb -- $(MYST) exec $(OPTS) ext2fs \
+	$(MYST_LLDB) -o "command script import ignore_sigill" \
+	-- $(MYST) exec $(OPTS) ext2fs \
 	--roothash=roothash \
 	--memory-size $(HEAP_SIZE) \
-	/usr/share/dotnet/dotnet \
-	/src/hello/bin/Debug/net5.0/alpine-x64/hello.dll
+	/app/hello
 
 ct:
 	sudo rm -fr /tmp/myst*

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -1,0 +1,51 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+HEAP_SIZE="768M"
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+all: appdir rootfs ext2fs
+
+appdir:
+	$(APPBUILDER)
+
+rootfs:
+	rm -rf appdir/tmp/clr-debug-pipe*
+	$(MYST) mkcpio appdir rootfs
+
+ext2fs:
+	rm -rf appdir/tmp/clr-debug-pipe*
+	sudo $(MYST) mkext2 appdir ext2fs
+	$(MYST) fssig --roothash ext2fs > roothash
+
+clean:
+	sudo rm -fr appdir ext2fs rootfs roothash /tmp/myst*
+
+##################################
+#			dev targets			 #
+##################################
+run-cpio:
+	$(MYST) exec rootfs \
+	--memory-size $(HEAP_SIZE) \
+	/usr/share/dotnet/dotnet \
+	/src/hello/bin/Debug/net5.0/alpine-x64/hello.dll
+
+run-ext2:
+	$(MYST) exec ext2fs --roothash=roothash \
+	--memory-size $(HEAP_SIZE) \
+	/usr/share/dotnet/dotnet \
+	/src/hello/bin/Debug/net5.0/alpine-x64/hello.dll
+
+run-ext2-lldb:
+	/mnt/oelldb/oelldb -- $(MYST) exec ext2fs \
+	--roothash=roothash \
+	--memory-size $(HEAP_SIZE) \
+	/usr/share/dotnet/dotnet \
+	/src/hello/bin/Debug/net5.0/alpine-x64/hello.dll
+
+ct:
+	sudo rm -fr /tmp/myst*

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -31,19 +31,14 @@ dotnet-sos:
 	&& $(HOME)/.dotnet/tools/dotnet-sos install || true
 
 clean:
-	sudo rm -fr appdir ext2fs rootfs roothash oelldb /tmp/myst*
-	$(HOME)/.dotnet/tools/dotnet-sos uninstall
-	sudo rm -rf ~/.dotnet
-	sudo apt remove -y dotnet-sdk-5.0
+	sudo rm -fr appdir ext2fs rootfs roothash oelldb stdouterr.txt /tmp/myst*
+	$(HOME)/.dotnet/tools/dotnet-sos uninstall && \
+	sudo rm -rf ~/.dotnet && \
+	sudo apt remove -y dotnet-sdk-5.0 || true
 
 tests:
-	$(MYST_LLDB) -b \
-	-o "command script import sos_test" \
-	-o "quit" \
-	-- $(MYST) exec $(OPTS) ext2fs \
-	--roothash=roothash \
-	--memory-size $(HEAP_SIZE) \
-	/app/hello
+	$(RUNTEST) ./exec.sh $(MYST_LLDB) $(MYST) $(OPTS) $(HEAP_SIZE)
+	@ echo "=== passed test (dotnet-sos)"
 
 ##################################
 #			dev targets			 #

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -27,10 +27,12 @@ oelldb:
 
 dotnet-sos:
 	sudo apt install -y dotnet-sdk-5.0
-	dotnet tool install -g dotnet-sos && dotnet-sos install
+	ls $(HOME)/.dotnet/tools/
+	dotnet tool install -g dotnet-sos && $(HOME)/.dotnet/tools/dotnet-sos install || true
 
 clean:
 	sudo rm -fr appdir ext2fs rootfs roothash oelldb /tmp/myst*
+	$(HOME)/.dotnet/tools/dotnet-sos uninstall
 	sudo apt remove -y dotnet-sdk-5.0
 
 tests:

--- a/tests/dotnet-sos/README.md
+++ b/tests/dotnet-sos/README.md
@@ -1,0 +1,26 @@
+### Debugging managed dotnet code
+
+## Prerequisites
+1. lldb:
+```
+sudo apt install lldb-8
+```
+2. dotnet-sos:
+```
+dotnet tool install -g dotnet-sos
+# Installs the SOS extension, and
+# updates .lldbinit file to load SOS on lldb startup
+dotnet-sos install
+```
+3. oelldb, SGX enclave extension for lldb:
+```
+git clone https://github.com/anakrish/oelldb
+ln -s <path-to-oelldb-dir>/oelldb /usr/bin/oelldb
+```
+
+## Example
+
+```
+make
+make run-ext2-lldb
+```

--- a/tests/dotnet-sos/README.md
+++ b/tests/dotnet-sos/README.md
@@ -14,7 +14,7 @@ dotnet-sos install
 ```
 3. oelldb, SGX enclave extension for lldb:
 ```
-git clone https://github.com/anakrish/oelldb
+git clone --branch working https://github.com/vtikoo/oelldb
 ln -s <path-to-oelldb-dir>/oelldb /usr/bin/oelldb
 ```
 
@@ -23,4 +23,30 @@ ln -s <path-to-oelldb-dir>/oelldb /usr/bin/oelldb
 ```
 make
 make run-ext2-lldb
+```
+
+
+Dotnet runtime issues a lot of cpuid instructions, which generate a SIGILL inside the enclave. To handle these run after the mystikos process is launched -
+```
+pro hand -p true -s false -n false SIGILL
+```
+
+Or alternatively import the ignore_sigill python script -
+```
+script import ignore_sigill
+```
+
+Some SOS commands -
+```
+soshelp
+bpmd hello.dll hello.Program.Main
+clrstack
+clrthreads
+clrmodules
+```
+
+To enable SOS debug logging -
+```
+logging enable
+dbgout
 ```

--- a/tests/dotnet-sos/README.md
+++ b/tests/dotnet-sos/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 1. lldb:
 ```
-sudo apt install lldb-8
+sudo apt install lldb-10
 ```
 2. dotnet-sos:
 ```

--- a/tests/dotnet-sos/code_view.py
+++ b/tests/dotnet-sos/code_view.py
@@ -1,0 +1,55 @@
+import io, re, sys
+import lldb
+from contextlib import redirect_stdout
+
+def my_stop_hook(debugger, command, result, internal_dict):
+    output = ""
+    with io.StringIO() as buf, redirect_stdout(buf):
+        old = debugger.GetOutputFile()
+        debugger.SetOutputFile(buf)
+        debugger.SetAsync(False)
+        stop_reason = (debugger.GetSelectedTarget()
+                        .GetProcess()
+                        .GetSelectedThread()
+                        .GetStopReason())
+        if stop_reason == lldb.eStopReasonBreakpoint:
+            debugger.HandleCommand("re r rip -f x")
+            output = buf.getvalue()
+            buf.truncate(0)
+            m = re.search("rip\\s*=\\s*([0-9a-fA-Fx]+)\.*", output)
+            if m:
+                rip = m[1]
+                debugger.HandleCommand(f"ip2md {rip}")
+                output = buf.getvalue()
+                buf.truncate(0)
+                # TODO: check if this if IP lies in a JITTED frame
+                #print(f"ip2md output: {output}", file=sys.stderr)
+            else:
+                return True  
+            debugger.SetOutputFile(old)
+        else:
+            return True
+    print(output)
+    # TODO: SOS reads source file info from PDB files,
+    # You can make SOS aware of the pdb file by: setsymbolserver -directory <path-to-dir-containing-pdb> 
+    # The source file path is the one recorded at the build time of the pdb file.
+    # If its a multi-stage docker build, the file directory structure will not be available.
+    # One solution is to read dotnet source directories from an environment variable,
+    # and search for the basename part of the file path in those specified directories.
+    m = re.search("Source file:\\s*(.+)\\s+@\\s+(\d+)", output)
+    if m:
+        filename = m[1]
+        line = int(m[2])
+        code = open(filename, "r").read().split('\n')
+        K=10
+        for i in range(line-K, line+K):
+            cursor = "->" if i == line else "  "
+            if i >= 0 and i < len(code):
+                print("%3d %s %s" % (i, cursor, code[i]))
+
+    return True
+    
+def __lldb_init_module(debugger, dict):
+    debugger.HandleCommand('command script add -f code_view.my_stop_hook my_stop_hook')
+    debugger.HandleCommand('target stop-hook add -o "my_stop_hook"')
+

--- a/tests/dotnet-sos/exec.sh
+++ b/tests/dotnet-sos/exec.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+$1 -b -o 'command script import sos_test' \
+	-o "quit" \
+	-- $2 exec $3 ext2fs \
+	--roothash=roothash \
+	--memory-size $4 \
+	/app/hello > stdouterr.txt 2>&1
+
+if [ "$?" != "0" ]; then
+    exit 1
+fi
+
+# Check no assertions failed
+grep -q "AssertionError" stdouterr.txt
+if [ "$?" == "0" ]; then
+    exit 1
+fi
+
+# Check managed breakpoint was set
+grep -q "Setting breakpoint: breakpoint set --address [0-9A-Fa-fx]* \[hello.Program.Main(System.String\[\])\]" stdouterr.txt
+if [ "$?" != "0" ]; then
+    exit 1
+fi
+
+# Check hello.Program.Main figures in clrstack
+grep -q "[0-9A-Fa-f]* [0-9A-Fa-f]* hello.Program.Main(System.String\[\])" stdouterr.txt
+if [ "$?" != "0" ]; then
+    exit 1
+fi
+
+# Check clrstack at Debugger.Break()
+grep -q "[0-9A-Fa-f]* [0-9A-Fa-f]* \[HelperMethodFrame: [0-9A-Fa-f]*\] System.Diagnostics.Debugger.BreakInternal()" stdouterr.txt
+if [ "$?" != "0" ]; then
+    exit 1
+fi

--- a/tests/dotnet-sos/hello/Program.cs
+++ b/tests/dotnet-sos/hello/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace hello
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Debugger.Break();
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/tests/dotnet-sos/hello/hello.csproj
+++ b/tests/dotnet-sos/hello/hello.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/tests/dotnet-sos/ignore_sigill.py
+++ b/tests/dotnet-sos/ignore_sigill.py
@@ -1,0 +1,33 @@
+'''
+Originally from https://github.com/rwestberg/lldbscripts
+'''
+import lldb
+import threading
+
+SIGILL_NUM = 4
+class ProcessEventListener(threading.Thread):
+    def __init__(self, debugger):
+        super(ProcessEventListener, self).__init__()
+        self._listener = debugger.GetListener()
+        self._debugger = debugger
+        self._interpreter = debugger.GetCommandInterpreter()
+        self._handled = set()
+    
+    def _suppress_signals(self, process):
+        signals = process.GetUnixSignals()
+        signals.SetShouldStop(SIGILL_NUM, False)
+        signals.SetShouldNotify(SIGILL_NUM, False)
+
+    def run(self):
+        while True:
+            event = lldb.SBEvent()
+            if not self._listener.PeekAtNextEvent(event):
+                continue                
+            process = self._interpreter.GetProcess()
+            if process and not process.GetUniqueID() in self._handled:
+                self._suppress_signals(process)
+                self._handled.add(process.GetUniqueID())
+
+def __lldb_init_module(debugger, *rest):
+    listener_thread = ProcessEventListener(debugger)
+    listener_thread.start()

--- a/tests/dotnet-sos/sos_test.py
+++ b/tests/dotnet-sos/sos_test.py
@@ -1,0 +1,55 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+import lldb
+import sys
+
+def run_test(debugger):
+    debugger.SetAsync(False)
+    res = lldb.SBCommandReturnObject()
+    ci = debugger.GetCommandInterpreter()
+
+    debugger.HandleCommand("run")
+
+    process = debugger.GetSelectedTarget().GetProcess()
+
+    # We hit the cpuid SIGILL pretty early in dotnet initialization
+    assert(process.GetState() == lldb.eStateStopped)
+    assert(process.GetSelectedThread().GetStopReason() == lldb.eStopReasonSignal)
+    debugger.HandleCommand("pro hand -p true -s false -n false SIGILL")
+
+    # Set managed breakpoint
+    ci.HandleCommand("bpmd hello.dll hello.Program.Main", res)
+    assert(res.Succeeded())
+    process.Continue()
+
+    # Should've hit managed breakpoint
+    assert(process.GetState() == lldb.eStateStopped)
+    assert(process.GetSelectedThread().GetStopReason() == lldb.eStopReasonBreakpoint)
+
+    print("\nRun clrstack at breakpoint hit: ")
+    print("=================================")
+    ci.HandleCommand("clrstack", res)
+    assert(res.Succeeded())
+
+    process.Continue()
+
+    # Should've hit Debugger.Break SIGTRAP
+    assert(process.GetState() == lldb.eStateStopped)
+    assert(process.GetSelectedThread().GetStopReason() == lldb.eStopReasonSignal)
+
+    print("\nRun clrstack at Debugger.Break() hit: ")
+    print("=======================================")
+    ci.HandleCommand("clrstack", res)
+    assert(res.Succeeded())
+
+    print("\nPrint thread info: ")
+    print("=======================================")
+    ci.HandleCommand("clrthreads", res)
+    assert(res.Succeeded())
+    print("=======================================")
+
+    process.Continue()
+
+def __lldb_init_module(debugger, dict):
+    run_test(debugger)

--- a/tests/dotnet-sos/sos_test.py
+++ b/tests/dotnet-sos/sos_test.py
@@ -27,8 +27,7 @@ def run_test(debugger):
     assert(process.GetState() == lldb.eStateStopped)
     assert(process.GetSelectedThread().GetStopReason() == lldb.eStopReasonBreakpoint)
 
-    print("\nRun clrstack at breakpoint hit: ")
-    print("=================================")
+    # Run clrstack at breakpoint hit
     ci.HandleCommand("clrstack", res)
     assert(res.Succeeded())
 
@@ -38,16 +37,13 @@ def run_test(debugger):
     assert(process.GetState() == lldb.eStateStopped)
     assert(process.GetSelectedThread().GetStopReason() == lldb.eStopReasonSignal)
 
-    print("\nRun clrstack at Debugger.Break() hit: ")
-    print("=======================================")
+    # Run clrstack at Debugger.Break() hit
     ci.HandleCommand("clrstack", res)
     assert(res.Succeeded())
 
-    print("\nPrint thread info: ")
-    print("=======================================")
+    # Print thread info
     ci.HandleCommand("clrthreads", res)
     assert(res.Succeeded())
-    print("=======================================")
 
     process.Continue()
 

--- a/tests/dotnet-ubuntu/Dockerfile
+++ b/tests/dotnet-ubuntu/Dockerfile
@@ -2,14 +2,9 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["hello", "hello/"]
 WORKDIR "/src/hello"
-ENV PATH="/lib/x86_64-linux-gnu/:/usr/lib/x86_64-linux-gnu/:${PATH}"
 RUN dotnet publish -o /app/build --self-contained true -r linux-x64
 
 FROM mcr.microsoft.com/dotnet/runtime:5.0
 
 WORKDIR /app
 COPY --from=build /app/build .
-# Hack: Copy over libraries to where musl can find them.
-RUN rmdir /usr/local/lib && ln -s /lib/x86_64-linux-gnu/ /usr/local/lib && \
-	cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/ && \
-	cp /usr/lib/x86_64-linux-gnu/libicu* /lib/x86_64-linux-gnu/ 

--- a/tests/dotnet-ubuntu/Makefile
+++ b/tests/dotnet-ubuntu/Makefile
@@ -3,6 +3,7 @@ include $(TOP)/defs.mak
 
 APPBUILDER=$(TOP)/scripts/appbuilder
 HEAP_SIZE="768M"
+OPTS += --report-native-tids
 
 ifdef STRACE
 OPTS += --strace

--- a/tests/dotnet-ubuntu/hello/Program.cs
+++ b/tests/dotnet-ubuntu/hello/Program.cs
@@ -7,7 +7,6 @@ namespace hello
     {
         static void Main(string[] args)
         {
-            Debugger.Break();
             Console.WriteLine("Hello World!");
         }
     }

--- a/tests/procfs/procfs.c
+++ b/tests/procfs/procfs.c
@@ -59,11 +59,28 @@ int test_self_fd()
     assert(!strcmp(target, filename));
 }
 
+int test_status()
+{
+    int fd;
+    char buf[1024];
+    printf("****\n");
+
+    fd = open("/proc/self/status", O_RDONLY);
+    assert(fd > 0);
+    while (read(fd, buf, sizeof(buf)))
+        printf("%s", buf);
+
+    close(fd);
+
+    printf("****\n");
+}
+
 int test_self_links(const char* pn)
 {
     test_self_symlink();
     test_self_exe(pn);
     test_self_fd();
+    test_status();
 }
 
 int test_readonly()

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -211,7 +211,7 @@ index 20d50f2c..c6ad4096 100644
 +    return -ENOTSUP;
 +}
 diff --git a/ldso/dynlink.c b/ldso/dynlink.c
-index afec985a..5435b9b5 100644
+index afec985a..0ac9f0c4 100644
 --- a/ldso/dynlink.c
 +++ b/ldso/dynlink.c
 @@ -27,6 +27,13 @@
@@ -228,7 +228,53 @@ index afec985a..5435b9b5 100644
  #define MAXP2(a,b) (-(-(a)&-(b)))
  #define ALIGN(x,y) ((x)+(y)-1 & -(y))
  
-@@ -1043,38 +1050,7 @@ static struct dso *load_library(const char *name, struct dso *needed_by)
+@@ -217,6 +224,14 @@ static int search_vec(size_t *v, size_t *r, size_t key)
+ 	return 1;
+ }
+ 
++static size_t* find_dynv_value_addr_by_key(size_t *v, size_t *r, size_t key)
++{
++	for (; v[0]!=key; v+=2)
++		if (!v[0]) return 0;
++	*r = v[1];
++	return &v[1];
++}
++
+ static uint32_t sysv_hash(const char *s0)
+ {
+ 	const unsigned char *s = (void *)s0;
+@@ -895,6 +910,7 @@ static int fixup_rpath(struct dso *p, char *buf, size_t buf_size)
+ static void decode_dyn(struct dso *p)
+ {
+ 	size_t dyn[DYN_CNT];
++	size_t* dynval_ptr = 0;
+ 	decode_vec(p->dynv, dyn, DYN_CNT);
+ 	p->syms = laddr(p, dyn[DT_SYMTAB]);
+ 	p->strings = laddr(p, dyn[DT_STRTAB]);
+@@ -906,8 +922,21 @@ static void decode_dyn(struct dso *p)
+ 		p->rpath_orig = p->strings + dyn[DT_RUNPATH];
+ 	if (dyn[0]&(1<<DT_PLTGOT))
+ 		p->got = laddr(p, dyn[DT_PLTGOT]);
+-	if (search_vec(p->dynv, dyn, DT_GNU_HASH))
++	if ((dynval_ptr = find_dynv_value_addr_by_key(p->dynv, dyn, DT_GNU_HASH)))
++	{
+ 		p->ghashtab = laddr(p, *dyn);
++		// patch the address in the original dynamic section.
++		*dynval_ptr = (size_t)p->ghashtab;
++	}
++	// patch addresses for symbol and string sections too
++	if ((dynval_ptr = find_dynv_value_addr_by_key(p->dynv, dyn, DT_SYMTAB)))
++	{
++		*dynval_ptr = (size_t)p->syms;
++	}
++	if ((dynval_ptr = find_dynv_value_addr_by_key(p->dynv, dyn, DT_STRTAB)))
++	{
++		*dynval_ptr = (size_t)p->strings;
++	}
+ 	if (search_vec(p->dynv, dyn, DT_VERSYM))
+ 		p->versym = laddr(p, *dyn);
+ }
+@@ -1043,38 +1072,7 @@ static struct dso *load_library(const char *name, struct dso *needed_by)
  				fd = path_open(name, p->rpath, buf, sizeof buf);
  		}
  		if (fd == -1) {
@@ -268,7 +314,7 @@ index afec985a..5435b9b5 100644
  			fd = path_open(name, sys_path, buf, sizeof buf);
  		}
  		pathname = buf;
-@@ -1098,6 +1074,7 @@ static struct dso *load_library(const char *name, struct dso *needed_by)
+@@ -1098,6 +1096,7 @@ static struct dso *load_library(const char *name, struct dso *needed_by)
  	map = noload ? 0 : map_library(fd, &temp_dso);
  	close(fd);
  	if (!map) return 0;
@@ -276,7 +322,7 @@ index afec985a..5435b9b5 100644
  
  	/* Avoid the danger of getting two versions of libc mapped into the
  	 * same process when an absolute pathname was used. The symbols
-@@ -1797,6 +1774,7 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1797,6 +1796,7 @@ void __dls3(size_t *sp, size_t *auxv)
  			dprintf(2, "%s: %s: Not a valid dynamic program\n", ldname, argv[0]);
  			_exit(1);
  		}
@@ -284,7 +330,7 @@ index afec985a..5435b9b5 100644
  		close(fd);
  		ldso.name = ldname;
  		app.name = argv[0];
-@@ -1936,6 +1914,7 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1936,6 +1936,7 @@ void __dls3(size_t *sp, size_t *auxv)
  	/* Determine if malloc was interposed by a replacement implementation
  	 * so that calloc and the memalign family can harden against the
  	 * possibility of incomplete replacement. */
@@ -292,7 +338,7 @@ index afec985a..5435b9b5 100644
  	if (find_sym(head, "malloc", 1).dso != &ldso)
  		__malloc_replaced = 1;
  
-@@ -1955,7 +1934,11 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1955,7 +1956,11 @@ void __dls3(size_t *sp, size_t *auxv)
  
  	errno = 0;
  
@@ -304,7 +350,7 @@ index afec985a..5435b9b5 100644
  	for(;;);
  }
  
-@@ -2058,6 +2041,10 @@ void *dlopen(const char *file, int mode)
+@@ -2058,6 +2063,10 @@ void *dlopen(const char *file, int mode)
  	pthread_mutex_lock(&init_fini_lock);
  	if (!p->constructed) ctor_queue = queue_ctors(p);
  	pthread_mutex_unlock(&init_fini_lock);
@@ -315,7 +361,7 @@ index afec985a..5435b9b5 100644
  	if (!p->relocated && (mode & RTLD_LAZY)) {
  		prepare_lazy(p);
  		for (i=0; p->deps[i]; i++)
-@@ -2100,6 +2087,7 @@ end:
+@@ -2100,6 +2109,7 @@ end:
  		free(ctor_queue);
  	}
  	pthread_setcancelstate(cs, 0);

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -349,6 +349,7 @@ static long _enter(void* arg_)
     bool trace_syscalls = false;
     bool shell_mode = false;
     bool memcheck = false;
+    bool report_native_tids = false;
     size_t max_affinity_cpus = 0;
     bool export_ramfs = false;
     const char* rootfs = NULL;
@@ -504,6 +505,7 @@ static long _enter(void* arg_)
         trace_syscalls = options->trace_syscalls;
         shell_mode = options->shell_mode;
         memcheck = options->memcheck;
+        report_native_tids = options->report_native_tids;
         max_affinity_cpus = options->max_affinity_cpus;
         export_ramfs = options->export_ramfs;
 
@@ -566,6 +568,7 @@ static long _enter(void* arg_)
 
         _kargs.shell_mode = shell_mode;
         _kargs.memcheck = memcheck;
+        _kargs.report_native_tids = report_native_tids;
 
         /* set ehdr and verify that the kernel is an ELF image */
         {

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -657,7 +657,8 @@ long myst_tcall_add_symbol_file(
     const void* file_data,
     size_t file_size,
     const void* text,
-    size_t text_size)
+    size_t text_size,
+    const char* enclave_rootfs_path)
 {
     long ret = 0;
     int retval;
@@ -666,7 +667,12 @@ long myst_tcall_add_symbol_file(
         ERAISE(-EINVAL);
 
     if (myst_add_symbol_file_ocall(
-            &retval, file_data, file_size, text, text_size) != OE_OK)
+            &retval,
+            file_data,
+            file_size,
+            text,
+            text_size,
+            enclave_rootfs_path) != OE_OK)
     {
         ERAISE(-EINVAL);
     }

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -857,21 +857,21 @@ int myst_load_fssig(const char* path, myst_fssig_t* fssig)
     return retval;
 }
 
-int myst_tcall_cpuinfo_size()
+int myst_tcall_get_file_size(const char* pathname)
 {
     int retval;
 
-    if (myst_cpuinfo_size_ocall(&retval) != OE_OK)
+    if (myst_get_file_size_ocall(&retval, pathname) != OE_OK)
         return -EINVAL;
 
     return retval;
 }
 
-int myst_tcall_get_cpuinfo(char* buf, size_t size)
+int myst_tcall_read_file(const char* pathname, char* buf, size_t size)
 {
     int retval;
 
-    if (myst_get_cpuinfo_ocall(&retval, buf, size) != OE_OK)
+    if (myst_read_file_ocall(&retval, pathname, buf, size) != OE_OK)
         return -EINVAL;
 
     return retval;

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -271,6 +271,10 @@ int exec_action(int argc, const char* argv[], const char* envp[])
         if (cli_getopt(&argc, argv, "--memcheck", NULL) == 0)
             options.memcheck = true;
 
+        /* Get --report-native-tids option */
+        if (cli_getopt(&argc, argv, "--report-native-tids", NULL) == 0)
+            options.report_native_tids = true;
+
         /* Get --max-affinity-cpus */
         {
             const char* arg = NULL;

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -73,6 +73,7 @@ struct options
     bool export_ramfs;
     bool shell_mode;
     bool memcheck;
+    bool report_native_tids;
     size_t max_affinity_cpus;
     char rootfs[PATH_MAX];
     size_t heap_size;
@@ -112,6 +113,10 @@ static void _get_options(int* argc, const char* argv[], struct options* opts)
     /* Get --memcheck option */
     if (cli_getopt(argc, argv, "--memcheck", NULL) == 0)
         opts->memcheck = true;
+
+    /* Get --report-native-tids option */
+    if (cli_getopt(argc, argv, "--report-native-tids", NULL) == 0)
+        opts->report_native_tids = true;
 
     /* Get --max-affinity-cpus */
     {
@@ -294,6 +299,8 @@ static int _enter_kernel(
     args.shell_mode = options->shell_mode;
 
     args.memcheck = options->memcheck;
+
+    args.report_native_tids = options->report_native_tids;
 
     /* Resolve the the kernel entry point */
     const elf_ehdr_t* ehdr = args.kernel_data;

--- a/tools/myst/host/host.c
+++ b/tools/myst/host/host.c
@@ -94,14 +94,14 @@ void myst_cpuid_ocall(
     __cpuid_count(leaf, subleaf, *rax, *rbx, *rcx, *rdx);
 }
 
-int myst_cpuinfo_size_ocall()
+int myst_get_file_size_ocall(const char* pathname)
 {
-    return myst_tcall_cpuinfo_size();
+    return myst_tcall_get_file_size(pathname);
 }
 
-int myst_get_cpuinfo_ocall(char* buf, size_t size)
+int myst_read_file_ocall(const char* pathname, char* buf, size_t size)
 {
-    return myst_tcall_get_cpuinfo(buf, size);
+    return myst_tcall_read_file(pathname, buf, size);
 }
 
 OE_EXPORT

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -575,6 +575,10 @@ int _exec_package(
     if (cli_getopt(&argc, argv, "--memcheck", NULL) == 0)
         options.memcheck = true;
 
+    /* Get --report-native-tids option */
+    if (cli_getopt(&argc, argv, "--report-native-tids", NULL) == 0)
+        options.report_native_tids = true;
+
     /* Get --max-affinity-cpus */
     {
         const char* arg = NULL;

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -369,9 +369,9 @@ enclave
 
         int myst_mprotect_ocall(void* addr, size_t len, int prot);
 
-        int myst_cpuinfo_size_ocall();
+        int myst_get_file_size_ocall([in, string] const char* pathname);
 
-        int myst_get_cpuinfo_ocall([out, size=size] char* buf, size_t size);
+        int myst_read_file_ocall([in, string] const char* pathname, [out, size=size] char* buf, size_t size);
 
         long myst_chown_ocall(
             [in, string] const char* pathname,

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -101,7 +101,8 @@ enclave
             [in, size=file_size] const void* file_data,
             size_t file_size,
             [user_check] const void* text_data,
-            size_t text_size);
+            size_t text_size,
+            [in, string] const char* enclave_rootfs_path);
 
         int myst_load_symbols_ocall();
 

--- a/utils/strings.c
+++ b/utils/strings.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -373,4 +374,20 @@ void* myst_memcchr(const void* b, int c, size_t n)
     }
 
     return NULL;
+}
+
+int myst_snprintf(char* str, size_t size, const char* format, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, format);
+    ret = vsnprintf(str, size, format, ap);
+    va_end(ap);
+
+    // check for overflow
+    if (ret >= size)
+        return -ERANGE;
+
+    return 0;
 }


### PR DESCRIPTION
### Summary
- Preserve file names when copying symbol files to host. SOS looks for the libcoreclr module by name.
- Add cmdline option to report host thread ids for SYS_gettid.
- Partial support for /proc/[pid]/status.
- Patch addresses in mmapped dynamic section in the musl loader.
- Test for dotnet sos integration.