### PR TITLE
back out --max-affinity-cpus=1 in aspnet solution

### DIFF
--- a/solutions/aspnet/Makefile
+++ b/solutions/aspnet/Makefile
@@ -9,7 +9,9 @@ OPTS += --strace
 endif
 
 OPTS += --memory-size=1024m
-OPTS += --max-affinity-cpus=1
+
+# ATTN: this setting causes curl to get empty responses after two attempts
+#OPTS += --max-affinity-cpus=1
 
 all: appdir private.pem
 

--- a/solutions/aspnet/client.sh
+++ b/solutions/aspnet/client.sh
@@ -8,6 +8,13 @@ while read -r line; do
     curl 127.0.0.1:5050 || exit 1
     curl 127.0.0.1:5050 || exit 1
     curl 127.0.0.1:5050 || exit 1
+    curl 127.0.0.1:5050 || exit 1
+    curl 127.0.0.1:5050 || exit 1
+    curl 127.0.0.1:5050 || exit 1
+    curl 127.0.0.1:5050 || exit 1
+    curl 127.0.0.1:5050 || exit 1
+    curl 127.0.0.1:5050 || exit 1
+    curl 127.0.0.1:5050 || exit 1
     touch client.output
     exit 0
   fi


### PR DESCRIPTION
The ``--max-affinity-cpus=1`` change to the aspnet solution caused curl to get empty responses on the third attempt. Commenting out the change and adding an ATTN for now.

I increased the number of attempts from 3 to 10 just to put the solution under a little more stress.