### PR TITLE
Enhance boundary condition check, group the OCALLs into categories.

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -102,6 +102,12 @@ int myst_load_fs(
     {
         if (locals->fssig.signature_size)
         {
+            /* Make sure signature_size set by the host-side does not exceed
+             * fssig.signature buffer size.
+             */
+            if (locals->fssig.signature_size > sizeof(locals->fssig.signature))
+                ERAISE(-EINVAL);
+
             ECHECK(myst_pubkey_verify(
                 __myst_kernel_args.archive_data,
                 __myst_kernel_args.archive_size,

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -516,7 +516,11 @@ static long _enter(void* arg_)
         /* rootfs buffer content set by the host side. Max length of the string
          * is PATH_MAX-1. Enforce NULL terminator at the end of the buffer.
          */
-        options->rootfs[PATH_MAX - 1] = '\0';
+        if (strnlen(options->rootfs, PATH_MAX) == PATH_MAX)
+        {
+            fprintf(stderr, "rootfs path too long (> %u)\n", PATH_MAX);
+            goto done;
+        }
 
         rootfs = options->rootfs;
     }

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -513,11 +513,10 @@ static long _enter(void* arg_)
         report_native_tids = options->report_native_tids;
         max_affinity_cpus = options->max_affinity_cpus;
 
-        if (strlen(options->rootfs) >= PATH_MAX)
-        {
-            fprintf(stderr, "rootfs path too long (> %u)\n", PATH_MAX);
-            goto done;
-        }
+        /* rootfs buffer content set by the host side. Max length of the string
+         * is PATH_MAX-1. Enforce NULL terminator at the end of the buffer.
+         */
+        options->rootfs[PATH_MAX - 1] = '\0';
 
         rootfs = options->rootfs;
     }
@@ -813,7 +812,11 @@ int myst_tcall_read_block_device(
     {
         return -EINVAL;
     }
-
+    /* guard against host setting the return value greater than num_blocks */
+    if (retval > (ssize_t)num_blocks)
+    {
+        retval = -EINVAL;
+    }
     return retval;
 }
 
@@ -830,7 +833,11 @@ int myst_tcall_write_block_device(
     {
         return -EINVAL;
     }
-
+    /* guard against host setting the return value greater than num_blocks */
+    if (retval > (ssize_t)num_blocks)
+    {
+        retval = -EINVAL;
+    }
     return retval;
 }
 

--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -827,7 +827,8 @@ static long _poll(struct pollfd* fds, nfds_t nfds, int timeout)
      */
     for (nfds_t i = 0; i < nfds; i++)
     {
-        fds[i].revents = copy[i].revents & fds[i].events;
+        const short int mask = POLLERR | POLLHUP | POLLNVAL;
+        fds[i].revents = copy[i].revents & (fds[i].events | mask);
     }
 
     /* guard against return value that is bigger than nfds */

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -38,9 +38,11 @@ enclave
         struct myst_timespec st_ctim;
     };
 
-    struct myst_fsid {
+    struct myst_fsid
+    {
         int __val[2];
     };
+
     struct myst_statfs
     {
         unsigned long f_type;
@@ -236,9 +238,8 @@ enclave
             [in, out] socklen_t* optlen,
             socklen_t optval_size);
 
-        /* ATTN: If Host file system support is exclude in certain build mode,
-        *  consider excluding relevant OCALL proxy code too.
-        */
+        // ATTN: If Host file system support is exclude in certain build mode,
+        // consider excluding relevant OCALL proxy code too.
 
         /*
         **======================================================================
@@ -260,7 +261,7 @@ enclave
             mode_t mode,
             uid_t uid,
             gid_t gid);
-        
+
         long myst_read_ocall(
             int fd,
             [out, size=count] void* buf,
@@ -284,7 +285,7 @@ enclave
             [out] struct myst_stat* statbuf,
             uid_t host_euid,
             gid_t host_egid);
-        
+
         long myst_fstat_ocall(int fd, [out] struct myst_stat* statbuf);
 
         long myst_access_ocall(
@@ -370,23 +371,24 @@ enclave
 
         int myst_get_file_size_ocall([in, string] const char* pathname);
 
-        int myst_read_file_ocall([in, string] const char* pathname, [out, size=size] char* buf, size_t size);
+        int myst_read_file_ocall(
+            [in, string] const char* pathname,
+            [out, size=size] char* buf,
+            size_t size);
 
         long myst_chown_ocall(
             [in, string] const char* pathname,
             uid_t owner,
             gid_t group,
             uid_t host_euid,
-            gid_t host_egid
-        );
+            gid_t host_egid);
 
         long myst_fchown_ocall(
             int fd,
             uid_t owner,
             gid_t group,
             uid_t host_euid,
-            gid_t host_egid
-        );
+            gid_t host_egid);
 
         long myst_lchown_ocall(
             [in, string] const char* pathname,
@@ -400,18 +402,20 @@ enclave
             [in, string] const char* pathname,
             mode_t mode,
             uid_t host_euid,
-            gid_t host_egid   
-        );
+            gid_t host_egid);
 
-        long myst_fchmod_ocall(int fd, uint32_t mode, uid_t host_euid, gid_t host_egid);
+        long myst_fchmod_ocall(
+            int fd,
+            uint32_t mode,
+            uid_t host_euid,
+            gid_t host_egid);
 
         long myst_fcntl_ocall(int fd, int cmd, long arg);
 
         long myst_fcntl_setlkw_ocall(int fd, [in] const struct flock* arg);
 
-        /* ATTN: If debugging support is excluded in certain build mode, consider
-         * excluding relevant OCALL proxy code too. 
-         */
+        // ATTN: If debugging support is excluded in certain build mode,
+        // consider excluding relevant OCALL proxy code too.
 
         /*
         **======================================================================
@@ -432,9 +436,8 @@ enclave
 
         int myst_unload_symbols_ocall();
 
-        /* ATTN: If EXT2 file system support is exlcuded in certain build mode,
-        *  consider excluding relevant OCALL proxy code too.
-        */
+        // ATTN: If EXT2 file system support is exlcuded in certain build mode,
+        // consider excluding relevant OCALL proxy code too.
 
         /*
         **======================================================================

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -89,26 +89,17 @@ enclave
     {
         void myst_rdtsc_ocall([out] uint32_t* rax, [out] uint32_t* rdx);
 
-        void myst_cpuid_ocall(
-            uint32_t leaf,
-            uint32_t subleaf,
-            [out] uint32_t* rax,
-            [out] uint32_t* rbx,
-            [out] uint32_t* rcx,
-            [out] uint32_t* rdx);
-
-        int myst_add_symbol_file_ocall(
-            [in, size=file_size] const void* file_data,
-            size_t file_size,
-            [user_check] const void* text_data,
-            size_t text_size,
-            [in, string] const char* enclave_rootfs_path);
-
-        int myst_load_symbols_ocall();
-
-        int myst_unload_symbols_ocall();
-
         long myst_syscall_isatty_ocall(int fd);
+
+        int myst_mprotect_ocall(void* addr, size_t len, int prot);
+
+        /*
+        **======================================================================
+        **
+        ** threading/scheduler
+        **
+        **======================================================================
+        */
 
         long myst_create_thread_ocall(uint64_t cookie);
 
@@ -123,11 +114,7 @@ enclave
             uint64_t self_event,
             [in] const struct myst_timespec* timeout);
 
-        long myst_fstat_ocall(int fd, [out] struct myst_stat* statbuf);
-
         long myst_sched_yield_ocall();
-
-        long myst_fchmod_ocall(int fd, uint32_t mode, uid_t host_euid, gid_t host_egid);
 
         long myst_poll_ocall(
             [in, out, count=nfds] struct pollfd* fds,
@@ -136,25 +123,17 @@ enclave
 
         long myst_poll_wake_ocall();
 
-        long myst_read_ocall(
-            int fd,
-            [out, size=count] void* buf,
-            size_t count);
-
-        long myst_write_ocall(
-            int fd,
-            [in, size=count] const void* buf,
-            size_t count);
-
-        long myst_close_ocall(int fd);
-
         long myst_nanosleep_ocall(
             [in] const struct timespec* req,
             [out] struct timespec* rem);
 
-        long myst_fcntl_ocall(int fd, int cmd, long arg);
-
-        long myst_fcntl_setlkw_ocall(int fd, [in] const struct flock* arg);
+        /*
+        **======================================================================
+        **
+        ** socket
+        **
+        **======================================================================
+        */
 
         long myst_bind_ocall(
             int sockfd,
@@ -257,6 +236,18 @@ enclave
             [in, out] socklen_t* optlen,
             socklen_t optval_size);
 
+        /* ATTN: If Host file system support is exclude in certain build mode,
+        *  consider excluding relevant OCALL proxy code too.
+        */
+
+        /*
+        **======================================================================
+        **
+        ** hostfs
+        **
+        **======================================================================
+        */
+
         long myst_ioctl_ocall(
             int fd,
             unsigned long request,
@@ -269,6 +260,18 @@ enclave
             mode_t mode,
             uid_t uid,
             gid_t gid);
+        
+        long myst_read_ocall(
+            int fd,
+            [out, size=count] void* buf,
+            size_t count);
+
+        long myst_write_ocall(
+            int fd,
+            [in, size=count] const void* buf,
+            size_t count);
+
+        long myst_close_ocall(int fd);
 
         long myst_stat_ocall(
             [in, string] const char* pathname,
@@ -281,6 +284,8 @@ enclave
             [out] struct myst_stat* statbuf,
             uid_t host_euid,
             gid_t host_egid);
+        
+        long myst_fstat_ocall(int fd, [out] struct myst_stat* statbuf);
 
         long myst_access_ocall(
             [in, string] const char* pathname,
@@ -362,7 +367,6 @@ enclave
             uid_t uid,
             gid_t gid);
 
-        int myst_mprotect_ocall(void* addr, size_t len, int prot);
 
         int myst_get_file_size_ocall([in, string] const char* pathname);
 
@@ -398,6 +402,39 @@ enclave
             uid_t host_euid,
             gid_t host_egid   
         );
+
+        long myst_fchmod_ocall(int fd, uint32_t mode, uid_t host_euid, gid_t host_egid);
+
+        long myst_fcntl_ocall(int fd, int cmd, long arg);
+
+        long myst_fcntl_setlkw_ocall(int fd, [in] const struct flock* arg);
+
+        /* ATTN: If debugging support is excluded in certain build mode, consider
+         * excluding relevant OCALL proxy code too. 
+         */
+
+        /*
+        **======================================================================
+        **
+        ** debugger
+        **
+        **======================================================================
+        */
+
+        int myst_add_symbol_file_ocall(
+            [in, size=file_size] const void* file_data,
+            size_t file_size,
+            [user_check] const void* text_data,
+            size_t text_size,
+            [in, string] const char* enclave_rootfs_path);
+
+        int myst_load_symbols_ocall();
+
+        int myst_unload_symbols_ocall();
+
+        /* ATTN: If EXT2 file system support is exlcuded in certain build mode,
+        *  consider excluding relevant OCALL proxy code too.
+        */
 
         /*
         **======================================================================
@@ -455,5 +492,13 @@ enclave
             pid_t pid,
             size_t cpusetsize,
             [out, size=cpusetsize] uint8_t* mask);
+
+        void myst_cpuid_ocall(
+            uint32_t leaf,
+            uint32_t subleaf,
+            [out] uint32_t* rax,
+            [out] uint32_t* rbx,
+            [out] uint32_t* rcx,
+            [out] uint32_t* rdx);
     };
 };


### PR DESCRIPTION
- Add boundary condition check for several input controlled by the host-side;
- Add more comments in myst_cond_timedwait();
- Group the OCALLs in the EDL into categories, preparing for future enhancement of excluding OCALL proxy code when the relevant feature is to be excluded in certain build configuration.

Signed-off-by: Bo Zhang (ACC) zhanb@microsoft.com