### PR TITLE
Add SYS_fchmodat support

### DIFF
--- a/doc/syscall-limitations.md
+++ b/doc/syscall-limitations.md
@@ -97,7 +97,7 @@ on lowering the incompatibilities to enable more applications.
 | -------------------- |-------------------| --------------|
 | SYS_fcntl | File descriptor operations | Partial |
 | SYS_mknod | Create a file system node  | Partial |
-| SYS_mknodat / SYS_renameat2 / SYS_linkat / SYS_fchmodat | File system operation relative to a directory file descriptor | Unsupported |
+| SYS_mknodat / SYS_renameat2 / SYS_linkat | File system operation relative to a directory file descriptor | Unsupported |
 | SYS_lsetxattr / SYS_fsetxattr / SYS_getxattr / SYS_lgetxattr / SYS_fgetxattr / SYS_listxattr / SYS_llistxattr / SYS_flistxattr / SYS_removexattr / SYS_lremovexattr/ SYS_fremovexattr | get/set/remove extended file attributes | Unsupported |
 | SYS_inotify_add_watch | Monitor file system changes | Partial |
 | SYS_fanotify_init / SYS_fanotify_mark | Monitor file system changes | Unsupported |

--- a/tests/fs/fs.c
+++ b/tests/fs/fs.c
@@ -941,6 +941,22 @@ static void test_enotdir()
     _passed(__FUNCTION__);
 }
 
+static void test_fchmodat()
+{
+    assert(mkdir("/test_fchmodat", 0777) == 0);
+    int dirfd = open("/test_fchmodat", O_DIRECTORY);
+    assert(dirfd >= 0);
+    int fd = creat("/test_fchmodat/file1", 0666);
+    assert(fd >= 0);
+    assert(fchmodat(dirfd, "file1", 0666, 0) == 0);
+    assert(fchmodat(dirfd, "file1", 0666, 0x3) < 0);
+    assert(errno = EINVAL);
+    assert(close(dirfd) == 0);
+    assert(close(fd) == 0);
+
+    _passed(__FUNCTION__);
+}
+
 static void test_fdatasync()
 {
     int fd = creat("/test_fdatasync", 0666);
@@ -1047,6 +1063,7 @@ int main(int argc, const char* argv[])
     test_pwritev_preadv("pwritev64v2");
     test_ioctl();
     test_enotdir();
+    test_fchmodat();
     test_fdatasync();
     test_fsync();
     test_o_excl();


### PR DESCRIPTION
/ltp/testcases/kernel/syscalls/fchmodat/fchmodat01.c missed flags parameter. So I can't enable it unless we push a commit to the ltp repo, which is undesirable.