### PR TITLE
Invoke atexit functions before fini functions

### DIFF
--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -679,6 +679,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     if (__options.have_syscall_instruction)
         myst_set_gsbase(myst_get_fsbase());
 
+    /* call global constructors within the kernel */
     myst_call_init_functions();
 
     /* Check arguments */
@@ -919,6 +920,10 @@ int myst_enter_kernel(myst_kernel_args_t* args)
 
     /* call functions installed with myst_atexit() */
     myst_call_atexit_functions();
+
+    // Call global destructors within the kernel.
+    // GCOV uses fini functions to generates .gcda files on exit.
+    myst_call_fini_functions();
 
     /* check for memory leaks */
     if (args->memcheck)

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -3947,15 +3947,7 @@ static long _syscall(void* args_)
             /* the kstack is freed after the long-jump below */
             thread->kstack = args->kstack;
 
-            if (thread == __myst_main_thread)
-            {
-                // execute fini functions with the CRT fsbase since only
-                // gcov uses them and gcov calls into CRT.
-                myst_set_fsbase(crt_td);
-                myst_call_fini_functions();
-                myst_set_fsbase(target_td);
-            }
-
+            /* jump back to myst_enter_kernel() */
             myst_longjmp(&thread->jmpbuf, 1);
 
             /* unreachable */


### PR DESCRIPTION
This PR fixes the wrong ordering of ``atexit`` and ``fini`` functions, where the ``fini`` functions should be called last.