### PR TITLE
Non-sudo version of "myst mkext2"

### DIFF
--- a/samples/openmp/Makefile
+++ b/samples/openmp/Makefile
@@ -13,10 +13,8 @@ appdir:
 	$(APPBUILDER) Dockerfile
 
 rootfs: appdir
-	sudo $(MYST) mkext2 appdir ext2rootfs
-	sudo chown $(USER).$(USER) ext2rootfs
+	$(MYST) mkext2 appdir ext2rootfs
 	$(MYST) fssig --roothash ext2rootfs > roothash
-	# $(MYST) mkcpio appdir rootfs
 
 run:
 	$(MYST_EXEC) $(OPTS) --roothash=roothash ext2rootfs /app/openmp-test

--- a/samples/pytorch/Makefile
+++ b/samples/pytorch/Makefile
@@ -44,8 +44,7 @@ endif
 	@echo "\n-------build end--------\n"
 
 build-ext2: appdir
-	sudo $(MYST) mkext2 appdir $(ROOTFS)
-	sudo chown $(USER).$(USER) $(ROOTFS)
+	$(MYST) mkext2 appdir $(ROOTFS)
 	$(MYST) fssig --roothash $(ROOTFS) > roothash
 
 build-package: appdir package.pem

--- a/solutions/aspnet/Makefile
+++ b/solutions/aspnet/Makefile
@@ -36,7 +36,7 @@ client:
 	curl 127.0.0.1:5050
 
 rootfs: appdir
-	sudo $(MYST) mkext2 appdir rootfs
+	$(MYST) mkext2 appdir rootfs
 	truncate --size=-4096 rootfs
 
 gdb: appdir private.pem

--- a/solutions/coreclr/Makefile
+++ b/solutions/coreclr/Makefile
@@ -27,7 +27,7 @@ rootfs: appdir
 	$(MYST) mkcpio appdir rootfs
 
 ext2fs: appdir
-	sudo $(MYST) mkext2 appdir ext2fs
+	$(MYST) mkext2 appdir ext2fs
 	$(MYST) fssig --roothash ext2fs > roothash
 
 run:

--- a/solutions/msgpack_c/Makefile
+++ b/solutions/msgpack_c/Makefile
@@ -22,8 +22,7 @@ $(APPDIR):
 	$(TOP)/scripts/appbuilder Dockerfile
 
 rootfs: appdir
-	sudo $(MYST) mkext2 $(APPDIR) rootfs
-	sudo chown $(USER).$(USER) rootfs
+	$(MYST) mkext2 $(APPDIR) rootfs
 	truncate --size=-4096 rootfs
 
 clean:

--- a/tests/azure-sdk-for-cpp/Makefile
+++ b/tests/azure-sdk-for-cpp/Makefile
@@ -18,7 +18,7 @@ $(APPDIR):
 	$(APPBUILDER) Dockerfile
 
 $(ROOTFS): $(APPDIR)
-	sudo $(MYST) mkext2 $(APPDIR) $(ROOTFS)
+	$(MYST) mkext2 $(APPDIR) $(ROOTFS)
 	truncate --size=-4096 $(ROOTFS)
 
 OPTS += --memory-size=256m

--- a/tests/bigfile/Makefile
+++ b/tests/bigfile/Makefile
@@ -13,7 +13,7 @@ LDFLAGS = -lcrypto
 all: rootfs bigfile
 
 rootfs: appdir
-	sudo $(MYST) mkext2 --force appdir rootfs
+	$(MYST) mkext2 --force appdir rootfs
 
 truncate:
 	truncate --size=-4096 rootfs

--- a/tests/cross_fs_symlinks/Makefile
+++ b/tests/cross_fs_symlinks/Makefile
@@ -35,7 +35,7 @@ rootfs: $(APPDIR)
 	$(MYST) mkcpio $(APPDIR) rootfs
 
 ext2rootfs: $(APPDIR)
