### PR TITLE
Paulcallen/mount buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,8 @@ tests/syscall_exception/appdir/
 tests/polleventfd/appdir/
 tests/mutex/appdir/
 tests/eventfd/appdir/
+tests/myst/auto-mount/ext2rootfs
+tests/myst/auto-mount/roothash
+tests/futex/futex
+tests/ext2/plain/test_read_write
+tests/dotnet-proc-maps/stdout.txt

--- a/doc/design/mount-config-design.md
+++ b/doc/design/mount-config-design.md
@@ -58,7 +58,7 @@ mount: [
 
 | Name | Value |
 | -- | -- |
-| target | This is the target mount point within the TEE. |
+| target | This is the target mount point within the TEE. This mount point path needs to already exist in the TEE filesystem. |
 | type | "ext2", "hostfs", "ramfs" |
 | flags | Optional field that specified flags like "ro", "rw". At this time no flags are supported. |
 | publicKey | For ext2 filesystems this is the public key used to validate the signing key of the ext2 filesystem when it is mounted. This configuration is not currently supported. |
@@ -85,7 +85,7 @@ The following new command line argument will be added:
 | Name | Value |
 | -- | -- |
 | source | This is the source location of the mount in the insecure host. |
-| target | This is the mount point within the TEE. There needs to be an associated target mount configuration specified at signing for this location otherwise the mount will fail. |
+| target | This is the mount point within the TEE. There needs to be an associated target mount configuration specified at signing for this location otherwise the mount will fail. This mount point path needs to already exist in the TEE filesystem. |
 | | |
 
 The target location is part of the TEE measurement which specifies that the target directory is being accessed from an insecure source.
@@ -103,7 +103,6 @@ Other than the specification of the rootfs during launch there is no automatic w
 ## Design
 
 During the signing of the application through sign-sgx or package-sgx commands via the myst command line tool the TEE mount configuration from the json configuration file is added to the signed application image and cannot be changed.
-
 
 On a host machine or container the application will be run either as an application in a directory with signed binaries, or via the self contained package binary.
 The new mount commandline parameter will be added to whatever command was used before, with one mount parameter option per mount point.

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -9,12 +9,6 @@
 #include <myst/kernel.h>
 #include <myst/types.h>
 
-typedef struct _myst_mount_mapping
-{
-    char** mounts; /* array of source=target */
-    size_t mounts_count;
-} myst_mount_mapping_t;
-
 typedef struct myst_options
 {
     bool trace_errors;
@@ -28,7 +22,6 @@ typedef struct myst_options
     char rootfs[PATH_MAX];
 
     myst_host_enc_uid_gid_mappings host_enc_uid_gid_mappings;
-    myst_mount_mapping_t mount_mapping;
 } myst_options_t;
 
 extern myst_options_t __options;

--- a/tools/myst/common.c
+++ b/tools/myst/common.c
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "shared.h"
+
+#include <myst/args.h>
 
 int myst_expand_size_string_to_ulong(const char* size_string, size_t* size)
 {
@@ -40,17 +41,19 @@ int myst_expand_size_string_to_ulong(const char* size_string, size_t* size)
 
 bool myst_merge_mount_mapping_and_config(
     myst_mounts_config_t* mounts,
-    myst_mount_mapping_t* mount_mapping)
+    myst_args_t* mount_mapping)
 {
     bool ret = false;
 
-    for (size_t i = 0; i < mount_mapping->mounts_count; i++)
+    for (size_t i = 0; i < mount_mapping->size; i++)
     {
         char* source;
         char* target;
         bool found = false;
-        source = strtok(mount_mapping->mounts[i], "=");
-        target = strtok(NULL, "");
+        char* save;
+
+        source = strtok_r((char*)(mount_mapping->data[i]), "=", &save);
+        target = strtok_r(NULL, "", &save);
         if (target)
         {
             for (size_t j = 0; j < mounts->mounts_count; j++)

--- a/tools/myst/host/exec.h
+++ b/tools/myst/host/exec.h
@@ -4,6 +4,7 @@
 #ifndef _MYST_HOST_EXEC_H
 #define _MYST_HOST_EXEC_H
 
+#include <myst/args.h>
 #include <myst/options.h>
 
 int exec_action(int argc, const char* argv[], const char* envp[]);
@@ -14,6 +15,7 @@ int exec_launch_enclave(
     uint32_t flags,
     const char* argv[],
     const char* envp[],
+    const myst_args_t* mount_mappings,
     struct myst_options* options);
 
 #endif /* _MYST_HOST_EXEC_H */

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -13,6 +13,7 @@
 #include <sys/user.h>
 #include <unistd.h>
 
+#include <myst/args.h>
 #include <myst/elf.h>
 #include <myst/getopt.h>
 #include <myst/strings.h>
@@ -544,6 +545,7 @@ int _exec_package(
     char* unpack_dir = NULL;
     int ret = -1;
     const char** exec_args = NULL;
+    myst_args_t mount_mappings = {0};
 
     /* Get options */
     {
@@ -551,7 +553,7 @@ int _exec_package(
         cli_get_mapping_opts(&argc, argv, &options.host_enc_uid_gid_mappings);
 
         // retrieve mount mapping options
-        cli_get_mount_mapping_opts(&argc, argv, &options.mount_mapping);
+        cli_get_mount_mapping_opts(&argc, argv, &mount_mappings);
 
         /* Get --trace-syscalls option */
         if (cli_getopt(&argc, argv, "--trace-syscalls", NULL) == 0 ||
@@ -828,7 +830,7 @@ int _exec_package(
     }
 
     ret = exec_launch_enclave(
-        scratch_path, type, flags, exec_args, envp, &options);
+        scratch_path, type, flags, exec_args, envp, &mount_mappings, &options);
     if (ret != 0)
     {
         fprintf(stderr, "Enclave %s returned %d\n", scratch_path, ret);
@@ -836,7 +838,7 @@ int _exec_package(
     }
 
 done:
-    free_mount_mapping_opts(&options.mount_mapping);
+    myst_args_release(&mount_mappings);
 
     if (unpack_dir)
         remove_recursive(unpack_dir);

--- a/tools/myst/host/utils.c
+++ b/tools/myst/host/utils.c
@@ -7,14 +7,16 @@
 #include <libgen.h>
 #include <limits.h>
 #include <malloc.h>
-#include <myst/getopt.h>
-#include <myst/strings.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
+
+#include <myst/args.h>
+#include <myst/getopt.h>
+#include <myst/strings.h>
 
 #include "utils.h"
 
@@ -301,7 +303,7 @@ int cli_get_mapping_opts(
 int cli_get_mount_mapping_opts(
     int* argc,
     const char* argv[],
-    myst_mount_mapping_t* mappings)
+    myst_args_t* mounts_buff)
 {
     bool found;
 
@@ -312,40 +314,10 @@ int cli_get_mount_mapping_opts(
         found = false;
         if (cli_getopt(argc, argv, "--mount", &arg) == 0)
         {
-            if (mappings->mounts_count == 0)
-            {
-                mappings->mounts = calloc(1, sizeof(char*));
-                if (mappings->mounts == NULL)
-                    _err("Out of memory\n");
-            }
-            else
-            {
-                char** tmp = reallocarray(
-                    mappings->mounts,
-                    mappings->mounts_count + 1,
-                    sizeof(char*));
-                if (tmp == NULL)
-                    _err("Out of memory\n");
-                mappings->mounts = tmp;
-            }
-            mappings->mounts[mappings->mounts_count] = strdup(arg);
-            mappings->mounts_count++;
+            myst_args_append1(mounts_buff, arg);
             found = 1;
         }
     } while (found);
 
     return 0;
-}
-
-void free_mount_mapping_opts(myst_mount_mapping_t* mappings)
-{
-    if (mappings->mounts)
-    {
-        int i;
-        for (i = 0; i < mappings->mounts_count; i++)
-        {
-            free(mappings->mounts[i]);
-        }
-        free(mappings->mounts);
-    }
 }

--- a/tools/myst/host/utils.h
+++ b/tools/myst/host/utils.h
@@ -4,6 +4,7 @@
 #ifndef _HOST_MYST_UTILS_H
 #define _HOST_MYST_UTILS_H
 
+#include <myst/args.h>
 #include <myst/defs.h>
 #include <myst/kernel.h>
 #include <myst/options.h>
@@ -46,8 +47,7 @@ int cli_get_mapping_opts(
 int cli_get_mount_mapping_opts(
     int* argc,
     const char* argv[],
-    myst_mount_mapping_t* mappings);
-void free_mount_mapping_opts(myst_mount_mapping_t* mappings);
+    myst_args_t* mappings);
 
 long myst_add_symbol_file_by_path(
     const char* path,

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -78,6 +78,8 @@ enclave
             size_t args_size,
             [in, size=env_size] const void* env,
             size_t env_size,
+            [in, size=mount_mappings_size] const void* mount_mappings,
+            size_t mount_mappings_size,
             uint64_t event,
             pid_t target_tid);
 

--- a/tools/myst/shared.h
+++ b/tools/myst/shared.h
@@ -4,6 +4,7 @@
 #ifndef _MYST_MYST_SHARED_H
 #define _MYST_MYST_SHARED_H
 
+#include <myst/args.h>
 #include <myst/kernel.h>
 #include <myst/options.h>
 #include <myst/regions.h>
@@ -11,7 +12,7 @@
 int myst_expand_size_string_to_ulong(const char* size_string, size_t* size);
 bool myst_merge_mount_mapping_and_config(
     myst_mounts_config_t* mounts,
-    myst_mount_mapping_t* mount_mapping);
+    myst_args_t* mount_mapping);
 bool myst_validate_mount_config(myst_mounts_config_t* mounts);
 
 #endif /* _MYST_MYST_SHARED_H */


### PR DESCRIPTION
packages up the command line arguments for mount mapping into a single buffer to marshal into the enclave.