### PR TITLE
Workaround for pipeline errors cause by different OE versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ include $(TOP)/rules.mak
 distclean: clean
 	rm -rf $(TOP)/third_party/musl/crt/musl
 	sudo rm -rf $(TOP)/build
+	git submodule deinit --all
 
 ##==============================================================================
 ##


### PR DESCRIPTION
Please try this one line fix to workaround errors in the pipeline caused by different versions of OE.