### PR TITLE
Define MYST_PROCESS_INIT_STACK_SIZE

### DIFF
--- a/include/myst/process.h
+++ b/include/myst/process.h
@@ -11,6 +11,19 @@
 #define MYST_DEFAULT_UMASK (S_IWGRP | S_IWOTH)
 #define MYST_DEFAULT_PGID (pid_t)100
 
+// ATTN: Small stack size for the primary thread of a process might not work
+// for certain apps, especially when on-demand stack growth is not supported
+// yet
+/* .NET runtime sets the default minimum stack size for MUSL to 1536 * 1024, if
+ *  env. variable COMPlus_DefaultStackSize is not present or set to other value.
+ *  For MUSL, the .NET runtime also probes the stack limit of the primary thread
+ *  using _alloca(min_stack_size) and writing to a stack variable on top of the
+ *  stack, during CoreCLR init. Set the process stack size as 1536 * 1024 plus
+ *  32K reserves
+ */
+#define MYST_PROCESS_INIT_STACK_SIZE (1568 * 1024);
+#define MYST_PROCESS_MAX_STACK_SIZE (1568 * 1024);
+
 MYST_INLINE pid_t myst_getsid(void)
 {
     return myst_thread_self()->sid;

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -825,18 +825,7 @@ int myst_exec(
     int ret = 0;
     void* stack = NULL;
     void* sp = NULL;
-    // ATTN: Small stack size for the primary thread of a process might not work
-    // for certain apps, especially when on-demand stack growth is not supported
-    // yet
-    /* .Net runtime set the default minimum stack size for MUSL to 1536 * 1024,
-     *  if env. variable COMPlus_DefaultStackSize is not present or set to other
-     *  value. For MUSL, it also probes the stack limit of the primary thread
-     *  using _alloca(min_stack_size) and writing to a stack variable on top of
-     *  the stack, during CoreCLR init. Set the default stack size as 1536 *
-     *  1024 plus 8 pages reserves for kernel and earlier stack frames
-     */
-    const size_t stack_size = 392 * PAGE_SIZE;
-    // const size_t stack_size = 64 * PAGE_SIZE;
+    const size_t stack_size = MYST_PROCESS_INIT_STACK_SIZE;
     void* crt_data = NULL;
     const Elf64_Ehdr* ehdr = NULL;
     const Elf64_Phdr* phdr = NULL;


### PR DESCRIPTION
Current implementation sets the stack size of a process' main thread in `kernel/exec.c`. The stack size value is not visible in other files. Adding the definition to make the value usable in other code, for example, the pending RLIMIT syscall implementation (PR #512)