### PR TITLE
Always return read and write events for ramfs

### DIFF
--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -2292,7 +2292,9 @@ static int _fs_get_events(myst_fs_t* fs, myst_file_t* file)
     if (!_ramfs_valid(ramfs) || !_file_valid(file))
         ERAISE(-EINVAL);
 
-    ret = -ENOTSUP;
+    /* Regular files always poll TRUE for reads and writes */
+    ret |= POLLIN;
+    ret |= POLLOUT;
 
 done:
     return ret;

--- a/tests/devfs/devfs.c
+++ b/tests/devfs/devfs.c
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <poll.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -32,6 +33,11 @@ void test_random(const char* path)
     struct stat statbuf;
     ret = fstat(fd, &statbuf);
     assert(ret == 0);
+
+    struct pollfd pset = {fd, POLLIN, 0};
+    ret = poll(&pset, 1, 1000);
+    assert(ret > 0);
+    assert((pset.revents & POLLIN) != 0);
 
     ret = close(fd);
     assert(ret == 0);


### PR DESCRIPTION
NodeJS 9 is using poll on /dev/random.