### PR TITLE
Fix crash caused by tkill of current pid

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -114,6 +114,7 @@ DIRS += mprotect
 DIRS += eventfd
 DIRS += polleventfd
 DIRS += dotnet-sos
+DIRS += tkillself
 
 .PHONY: $(DIRS)
 

--- a/tests/callonce/Makefile
+++ b/tests/callonce/Makefile
@@ -6,9 +6,11 @@ APPDIR = appdir
 
 all: rootfs
 
-rootfs:
-	$(APPBUILDER) Dockerfile
+rootfs: appdir
 	$(MYST) mkcpio $(APPDIR) rootfs
+
+appdir:
+	$(APPBUILDER) Dockerfile
 
 tests:
 	$(RUNTEST) $(MYST_EXEC) rootfs /app/call-once $(OPTS)

--- a/tests/tkillself/Makefile
+++ b/tests/tkillself/Makefile
@@ -1,0 +1,28 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs: tkillself.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/tkillself tkillself.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+tests: all
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/tkillself $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/tkillself/tkillself.c
+++ b/tests/tkillself/tkillself.c
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <signal.h>
+#include <syscall.h>
+#include <unistd.h>
+
+int main(int argc, const char* argv[])
+{
+    syscall(SYS_tkill, getpid(), SIGABRT);
+    return 0;
+}


### PR DESCRIPTION
This PR fixes a crash that occurred when a process sends ``tkill-SIGABORT`` to itself. 

The bug occurred when unmapping the **CRT data** (which contained the current fsbase). Then ``munmap`` called ``mprotect`` (to remove read rights on the memory) so the next call to obtain the first word of the fsbase got a segmentation fault (because the memory was no longer readable). The resolution was to restore the kernel's fsbase before unmapping the CRT data.

Also added a regression test for this case.

```
./tests/tkillself
```