### PR TITLE
Add --max-affinity-cpus=1 for aspnet solution

### DIFF
--- a/solutions/aspnet/Makefile
+++ b/solutions/aspnet/Makefile
@@ -9,6 +9,7 @@ OPTS += --strace
 endif
 
 OPTS += --memory-size=1024m
+OPTS += --max-affinity-cpus=1
 
 all: appdir private.pem
 


### PR DESCRIPTION
Added ``--max-affinity-cpus=1`` to improve performance of the solution.

Test results for three consecutive runs on NUC SGX-2 hardware.

| COMPlus_GCHeapHardLimit=0x10000000 | --max-affinity-cpus=1 | results |
| --------- | -------- | -------- |
| no | no | HRESULT: 0x8007000E |
| yes | no | 1m32s, 0m58s, 3m59s |
| yes | yes | 0m53s, 0m53s, 0m53  |
| no | yes | 0m50s,  1m3s, 0m50s |