### PR TITLE
Fix memleak for auto-mounts

### DIFF
--- a/include/myst/mount.h
+++ b/include/myst/mount.h
@@ -8,10 +8,17 @@
 #include <myst/fs.h>
 
 /* Mount a file system onto a target path */
-int myst_mount(myst_fs_t* fs, const char* source, const char* target);
+int myst_mount(
+    myst_fs_t* fs,
+    const char* source,
+    const char* target,
+    bool is_auto);
 
 /* Unmount the file system that is mounted on target */
 int myst_umount(const char* target);
+
+/* Unmount all auto-mounted file systems */
+int myst_teardown_auto_mounts();
 
 /* Use mounter to resolve this path to a target path */
 int myst_mount_resolve(const char* path, char suffix[PATH_MAX], myst_fs_t** fs);

--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -249,7 +249,8 @@ long myst_syscall_mount(
     const char* target,
     const char* filesystemtype,
     unsigned long mountflags,
-    const void* data);
+    const void* data,
+    bool is_auto);
 
 long myst_syscall_umount2(const char* target, int flags);
 long myst_syscall_kill(int pid, int sig);

--- a/kernel/devfs.c
+++ b/kernel/devfs.c
@@ -102,7 +102,7 @@ int devfs_setup()
         ERAISE(-EINVAL);
     }
 
-    if (myst_mount(_devfs, "/", "/dev") != 0)
+    if (myst_mount(_devfs, "/", "/dev", false) != 0)
     {
         myst_eprintf("cannot mount dev file system\n");
         ERAISE(-EINVAL);

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -78,7 +78,8 @@ static int _process_mount_configuration(myst_mounts_config_t* mounts)
             mounts->mounts[i].target,
             mounts->mounts[i].fs_type,
             0,
-            NULL);
+            NULL,
+            true);
         if (ret != 0)
         {
             myst_eprintf(
@@ -255,7 +256,7 @@ static int _init_tmpfs(const char* target, myst_fs_t** fs_out)
         ERAISE(-EINVAL);
     }
 
-    if (myst_mount(fs, "/", target) != 0)
+    if (myst_mount(fs, "/", target, false) != 0)
     {
         myst_eprintf("cannot mount %s\n", target);
         ERAISE(-EINVAL);
@@ -305,7 +306,7 @@ static int _setup_ramfs(void)
         ERAISE(-EINVAL);
     }
 
-    if (myst_mount(_fs, "/", "/") != 0)
+    if (myst_mount(_fs, "/", "/", false) != 0)
     {
         myst_eprintf("cannot mount root file system\n");
         ERAISE(-EINVAL);
@@ -331,7 +332,7 @@ static int _setup_ext2(const char* rootfs, char* err, size_t err_size)
         ERAISE(-EINVAL);
     }
 
-    if (myst_mount(_fs, rootfs, "/") != 0)
+    if (myst_mount(_fs, rootfs, "/", false) != 0)
     {
         snprintf(err, err_size, "cannot mount EXT2 rootfs: %s", rootfs);
         ERAISE(-EINVAL);
@@ -359,7 +360,7 @@ static int _setup_hostfs(const char* rootfs, char* err, size_t err_size)
         ERAISE(-EINVAL);
     }
 
-    if (myst_mount(_fs, rootfs, "/") != 0)
+    if (myst_mount(_fs, rootfs, "/", false) != 0)
     {
         snprintf(err, err_size, "cannot mount HOSTFS rootfs: %s", rootfs);
         ERAISE(-EINVAL);
@@ -904,6 +905,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
 #ifdef USE_TMPFS
     _teardown_tmpfs();
 #endif
+
+    /* Tear down all auto-mounted file systems */
+    myst_teardown_auto_mounts();
 
     /* Tear down the proc file system */
     procfs_teardown();

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -40,7 +40,7 @@ int procfs_setup()
         ERAISE(-EINVAL);
     }
 
-    if (myst_mount(_procfs, "/", "/proc") != 0)
+    if (myst_mount(_procfs, "/", "/proc", false) != 0)
     {
         myst_eprintf("cannot mount proc file system\n");
         ERAISE(-EINVAL);

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -4670,7 +4670,7 @@ static long _syscall(void* args_)
                 data);
 
             ret = myst_syscall_mount(
-                source, target, filesystemtype, mountflags, data);
+                source, target, filesystemtype, mountflags, data, false);
 
             BREAK(_return(n, ret));
         }


### PR DESCRIPTION
This is to fix #418 
It seems the easiest way to find which fs should be automatically teared down is by adding a `is_auto` flag to the `_mount_table`.