### PR TITLE
Simplify the runtest script

### DIFF
--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -55,7 +55,7 @@ jobs:
 
       # run all tests
       - script: |
-          make -j tests ALLTESTS=1 VERBOSE=1
+          make -j tests ALLTESTS=1
         displayName: 'run all tests'
         continueOnError: true
         enabled: true

--- a/Makefile
+++ b/Makefile
@@ -157,11 +157,11 @@ summary:
 	@ SUMMARY=1 $(RUNTEST_COMMAND) /bin/true
 
 tests:
-	@ $(MAKE) -s -C tests tests RUNTEST=$(RUNTEST_COMMAND)
+	@ $(MAKE) -C tests tests RUNTEST=$(RUNTEST_COMMAND)
 	@ $(MAKE) -s summary
 
 alltests:
-	$(MAKE) -s tests ALLTESTS=1 VERBOSE=1
+	$(MAKE) tests ALLTESTS=1
 
 
 ##==============================================================================

--- a/scripts/runtest
+++ b/scripts/runtest
@@ -72,27 +72,20 @@ run_test()
 
     # run the test
     if [ -z "${NOTIMEOUT}" ]; then
-        timeout="/usr/bin/timeout ${timeout}"
+        timeout_command="/usr/bin/timeout ${timeout}"
     else
-        timeout=
+        timeout_command=
     fi
 
-    output=${TESTSUBDIR}/output
-    time="/usr/bin/time -f "%e" --quiet -o ${tempfile}"
+    # save the test start time in a temporary file
+    time_command="/usr/bin/time -f "%e" --quiet -o ${tempfile}"
 
-    if [ -z "${VERBOSE}" ]; then
-        echo ${cmd} 2>&1 | tee ${output} > /dev/null
-        set -o pipefail
-        ${timeout} ${time} ${cmd} 2>&1 | tee -a ${output} > /dev/null
-        ret=$?
-        set +o pipefail
-    else
-        echo ${cmd} 2>&1 | tee ${output}
-        set -o pipefail
-        ${timeout} ${time} ${cmd} 2>&1 | tee -a ${output}
-        ret=$?
-        set +o pipefail
-    fi
+    # run the test
+    echo "runtest[start]: ${timeout_command} ${time_command} ${cmd}"
+    ${timeout_command} ${time_command} ${cmd}
+    echo "runtest[finish]: ${timeout_command} ${time_command} ${cmd}"
+    ret=$?
+
     seconds=$(cat ${tempfile})
     rm -f ${tempfile}
 

--- a/solutions/aspnet/Makefile
+++ b/solutions/aspnet/Makefile
@@ -14,28 +14,26 @@ all: appdir private.pem
 
 TIMEOUT=180s
 
-run: appdir private.pem
-	# Kill the server from a previous run if it wasn't shut down properly.
+export COMPlus_EnableDiagnostics=0
+export COMPlus_GCHeapHardLimit=0x10000000
+
+run: rootfs private.pem
 	test -f server.pid && kill -9 `cat server.pid` || true
-	$(MYST) package appdir private.pem config.json
-	myst/bin/$(APPNAME) $(OPTS) > server.output & echo $$! > server.pid
+	$(MYST_EXEC) $(OPTS) rootfs /app/webapp > server.output & echo $$! > server.pid
 	timeout $(TIMEOUT) tail -f server.output | ./client.sh
 	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
 	test -f client.output
 
 # run the server in the foreground:
-server:
-	$(MAKE) appdir
-	$(MAKE) rootfs
+server: rootfs
 	$(MYST_EXEC) rootfs /app/webapp $(OPTS)
 
 # run the client
 client:
 	curl 127.0.0.1:5050
 
-rootfs:
+rootfs: appdir
 	sudo $(MYST) mkext2 appdir rootfs
-	sudo chown $(USER).$(USER) rootfs
 	truncate --size=-4096 rootfs
 
 gdb: appdir private.pem
@@ -44,21 +42,6 @@ gdb: appdir private.pem
 
 appdir:
 	$(APPBUILDER) Dockerfile
-
-rootfs:
-	sudo $(MYST) mkext2 appdir rootfs
-	sudo chown $(USER).$(USER) rootfs
-	truncate --size=-4096 rootfs
-
-# standalone server rule:
-server:
-	$(MAKE) appdir
-	$(MAKE) rootfs
-	$(MYST_EXEC) $(OPTS) rootfs /app/webapp
-
-# standalone client rule:
-client:
-	curl 127.0.0.1:5050
 
 private.pem:
 	openssl genrsa -out private.pem -3 3072

--- a/solutions/aspnet/client.sh
+++ b/solutions/aspnet/client.sh
@@ -3,7 +3,7 @@ rm -f client.output
 
 # wait for the server to launch and then run client command
 while read -r line; do