-	sudo $(MYST) mkext2 --force $(APPDIR) ext2rootfs
+	$(MYST) mkext2 --force $(APPDIR) ext2rootfs
 
 clean:
 	rm -rf $(APPDIR) rootfs ramfs cpio_image ext2rootfs roothash

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -19,7 +19,7 @@ appdir:
 
 ext2fs: appdir
 	rm -rf appdir/tmp/clr-debug-pipe*
-	sudo $(MYST) mkext2 appdir ext2fs
+	$(MYST) mkext2 appdir ext2fs
 	$(MYST) fssig --roothash ext2fs > roothash
 
 oelldb:

--- a/tests/dotnet-ubuntu/Makefile
+++ b/tests/dotnet-ubuntu/Makefile
@@ -15,8 +15,7 @@ appdir:
 	$(APPBUILDER) Dockerfile
 
 ext2fs: appdir
-	sudo $(MYST) mkext2 appdir ext2fs
-	sudo chown $(USER).$(USER) ext2fs
+	$(MYST) mkext2 appdir ext2fs
 	$(MYST) fssig --roothash ext2fs > roothash
 
 clean:

--- a/tests/ext2/crypt/Makefile
+++ b/tests/ext2/crypt/Makefile
@@ -58,7 +58,7 @@ OUTFILE=$(SUBOBJDIR)/outfile
 
 $(IMAGE):
 	mkdir -p $(SUBOBJDIR)
-	sudo $(MYST) mkext2 $(MKEXT2_OPTS) ext2dir $(IMAGE)
+	$(MYST) mkext2 $(MKEXT2_OPTS) ext2dir $(IMAGE)
 	$(MYST) fssig $(IMAGE) > $(OUTFILE)
 	@ grep root_hash= $(OUTFILE) | cut -d= -f 2 > $(ROOTHASH)
 

--- a/tests/ext2/plain/Makefile
+++ b/tests/ext2/plain/Makefile
@@ -33,13 +33,13 @@ EXT2FS_SIZE=134217728
 
 tests:
 	mkdir -p $(SUBOBJDIR)
-	sudo $(MYST) mkext2 --force --size=$(EXT2FS_SIZE) ext2dir $(EXT2FS)
+	$(MYST) mkext2 --force --size=$(EXT2FS_SIZE) ext2dir $(EXT2FS)
 	chown $(USER).$(USER) $(EXT2FS)
 	$(PREFIX) $(RUNTEST) $(PREFIX) $(SUBBINDIR)/ext2 $(EXT2FS)
 
 cachegrind:
 	mkdir -p $(SUBOBJDIR)
-	sudo $(MYST) mkext2 --force --size=$(EXT2FS_SIZE) ext2dir $(EXT2FS)
+	$(MYST) mkext2 --force --size=$(EXT2FS_SIZE) ext2dir $(EXT2FS)
 	chown $(USER).$(USER) $(EXT2FS)
 	$(CACHEGRIND_COMMAND) $(SUBBINDIR)/ext2 $(EXT2FS)
 

--- a/tests/ext2/verity/Makefile
+++ b/tests/ext2/verity/Makefile
@@ -61,7 +61,7 @@ image: $(IMAGE)
 
 $(IMAGE):
 	mkdir -p $(SUBOBJDIR)
-	sudo $(MYST) mkext2 $(MKEXT2_OPTS) ext2dir $(IMAGE)
+	$(MYST) mkext2 $(MKEXT2_OPTS) ext2dir $(IMAGE)
 	$(MYST) fssig $(IMAGE) > $(OUTFILE)
 	@ grep root_hash= $(OUTFILE) | cut -d= -f 2 > $(ROOTHASH)
 

--- a/tests/fs/Makefile
+++ b/tests/fs/Makefile
@@ -40,7 +40,7 @@ rootfs: appdir
 	$(MYST) mkcpio appdir rootfs
 
 ext2rootfs: appdir
