### PR TITLE
Return ENOSYS on membarrier syscall

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -5587,10 +5587,12 @@ static long _syscall(void* args_)
             int flags = (int)x2;
 
             _strace(n, "cmd=%d flags=%d", cmd, flags);
-
-            myst_barrier();
-
-            BREAK(_return(n, 0));
+            /* membarrier syscall relies on inter-processor-interrupt and the
+             * untrusted privileged SW layer such as the hypervisor or bare
+             * metal OS to sychronize code execution across CPU cores. Not
+             * supported.
+             */
+            BREAK(_return(n, -ENOSYS));
         }
         case SYS_mlock2:
             break;


### PR DESCRIPTION
Membarrier syscall relies on inter-processor-interrupt and the untrusted privileged SW layer such as the hypervisor or bare metal OS to synchronize code execution across CPU cores. Existing implementation executes a compiler barrier and returns success without triggering cross-CPU synchronization, which might cause unexpected result due to synchronization failure. Membarrier syscall is not supported in all Linux kernel versions. Many libs and applications fallback to alternative synchronization mechanisms after detecting that the syscall is not supported.