### PR TITLE
Patch musl with fcntl64 and sigsetmask

### DIFF
--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -404,6 +404,16 @@ index a6869b37..a312428b 100644
  }
 +
 +_Noreturn weak_alias(do_crt_exit, exit);
+diff --git a/src/fcntl/fcntl.c b/src/fcntl/fcntl.c
+index d3bff5c4..78c373ab 100644
+--- a/src/fcntl/fcntl.c
++++ b/src/fcntl/fcntl.c
+@@ -46,3 +46,5 @@ int fcntl(int fd, int cmd, ...)
+ 		return syscall(SYS_fcntl, fd, cmd, arg);
+ 	}
+ }
++
++weak_alias(fcntl, fcntl64);
 diff --git a/src/fcntl/open.c b/src/fcntl/open.c
 index 1d817a2d..a36ba05e 100644
 --- a/src/fcntl/open.c

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -405,7 +405,7 @@ index a6869b37..a312428b 100644
 +
 +_Noreturn weak_alias(do_crt_exit, exit);
 diff --git a/src/fcntl/fcntl.c b/src/fcntl/fcntl.c
-index d3bff5c4..78c373ab 100644
+index d3bff5c4..be23a7f5 100644
 --- a/src/fcntl/fcntl.c
 +++ b/src/fcntl/fcntl.c
 @@ -46,3 +46,5 @@ int fcntl(int fd, int cmd, ...)
@@ -414,6 +414,7 @@ index d3bff5c4..78c373ab 100644
  }
 +
 +weak_alias(fcntl, fcntl64);
+\ No newline at end of file
 diff --git a/src/fcntl/open.c b/src/fcntl/open.c
 index 1d817a2d..a36ba05e 100644
 --- a/src/fcntl/open.c
@@ -753,6 +754,53 @@ index c84c8a99..a5f561bd 100644
  #endif
  }
 +weak_alias (poll, __poll);
+diff --git a/src/signal/sigprocmask.c b/src/signal/sigprocmask.c
+index 297e20c6..fb1ea903 100644
+--- a/src/signal/sigprocmask.c
++++ b/src/signal/sigprocmask.c
+@@ -8,3 +8,42 @@ int sigprocmask(int how, const sigset_t *restrict set, sigset_t *restrict old)
+ 	errno = r;
+ 	return -1;
+ }
++
++static unsigned int sigset_to_int(const sigset_t *set)
++{
++  unsigned int ret = 0;
++  if (sizeof(sigset_t) == sizeof(ret))
++    return *(unsigned int*)set;
++
++  for (unsigned sig = 1; sig < _NSIG && sig <= sizeof(ret) * 8; sig++) {
++    if (sigismember (set, sig))
++      ret |= (1u << ((sig) - 1));
++  }
++  return ret;
++}
++
++static void int_to_sigset(sigset_t *set, int sigs)
++{
++  if (sizeof(sigset_t) == sizeof(sigs))
++    *(unsigned*)set = sigs;
++
++  sigemptyset(set);
++  for (unsigned sig = 1; sig < _NSIG && sig <= sizeof(sigs) * 8; sig++) {
++    if (sigs & (1u << ((sig) - 1)))
++      sigaddset(set, sig);
++  }
++}
++
++int __sigsetmask (int mask)
++{
++  sigset_t set, old;
++  
++  int_to_sigset(&set, mask);
++
++  if (sigprocmask (SIG_SETMASK, &set, &old) < 0)
++    return -1;
++
++  return sigset_to_int(&old);
++}
++
++weak_alias (__sigsetmask, sigsetmask);
 diff --git a/src/stdio/snprintf.c b/src/stdio/snprintf.c
 index 771503b2..8a8529b1 100644
 --- a/src/stdio/snprintf.c


### PR DESCRIPTION
Signed-off-by: Xuejun Yang <xuejya@microsoft.com>

These are required for the Python runtime from the official Python container images: https://hub.docker.com/_/python