### PR TITLE
Optimize kstack usage

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -48,10 +48,6 @@ typedef struct myst_kernel_args
     const void* image_data;
     size_t image_size;
 
-    /* the region that contains the kernel stacks */
-    const void* kernel_stacks_data;
-    size_t kernel_stacks_size;
-
     /* The loaded kernel ELF image (ELF header start here) */
     const void* kernel_data;
     size_t kernel_size;

--- a/include/myst/regions.h
+++ b/include/myst/regions.h
@@ -15,7 +15,6 @@
 
 /* memory region identifiers */
 #define MYST_REGION_CONFIG "config"
-#define MYST_REGION_KERNEL_STACKS "kernel.stacks"
 #define MYST_REGION_KERNEL "kernel"
 #define MYST_REGION_KERNEL_RELOC "kernel.reloc"
 #define MYST_REGION_KERNEL_SYMTAB "kernel.symtab" /* .symtab section */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -747,9 +747,6 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         }
     }
 
-    /* initialize the kernel stacks free list */
-    myst_init_kstacks();
-
     /* Setup the memory manager */
     if (myst_setup_mman(args->mman_data, args->mman_size) != 0)
     {

--- a/tools/myst/kargs.c
+++ b/tools/myst/kargs.c
@@ -75,15 +75,6 @@ int init_kernel_args(
     if (!args || !argv || !envp || !cwd || !regions_end || !err)
         ERAISE(-EINVAL);
 
-    /* find the kernel stacks region */
-    ECHECK(_find_region(
-        regions_end,
-        MYST_REGION_KERNEL_STACKS,
-        (void**)&args->kernel_stacks_data,
-        &args->kernel_stacks_size,
-        err,
-        err_size));
-
     /* find the kernel region */
     ECHECK(_find_region(
         regions_end,


### PR DESCRIPTION
Currently Mystikos adds a **kernel stacks region** to the image during loading. This region contains **1024**, **64-kilobyte** stacks. The cost is incurred by any application, regardless of how many stacks are actually needed (one stack is required per thread). Loading this region during startup roughly doubles the boot time for the typical application.

This PR removes the **kernel stacks region** and instead allocates each kernel stack on demand using ``mmap``. Kernel stacks are cached and re-used and obtaining a kernel stack to service a syscall is an O(1) operation. This approach was made possible thanks to the ``mprotect`` feature, which is needed to set permissions for a guard page (at the top of the stack).

This change reduces the image size, decreases the startup time, and reduces the code size.