### PR TITLE
Enable #PF/#GP delivery

### DIFF
--- a/tools/myst/config.h
+++ b/tools/myst/config.h
@@ -23,7 +23,21 @@
 
 #define ENCLAVE_SECURITY_VERSION 1
 
+#define ENCLAVE_EXTENDED_PRODUCT_ID \
+    {                               \
+        0                           \
+    }
+
+#define ENCLAVE_FAMILY_ID \
+    {                     \
+        0                 \
+    }
+
 #define ENCLAVE_DEBUG true
+
+#define ENCLAVE_CAPTURE_PF_GP_EXCEPTIONS true
+
+#define ENCLAVE_REQUIRE_KSS false
 
 typedef struct _config_parsed_data_t
 {


### PR DESCRIPTION
This PR enables the #PF/#GP forwarding with the SGX2 feature. Also, falling back to the #PF simulation when the enclave is running in debug mode on the SGX1 machine.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>