### PR TITLE
fix bug in strnlen()

### DIFF
--- a/kernel/libc.c
+++ b/kernel/libc.c
@@ -50,7 +50,7 @@ size_t strnlen(const char* s, size_t maxlen)
 {
     size_t i;
 
-    for (i = 0; *s && i < maxlen; s++)
+    for (i = 0; *s && i < maxlen; s++, i++)
         ;
 
     return i;


### PR DESCRIPTION
strlnlen() was returning 0 always.