### PR TITLE
Pipefix july

### DIFF
--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -26,7 +26,7 @@ jobs:
   - job: BuildAndTest
     displayName: 'Building and Testing'
     timeoutInMinutes: 60
-    pool: '1804DC4CCagentpool'
+    pool: '1804DC4v2agentpool'
 
     steps:
       # perform cleanup before starting pipeline
@@ -67,7 +67,7 @@ jobs:
           make tests -C $(Build.SourcesDirectory)/solutions
         displayName: 'run solution tests'
         continueOnError: true
-        enabled: true
+        enabled: false
         workingDirectory: $(Build.SourcesDirectory)
         env:
           # by default sql solution test will run on US EAST DB Node

--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -26,7 +26,7 @@ jobs:
   - job: BuildAndTest
     displayName: 'Building and Testing'
     timeoutInMinutes: 60
-    pool: '1804DC4v2agentpool'
+    pool: '1804DC4CCagentpool'
 
     steps:
       # perform cleanup before starting pipeline
@@ -67,7 +67,7 @@ jobs:
           make tests -C $(Build.SourcesDirectory)/solutions
         displayName: 'run solution tests'
         continueOnError: true
-        enabled: false
+        enabled: true
         workingDirectory: $(Build.SourcesDirectory)
         env:
           # by default sql solution test will run on US EAST DB Node

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -196,7 +196,7 @@ struct myst_thread
         posix_sigaction_t* sigactions;
 
         /* The condition we were waiting on a futex */
-        void* cond_wait;
+        _Atomic bool waiting_on_event;
 
         /* The mask of blocked signals */
         uint64_t mask;

--- a/kernel/cond.c
+++ b/kernel/cond.c
@@ -65,8 +65,7 @@ int myst_cond_timedwait(
         /* Add the self thread to the end of the wait queue */
         myst_thread_queue_push_back(&c->queue, self);
 
-        // assert(self->signal.cond_wait == NULL);
-        self->signal.cond_wait = c;
+        self->signal.waiting_on_event = true;
         if (c->queue.front != c->queue.back &&
             c->queue.front->status == MYST_ZOMBIE)
         {
@@ -117,7 +116,7 @@ int myst_cond_timedwait(
                 break;
             }
         }
-        self->signal.cond_wait = NULL;
+        self->signal.waiting_on_event = false;
     }
 
     myst_spin_unlock(&c->lock);
@@ -262,7 +261,7 @@ int myst_cond_requeue(
         for (myst_thread_t* p = requeues.front; p; p = next)
         {
             next = p->qnext;
-            p->signal.cond_wait = c2;
+            p->signal.waiting_on_event = true;
             myst_thread_queue_push_back(&c2->queue, p);
         }
     }

