### PR TITLE
Ignore FIFOs when packaging CPIO

### DIFF
--- a/utils/cpio.c
+++ b/utils/cpio.c
@@ -494,8 +494,8 @@ int myst_cpio_write_entry(myst_cpio_t* cpio, const myst_cpio_entry_t* entry)
     if (!cpio || cpio->fd < 0 || !entry)
         GOTO(done);
 
-    /* ATTN: Skip character files */
-    if (S_ISCHR(entry->mode))
+    /* ATTN: Skip character files and fifos */
+    if (S_ISCHR(entry->mode) || S_ISFIFO(entry->mode))
     {
         ret = 0;
         goto done;


### PR DESCRIPTION
The Mystikos CPIO packager fails when encountering FIFO file types. This PR modifies the packager to ignore FIFOs for now. This error was encountered recently in the `aspnet` solution.

see issue https://github.com/deislabs/mystikos/issues/477