### PR TITLE
Optionally support memcheck on process mappings

### DIFF
--- a/tests/getcwd/Makefile
+++ b/tests/getcwd/Makefile
@@ -19,7 +19,7 @@ OPTS = --strace
 endif
 
 tests: all
-	$(RUNTEST) $(MYST_EXEC) rootfs /bin/getcwd $(OPTS)
+	$(RUNTEST) $(MYST_EXEC) --memcheck rootfs /bin/getcwd $(OPTS)
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/getcwd/Makefile
+++ b/tests/getcwd/Makefile
@@ -19,7 +19,7 @@ OPTS = --strace
 endif
 
 tests: all
-	$(RUNTEST) $(MYST_EXEC) --memcheck rootfs /bin/getcwd $(OPTS)
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/getcwd $(OPTS)
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst


### PR DESCRIPTION
Process mappings are excluded from the debug-malloc leak checker (memcheck) by default. Provide a way to enable leaks checks on these memory objects.