-	sudo $(MYST) mkext2 --force appdir ext2rootfs
+	$(MYST) mkext2 --force appdir ext2rootfs
 
 appdir: $(SUBBINDIR)/fs fs.c
 	mkdir -p appdir/bin

--- a/tests/libc/Makefile
+++ b/tests/libc/Makefile
@@ -41,7 +41,7 @@ $(APPDIR)/bin/run: run.c
 	$(MUSL_GCC) -Wall -o $(APPDIR)/bin/run run.c
 
 $(ROOTFS): run.c
-	sudo $(MYST) mkext2 --force $(APPDIR) $(ROOTFS)
+	$(MYST) mkext2 --force $(APPDIR) $(ROOTFS)
 	chown $(USER).$(USER) $(ROOTFS)
 	truncate --size=-4096 $(ROOTFS)
 

--- a/tests/libcxx/Makefile
+++ b/tests/libcxx/Makefile
@@ -55,7 +55,7 @@ $(APPDIR):
 	# this call.
 
 $(ROOTFS): run.c
-	sudo $(MYST) mkext2 $(APPDIR) $(ROOTFS)
+	$(MYST) mkext2 $(APPDIR) $(ROOTFS)
 	# run with posix spawn
 
 $(ROOTHASH): run.c

--- a/tests/libcxx2/Makefile
+++ b/tests/libcxx2/Makefile
@@ -54,7 +54,7 @@ $(APPDIR):
 	# this call.
 
 $(ROOTFS): run.c
-	sudo $(MYST) mkext2 $(APPDIR) $(ROOTFS)
+	$(MYST) mkext2 $(APPDIR) $(ROOTFS)
 	# run with posix spawn
 
 $(ROOTHASH): run.c

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -47,7 +47,7 @@ HOSTFS=$(CURDIR)/hostfs
 all: ext2fs
 
 ext2fs: appdir
-	sudo $(MYST) mkext2 --force appdir ext2fs
+	$(MYST) mkext2 --force appdir ext2fs
 	sudo chown $(USER).$(USER) ext2fs
 	truncate --size=-4096 ext2fs
 

--- a/tests/myst/auto-mount/Makefile
+++ b/tests/myst/auto-mount/Makefile
@@ -28,7 +28,7 @@ rootfs: build ramfs
 	mkdir -p $(APPDIR)/ext2-target
 	mkdir -p $(APPDIR)/hostfs-target
 	$(MYST) mkcpio $(APPDIR) $(ROOTFS)
-	sudo $(MYST) mkext2 --force $(APPDIR) ext2rootfs
+	$(MYST) mkext2 --force $(APPDIR) ext2rootfs
 	$(MYST) fssig --roothash ext2rootfs > roothash
 
 ramfs:
@@ -40,7 +40,7 @@ ramfs:
 ext2fs:
 	mkdir -p $(EXT2FSDIR)
 	touch $(EXT2FSDIR)/ext2-file
-	sudo $(MYST) mkext2 --force --size=$(EXT2FS_SIZE) $(EXT2FSDIR) $(EXT2FS) 
+	$(MYST) mkext2 --force --size=$(EXT2FS_SIZE) $(EXT2FSDIR) $(EXT2FS) 
 	truncate --size=-4096 $(EXT2FS)
 
 hostfs:

--- a/tests/myst/exec-package-ext2/Makefile
+++ b/tests/myst/exec-package-ext2/Makefile
@@ -13,9 +13,8 @@ GROUP=$(shell id --group)
 all: $(PUBKEY)
 	mkdir -p $(APPDIR)/bin
 	$(MUSL_GCC) -Wall -o $(APPDIR)/bin/hello hello.c
-	sudo $(MYST) mkext2 --force --sign=$(PUBKEY):$(PRIVKEY) $(APPDIR) $(ROOTFS)
+	$(MYST) mkext2 --force --sign=$(PUBKEY):$(PRIVKEY) $(APPDIR) $(ROOTFS)
 	$(MYST) package --pubkey=$(PUBKEY) $(PRIVKEY) config.json
