### PR TITLE
Add syscall renameat

### DIFF
--- a/doc/syscall-limitations.md
+++ b/doc/syscall-limitations.md
@@ -103,7 +103,7 @@ on lowering the incompatibilities to enable more applications.
 | SYS_fcntl | File descriptor operations | Partial |
 | SYS_mknod | Create a file system node  | Partial |
 | SYS_openat / SYS_futimesat / SYS_faccessat | File system operation relative to a directory file descriptor | Partial |
-| SYS_mkdirat / SYS_mknodat / SYS_fchownat / SYS_unlinkat / SYS_renameat / SYS_renameat2 / SYS_linkat / SYS_symlinkat / SYS_fchmodat | File system operation relative to a directory file descriptor | Unsupported |
+| SYS_mkdirat / SYS_mknodat / SYS_fchownat / SYS_unlinkat / SYS_renameat2 / SYS_linkat / SYS_symlinkat / SYS_fchmodat | File system operation relative to a directory file descriptor | Unsupported |
 | SYS_lsetxattr / SYS_fsetxattr / SYS_getxattr / SYS_lgetxattr / SYS_fgetxattr / SYS_listxattr / SYS_llistxattr / SYS_flistxattr / SYS_removexattr / SYS_lremovexattr/ SYS_fremovexattr | get/set/remove extended file attributes | Unsupported |
 | SYS_inotify_add_watch | Monitor file system changes | Partial |
 | SYS_fanotify_init / SYS_fanotify_mark | Monitor file system changes | Unsupported |

--- a/tests/fs/fs.c
+++ b/tests/fs/fs.c
@@ -404,6 +404,26 @@ void test_rename(void)
     _passed(__FUNCTION__);
 }
 
+void test_renameat(void)
+{
+    int ret = 0;
+    int olddirfd, newdirfd;
+    // Create directories and files
+    {
+        assert(mkdir("/renameat", 0777) == 0);
+        assert(mkdir("/renameat/dir1", 0777) == 0);
+        assert(_touch("/renameat/dir1/file1", 0600) == 0);
+        assert(access("/renameat/dir1/file1", R_OK) == 0);
+        assert(mkdir("/renameat/dir2", 0777) == 0);
+        assert((olddirfd = open("/renameat/dir1", O_DIRECTORY)) >= 0);
+        assert((newdirfd = open("/renameat/dir2", O_DIRECTORY)) >= 0);
+        assert((renameat(olddirfd, "file1", newdirfd, "file3")) == 0);
+        assert(access("/renameat/dir2/file3", R_OK) == 0);
+    }
+
+    _passed(__FUNCTION__);
+}
+
 void test_truncate(void)
 {
     int fd;
@@ -954,6 +974,7 @@ int main(int argc, const char* argv[])
     test_link();
     test_access();
     test_rename();
+    test_renameat();
     test_truncate();
     test_symlink();
     test_tmpfile();


### PR DESCRIPTION
Only `renameat` is supported.
`renameat2` is not supported in MUSL or Ubuntu18.04's default glibc (2.27).