### PR TITLE
Support mmap() request with preferred address

### DIFF
--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -257,7 +257,12 @@ void* myst_mmap(
         return addr;
     }
 
-    int tflags = MYST_MAP_ANONYMOUS | MYST_MAP_PRIVATE;
+    int tflags = 0;
+
+    if (flags & MYST_MAP_FIXED)
+        tflags = MYST_MAP_ANONYMOUS | MYST_MAP_PRIVATE | MYST_MAP_FIXED;
+    else
+        tflags = MYST_MAP_ANONYMOUS | MYST_MAP_PRIVATE;
 
     if ((r = myst_mman_mmap(&_mman, addr, length, prot, tflags, &ptr)) < 0)
         return (void*)(long)r;

--- a/tests/mman/test_mman.c
+++ b/tests/mman/test_mman.c
@@ -607,6 +607,40 @@ void test_mman_6()
 }
 
 /*
+** test_mman_7()
+**
+**     mmap with preferred address, without setting MAP_FIXED
+**
+*/
+#define PREFERRED_ADDR 0x400000
+void test_mman_7()
+{
+    myst_mman_t h;
+    size_t i;
+    const size_t n = 8;
+    const size_t npages = 1024;
+    const size_t size = npages * PAGE_SIZE;
+
+    assert(_init_mman(&h, size) == 0);
+
+    void* ptr;
+
+    /* Map N pages */
+    if (!(ptr = _mman_mmap(&h, (void*)PREFERRED_ADDR, n * PAGE_SIZE)))
+        assert(0);
+
+    /* Unmap 8 pages, 1 page at a time */
+    for (i = 0; i < n; i++)
+    {
+        void* p = (uint8_t*)ptr + (i * PAGE_SIZE);
+        assert(_mman_unmap(&h, p, PAGE_SIZE) == 0);
+    }
+
+    _free_mman(&h);
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+/*
 ** test_remap_1()
 **
 **     Test remap that enlarges the allocation. Then test remap that shrinks
@@ -1199,6 +1233,7 @@ void test_mman(void)
     test_mman_4();
     test_mman_5();
     test_mman_6();
+    test_mman_7();
     test_remap_1();
     test_remap_2();
     test_remap_3();

--- a/tests/mman_err/mman_err.c
+++ b/tests/mman_err/mman_err.c
@@ -9,12 +9,13 @@
 void test_unsupported_fixed_addr_mapping(void)
 {
     const int prot = PROT_READ | PROT_WRITE;
-    const int flags = MAP_ANONYMOUS | MAP_PRIVATE;
+    int flags = MAP_ANONYMOUS | MAP_PRIVATE;
 
     void* ptr = mmap(NULL, 4096, prot, flags, -1, 0);
     assert(ptr != (void*)-1);
     munmap(ptr, 4096);
 
+    flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED;
     ptr = mmap(ptr, 4096, prot, flags, -1, 0);
     assert(ptr == (void*)-1);
 }


### PR DESCRIPTION
For mmap(addr, ...) request with non-zero addr, if the requested mapping is not part of an existing mapping, and MAP_FIXED flag is not set, treat the request as if addr=0.