### PR TITLE
shutdown socket on shutdown

### DIFF
--- a/kernel/fdtable.c
+++ b/kernel/fdtable.c
@@ -190,7 +190,8 @@ int myst_fdtable_interrupt(myst_fdtable_t* fdtable)
     {
         myst_fdtable_entry_t* entry = &fdtable->entries[i];
 
-        if (entry->type == MYST_FDTABLE_TYPE_PIPE)
+        if ((entry->type == MYST_FDTABLE_TYPE_PIPE) ||
+            (entry->type == MYST_FDTABLE_TYPE_SOCK))
         {
             myst_fdops_t* fdops = entry->device;
             (*fdops->fd_interrupt)(fdops, entry->object);

--- a/kernel/sockdev.c
+++ b/kernel/sockdev.c
@@ -392,6 +392,11 @@ done:
     return ret;
 }
 
+static int _sd_interrupt(myst_sockdev_t* sd, myst_sock_t* sock)
+{
+    return _sd_shutdown(sd, sock, SHUT_RDWR);
+}
+
 static int _sd_getsockopt(
     myst_sockdev_t* sd,
     myst_sock_t* sock,
@@ -715,6 +720,7 @@ extern myst_sockdev_t* myst_sockdev_get(void)
             .fd_close = (void*)_sd_close,
             .fd_target_fd = (void*)_sd_target_fd,
             .fd_get_events = (void*)_sd_get_events,
+            .fd_interrupt = (void*)_sd_interrupt,
         },
         .sd_socket = _sd_socket,
         .sd_socketpair = _sd_socketpair,


### PR DESCRIPTION
when shutting down a process, if there is a blocking socket call, the
process shutdown will hang while waiting for this thread.
Sending a shutdown to the socket should be sufficient to wake it up so
we can process the signals.