--- a/kernel/cond.c
+++ b/kernel/cond.c
@@ -65,7 +65,6 @@ int myst_cond_timedwait(
         /* Add the self thread to the end of the wait queue */
         myst_thread_queue_push_back(&c->queue, self);
 
-        self->signal.waiting_on_event = true;
         if (c->queue.front != c->queue.back &&
             c->queue.front->status == MYST_ZOMBIE)
         {
@@ -83,6 +82,7 @@ int myst_cond_timedwait(
         {
             myst_spin_unlock(&c->lock);
             {
+                self->signal.waiting_on_event = true;
                 if (waiter)
                 {
                     ret = (int)myst_tcall_wake_wait(
@@ -94,6 +94,7 @@ int myst_cond_timedwait(
                 {
                     ret = (int)myst_tcall_wait(self->event, timeout);
                 }
+                self->signal.waiting_on_event = false;
             }
             myst_spin_lock(&c->lock);
 
@@ -116,7 +117,6 @@ int myst_cond_timedwait(
                 break;
             }
         }
-        self->signal.waiting_on_event = false;
     }
 
     myst_spin_unlock(&c->lock);

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -98,8 +98,10 @@ int myst_mutex_lock(myst_mutex_t* mutex)
         myst_spin_unlock(&m->lock);
 
         /* Ask host to wait for an event on this thread */
+        self->signal.waiting_on_event = true;
         if ((r = myst_tcall_wait(self->event, NULL)) != 0)
             myst_panic("myst_tcall_wait(): %ld: %d", r, *(int*)self->event);
+        self->signal.waiting_on_event = false;
     }
 
     /* Unreachable! */

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -153,7 +153,6 @@ static long _default_signal_handler(unsigned signum)
         if (process_thread->signal.waiting_on_event)
         {
             myst_tcall_wake(process_thread->event);
-            process_thread->signal.waiting_on_event = false;
         }
     }
     thread->exit_status = 0;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1220,7 +1220,6 @@ size_t myst_kill_thread_group()
             if (t->signal.waiting_on_event)
             {
                 myst_tcall_wake(t->event);
-                t->signal.waiting_on_event = false;
             }
 
             myst_spin_lock(process->thread_lock);
@@ -1260,6 +1259,9 @@ size_t myst_kill_thread_group()
 
         if (t == NULL)
             break;
+
+        if (t->signal.waiting_on_event)
+            myst_tcall_wake(t->event);
 
         myst_sleep_msec(1);
     }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -98,7 +98,7 @@ DIRS += sockperf
 endif
 DIRS += clock
 DIRS += pollpipe2
-#DIRS += dotnet-proc-maps
+DIRS += dotnet-proc-maps
 DIRS += dotnet-ubuntu
 DIRS += openmp
 endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -115,6 +115,7 @@ DIRS += eventfd
 DIRS += polleventfd
 DIRS += dotnet-sos
 DIRS += tkillself
+DIRS += thread_abort
 
 .PHONY: $(DIRS)
 

--- a/tests/dotnet-proc-maps/Makefile
+++ b/tests/dotnet-proc-maps/Makefile
@@ -11,7 +11,7 @@ endif
 all: rootfs
 
 tests:
-	$(RUNTEST) ./exec.sh $(MYST_EXEC) $(OPTS) --memory-size=1024m rootfs /app/HelloWorld
+	$(RUNTEST) ./exec.sh $(MYST_EXEC) $(OPTS) --app-config-path config.json rootfs /app/HelloWorld
 	@ echo "=== passed test (dotnet-proc-maps)"
 
 gdb: rootfs

--- a/tests/dotnet-proc-maps/config.json
+++ b/tests/dotnet-proc-maps/config.json
@@ -1,0 +1,23 @@
+{
+    // OpenEnclave specific values
+
+    // Whether we are running myst+OE+app in debug mode
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+
+    // The heap size of the user application. Increase this setting if your app experienced OOM.
+    "MemorySize": "1g",
+    // The path to the entry point application in rootfs
+    "ApplicationPath": "/app/HelloWorld",
+    // The parameters to the entry point application
+    "ApplicationParameters": [],
+    // Whether we allow "ApplicationParameters" to be overridden by command line options of "myst exec"
+    "HostApplicationParameters": false,
+    // The environment variables accessible inside the enclave.
+    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0"],
+    // The environment variables we get from the host
+    "HostEnvironmentVariables": []
+}

--- a/tests/thread_abort/Makefile
+++ b/tests/thread_abort/Makefile
@@ -1,0 +1,27 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC -g
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs:
+	mkdir -p $(APPDIR)
+	$(CC) $(CFLAGS) -o $(APPDIR)/main main.c -lpthread
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+tests: all
+	$(RUNTEST) $(MYST_EXEC) rootfs /main $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/thread_abort/main.c
+++ b/tests/thread_abort/main.c
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void* thread_func1(void* arg)
+{
+    printf("In child thread: expecting assertion failure ...\n");
+    assert(0);
+    // Unreachable
+    return NULL;
+}
+
+void test_child_abort()
+{
+    pthread_t t;
+
+    pthread_create(&t, NULL, thread_func1, NULL);
+
+    printf("In main thread: before sleep...\n");
+    sleep(3);
+    printf("In main thread: after sleep. We should not be here...\n");
+    assert(0);
+}
+
+int main()
+{
+    test_child_abort();
+    return 0;
+}


### PR DESCRIPTION
This PR fixes hangs in the event of shutdown for two cases:

* dotnet-proc-maps
* libcxx when a child thread fails an assertion

In both cases, there were thread waiting for a futex with infinite timeout, thus caused the process not able to shutdown.  This PR attempts to wake up the futex while sending the kill signal to the thread.