-  echo $line
+  echo "$line"
   if echo $line | grep -q 'Content root path'; then
     curl 127.0.0.1:5050 || exit 1
     curl 127.0.0.1:5050 || exit 1

--- a/solutions/python_web_frameworks/Makefile
+++ b/solutions/python_web_frameworks/Makefile
@@ -17,19 +17,30 @@ appdir:
 	$(APPBUILDER) Dockerfile
 
 run:
+	$(MAKE) run1
+	$(MAKE) run2
+
+run1:
 	test -f server.pid && kill -9 `cat server.pid` || true
 	@echo "=== starting flask server ==="
-	@$(MYST_EXEC) $(OPTS) $(ROOTFS) /usr/local/bin/python3 /app/flask_app.py & echo $$! > server.pid
-	@sleep 10
-	curl 127.0.0.1:8000 -w "\n"
+	$(MYST_EXEC) $(OPTS) $(ROOTFS) /usr/local/bin/python3 /app/flask_app.py 2> server.output & echo $$! > server.pid
+	timeout 60s tail -f server.output | ./client.sh "Running on http"
+	@echo ""
 	@echo "=== stopping flask server ==="
-	@test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
+	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
+	test -f client.output
+	@echo ""
+
+run2:
+	test -f server.pid && kill -9 `cat server.pid` || true
 	@echo "=== starting uwsgi server ==="
-	@$(MYST_EXEC) $(OPTS) $(ROOTFS) /usr/local/bin/uwsgi /app/uwsgi.ini & echo $$! > server.pid
-	@sleep 10
-	curl 127.0.0.1:8000 -w "\n"
+	$(MYST_EXEC) $(OPTS) $(ROOTFS) /usr/local/bin/uwsgi /app/uwsgi.ini 2> server.output & echo $$! > server.pid
+	timeout 60s tail -f server.output | ./client.sh "spawned uWSGI worker"
+	@echo ""
 	@echo "=== stopping flask server ==="
-	@test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
+	test -f server.pid && kill -9 `cat server.pid` && rm server.pid || true
+	test -f client.output
+	@echo ""
 
 server-flask:
 	$(MYST_EXEC) $(OPTS) $(ROOTFS) /usr/local/bin/python3 /app/flask_app.py

--- a/solutions/python_web_frameworks/client.sh
+++ b/solutions/python_web_frameworks/client.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+rm -f client.output
+
+# wait for the server to launch and then run client command
+while read -r line; do
+  echo "$line"
+  if echo $line | grep -q "$1"; then
+    curl 127.0.0.1:8000 || exit 1
+    touch client.output
+    exit 0
+  fi
+done

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -120,8 +120,8 @@ __tests:
 
 tests:
 	@ sudo rm -rf $(TESTDIR)
-	@ $(MAKE) -s __tests TARGET=sgx TESTSUFFIX=.sgx
-	@ $(MAKE) -s __tests TARGET=linux TESTSUFFIX=.linux
+	@ $(MAKE) __tests TARGET=sgx TESTSUFFIX=.sgx
+	@ $(MAKE) __tests TARGET=linux TESTSUFFIX=.linux
 
 clean:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) clean $(NL) )

--- a/utils/cpio.c
+++ b/utils/cpio.c
@@ -26,7 +26,7 @@ void free(void* ptr);
 
 #define CPIO_BLOCK_SIZE 512
 
-//#define TRACE
+#define TRACE
 #define PRINTF printf
 
 // clang-format off


### PR DESCRIPTION
This PR simplifies the `runtest` script in hopes of working around random failures in libcxx and other tests. In particular is simplifies the `runtest` exec command from this (taking ``getcwd`` as an example):

```
set -o pipefail
/usr/bin/timeout 60 /usr/bin/time -f %e --quiet -o /tmp/tmp.UTlru6Dbs8  /home/mike/mystikos-main/build/bin/myst exec-linux rootfs /bin/getcwd 2>&1 | tee -a /home/mike/mystikos-main/build/tests/tests/getcwd.linux/output > /dev/null
set +o pipefail
```

to this:

```
/usr/bin/timeout 60 /usr/bin/time -f %e --quiet -o /tmp/tmp.UTlru6Dbs8  /home/mike/mystikos-main/build/bin/myst exec-linux rootfs /bin/getcwd
```

This simply removes the saving of output to files in the test directories (which nobody has ever used).

I suspect that the complex pipe command fails in various conditions, causing some tests to crash randomly (but I am not certain). The previous version of `runtest` allows more than one process to write to the same output file.

Also, this PR removes the "silent" option so that all test output can be seen in the pipeline log.