-	sudo chown -R $(USER).$(USER) myst
 
 $(PUBKEY): $(PRIVKEY)
 	openssl rsa -in $(PRIVKEY) -pubout -out $(PUBKEY)

--- a/tests/sockperf/Makefile
+++ b/tests/sockperf/Makefile
@@ -22,7 +22,7 @@ $(APPDIR):
 	# Then, replace this container name with the new name.
 
 $(ROOTFS): $(APPDIR)
-	sudo $(MYST) mkext2 $(APPDIR) $(ROOTFS)
+	$(MYST) mkext2 $(APPDIR) $(ROOTFS)
 
 $(ROOTHASH): $(ROOTFS)
 	mkdir -p $(SUBOBJDIR)

--- a/tools/myst/host/host.c
+++ b/tools/myst/host/host.c
@@ -384,7 +384,7 @@ Where <action> is one of:\n\
 \n\
 "
 
-static int _main(int argc, const char* argv[], const char* envp[])
+int main(int argc, const char* argv[], const char* envp[])
 {
     if (set_program_file(argv[0]) == NULL)
     {
@@ -462,36 +462,4 @@ static int _main(int argc, const char* argv[], const char* envp[])
         fprintf(stderr, USAGE, argv[0]);
         return 1;
     }
-}
-
-int main(int argc, const char* argv[], const char* envp[])
-{
-#ifdef MYST_ENABLE_GCOV
-    const char* uid_str = getenv("SUDO_UID");
-    const char* gid_str = getenv("SUDO_GID");
-    uid_t uid = UINT_MAX;
-    gid_t gid = UINT_MAX;
-
-    /* if running as SUDO, then save the uid and gid */
-    if (uid_str && gid_str)
-    {
-        uid = atoi(uid_str);
-        gid = atoi(gid_str);
-    }
-#endif
-
-    int ec = _main(argc, argv, envp);
-
-#ifdef MYST_ENABLE_GCOV
-    /* if running as SUDO, then restore uid and gid for gcov */
-    if (uid_str && gid_str)
-    {
-        setgid(gid);
-        setegid(gid);
-        setuid(uid);
-        seteuid(uid);
-    }
-#endif
-
-    return ec;
 }

--- a/tools/myst/host/mkext2/mkext2.c
+++ b/tools/myst/host/mkext2/mkext2.c
@@ -208,33 +208,12 @@ static void _create_ext2_image(
     const char* image,
     size_t size)
 {
-    char loop[PATH_MAX];
-    char mntdir[] = "/tmp/mystXXXXXX";
-
     /* create a zero-filled image with holes */
     _create_zero_filled_image(image, size);
 
-    /* format the ext2 file system */
-    _systemf("/sbin/mke2fs -q %s", image);
-
-    /* associate the image with a loopback device */
-    _execf(loop, sizeof(loop), "/sbin/losetup --show -f %s", image);
-
-    /* create the mount directory */
-    if (!mkdtemp(mntdir))
-        _err("failed to create temporary directory");
-
-    /* mount the ext2 image */
-    _systemf("/bin/mount %s %s", loop, mntdir);
-
-    /* copy the directory into the mounted ext2 file system */
-    _systemf("/bin/tar c -C %s -f - .|/bin/tar x -C %s -f -", dirname, mntdir);
-
-    /* unmount the ext2 image */
-    _systemf("/bin/umount %s", mntdir);
-
-    /* detach the loopback device */
-    _systemf("/sbin/losetup -d %s", loop);
+    // format as an EXT2 image and copy the contents of the given directory
+    // into the root directory of the image
+    _systemf("/sbin/mke2fs -q %s -d %s", image, dirname);
 }
 
 static void _create_luks_image(


### PR DESCRIPTION
This PR eliminates the need to use sudo when creating ext2 file system images with ``myst mkext2``.