### PR TITLE
SYS_arch_prctl: support get operation for FS and GS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ tests/myst/exec-signed-1/result
 tests/myst/exec-signed-2/appdir/
 tests/myst/exec-signed-2/result
 tests/robust/appdir/
+tests/arch_prctl/appdir

--- a/include/myst/fsgs.h
+++ b/include/myst/fsgs.h
@@ -6,6 +6,11 @@
 
 #include <myst/types.h>
 
+#define ARCH_SET_GS 0x1001
+#define ARCH_SET_FS 0x1002
+#define ARCH_GET_FS 0x1003
+#define ARCH_GET_GS 0x1004
+
 void* myst_get_fsbase(void);
 
 void myst_set_fsbase(void* p);

--- a/kernel/fsgs.c
+++ b/kernel/fsgs.c
@@ -14,7 +14,6 @@ void myst_set_fsbase(void* p)
 {
     if (__options.have_syscall_instruction)
     {
-        const long ARCH_SET_FS = 0x1002;
         const long n = SYS_arch_prctl;
         myst_syscall2(n, ARCH_SET_FS, (long)p);
     }
@@ -28,7 +27,6 @@ void* myst_get_fsbase(void)
 {
     if (__options.have_syscall_instruction)
     {
-        const long ARCH_GET_FS = 0x1003;
         const long n = SYS_arch_prctl;
         void* p;
         myst_syscall2(n, ARCH_GET_FS, (long)&p);
@@ -46,7 +44,6 @@ void myst_set_gsbase(void* p)
 {
     if (__options.have_syscall_instruction)
     {
-        const long ARCH_SET_GS = 0x1001;
         const long n = SYS_arch_prctl;
         myst_syscall2(n, ARCH_SET_GS, (long)p);
     }
@@ -61,7 +58,6 @@ void* myst_get_gsbase(void)
 {
     if (__options.have_syscall_instruction)
     {
-        const long ARCH_GET_GS = 0x1004;
         const long n = SYS_arch_prctl;
         void* p;
         myst_syscall2(n, ARCH_GET_GS, (long)&p);

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2845,6 +2845,9 @@ long myst_syscall_arch_prctl(
 {
     long ret = 0;
 
+    if (!addr)
+        ERAISE(-EFAULT);
+
     if (code == ARCH_GET_FS)
     {
         *addr = cached_fsbase;
@@ -2855,9 +2858,10 @@ long myst_syscall_arch_prctl(
     }
     else
     {
-        ret = -EINVAL;
+        ERAISE(-EINVAL);
     }
 
+done:
     return ret;
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -58,6 +58,7 @@ DIRS += tlscert
 DIRS += tlscert2
 DIRS += wake_and_kill
 DIRS += cross_fs_symlinks
+DIRS += arch_prctl
 
 ifndef MYST_SKIP_LTP_TESTS
 DIRS += ltp

--- a/tests/arch_prctl/Makefile
+++ b/tests/arch_prctl/Makefile
@@ -1,0 +1,26 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+PROGRAM = arch_prctl
+APPDIR = appdir
+CFLAGS = -fPIC -g
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+OPTS =
+ifdef STRACE
+OPTS += --strace
+endif
+
+all:
+	$(MAKE) rootfs
+
+rootfs: $(PROGRAM).c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(PROGRAM) $(PROGRAM).c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+tests:
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/$(PROGRAM)
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/arch_prctl/arch_prctl.c
+++ b/tests/arch_prctl/arch_prctl.c
@@ -1,0 +1,74 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define ARCH_SET_GS 0x1001
+#define ARCH_SET_FS 0x1002
+#define ARCH_GET_FS 0x1003
+#define ARCH_GET_GS 0x1004
+#define ARCH_GET_CPUID 0x1011
+#define ARCH_SET_CPUID 0x1012
+
+struct test_case
+{
+    int code;
+    int ret;
+    int errno_val;
+} test_cases[] = {
+    {ARCH_GET_FS, 0, 0},
+    {ARCH_GET_GS, 0, 0},
+    {ARCH_SET_FS, -1, EINVAL},
+    {ARCH_SET_GS, -1, EINVAL},
+    {ARCH_GET_CPUID, -1, EINVAL},
+    {ARCH_SET_CPUID, -1, EINVAL},
+};
+int ntests = sizeof(test_cases) / sizeof(struct test_case);
+
+int arch_prctl(int code, unsigned long* addr)
+{
+    int ret;
+    ret = syscall(SYS_arch_prctl, code, addr);
+    // printf("ret= %d code= %x addr= %lx errno= %d \n", ret, code, *addr,
+    // errno);
+    return ret;
+}
+
+/* Assumes fs:0 will be a self pointer */
+long read_fs_base()
+{
+    long x0 = 0;
+    __asm__ volatile("mov %%fs:0, %0" : "=r"(x0));
+    // printf("fs=%lx\n", x0);
+    return x0;
+}
+
+/* Assumes gs:0 will be a self pointer */
+long read_gs_base()
+{
+    long x0 = 0;
+    __asm__ volatile("mov %%gs:0, %0" : "=r"(x0));
+    // printf("gs=%lx\n", x0);
+    return x0;
+}
+
+int main(int argc, const char* argv[])
+{
+    for (int i = 0; i < ntests; i++)
+    {
+        struct test_case tc = test_cases[i];
+        long addr;
+        int ret = arch_prctl(tc.code, &addr);
+        assert(ret == tc.ret);
+        if (ret != 0)
+            assert(errno == tc.errno_val);
+        if (tc.code == ARCH_GET_FS)
+            assert(addr == read_fs_base());
+        if (tc.code == ARCH_GET_GS)
+            assert(addr == read_gs_base());
+    }
+    printf("=== passed test (%s)\n", argv[0]);
+    return 0;
+}


### PR DESCRIPTION
### Summary
Only ARCH_GET_FS and ARCH_GET_GS codes are supported.

Setting fs and gs is not allowed, for following reasons:
- modifying fs will mess up musl pthreads.
- gs value is controlled by OE for its thread specific structures.

Code for enabling/disabling cpuid - ARCH_SET_CPUID, is also not supported. 

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>