### PR TITLE
Set --max-affinity-cpus=1 for aspnet solution

### DIFF
--- a/solutions/aspnet/Makefile
+++ b/solutions/aspnet/Makefile
@@ -9,6 +9,7 @@ OPTS += --strace
 endif
 
 OPTS += --memory-size=1024m
+OPTS += --max-affinity-cpus=1
 
 all: appdir private.pem
 


### PR DESCRIPTION
The aspnet solution was recently converted to an ext2 example and so no longer heeds these environment variables:

```
OPTS += --memory-size=1024m
OPTS += --max-affinity-cpus=1
```

For now I added the ``max-affinity-cpus=1`` option to speed up execution.

The conversion was done because package mode depends on CPIO which is now broken for aspnet which now includes fifo's in the root file system (the Mystikos packager cannot handle fifos).