### PR TITLE
Sockperf

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -109,6 +109,8 @@ DIRS += eventfd
 DIRS += polleventfd
 DIRS += dotnet-sos
 
+DIRS += sockperf
+
 .PHONY: $(DIRS)
 
 dirs: $(DIRS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -109,8 +109,6 @@ DIRS += eventfd
 DIRS += polleventfd
 DIRS += dotnet-sos
 
-DIRS += sockperf
-
 .PHONY: $(DIRS)
 
 dirs: $(DIRS)

--- a/tests/sockperf/Makefile
+++ b/tests/sockperf/Makefile
@@ -31,16 +31,19 @@ $(ROOTHASH): $(ROOTFS)
 OPTS += --roothash=$(ROOTHASH)
 
 tests:
-	docker run --network="host" temp-image-for-server /app/sockperf server&
-	echo "Server created"
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf ping-pong 
+	./kill.sh
+	docker run --network="host" temp-image-for-server /app/sockperf server &
+	./wait.sh
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf ping-pong
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf under-load
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf throughput --msg-size=1472
+	./kill.sh
 	docker run --network="host" temp-image-for-server /app/sockperf server --tcp &
-	echo "Server created"
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf ping-pong --tcp 
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf under-load --tcp 
+	./wait.sh
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf ping-pong --tcp
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf under-load --tcp
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf throughput --msg-size=1472 --tcp
+	./kill.sh
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/sockperf/kill.sh
+++ b/tests/sockperf/kill.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+pid=$(ps -eaf | grep /app/sockperf | grep root | awk '{ print $2 }')
+if [ ! -z "${pid}" ]; then
+    sudo kill -9 ${pid}
+fi

--- a/tests/sockperf/wait.sh
+++ b/tests/sockperf/wait.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+while [ -z "${str}" ]
+do
+    str=$(sudo lsof -i -P -n | grep "\<11111\>")
+done
+echo "Server created"


### PR DESCRIPTION
@salsal97 and I created this fix for ``./tests/sockperf``, which ensures that the server is listening on port ``11111`` before the clients attempt to connect.