### PR TITLE
Fix dotnet testsuite pipeline

### DIFF
--- a/.azure_pipelines/ci-pipeline-dotnet-test-suite.yml
+++ b/.azure_pipelines/ci-pipeline-dotnet-test-suite.yml
@@ -11,8 +11,8 @@ jobs:
   - job: BuildAndTest
     displayName: 'Building and Testing'
     # 10m build
-    # ~3h for dotnet 5 test suite
-    timeoutInMinutes: 300
+    # over 5h for dotnet 5 test suite
+    timeoutInMinutes: 360
     pool: '1804DC4CCagentpool'
 
     steps:

--- a/solutions/coreclr/config.json
+++ b/solutions/coreclr/config.json
@@ -13,7 +13,7 @@
     // Mystikos specific values
 
     // The heap size of the user application. Increase this setting if your app experienced OOM.
-    "MemorySize": "768M",
+    "MemorySize": "256M",
     // The path to the entry point application in rootfs
     "ApplicationPath": "/coreclr-tests-all/Tests/Core_Root/corerun",
     // The parameters to the entry point application
@@ -21,5 +21,6 @@
     // Whether we allow "ApplicationParameters" to be overridden by command line options of "myst exec"
     "HostApplicationParameters": true,
     // The environment variables accessible inside the enclave.
-    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0", "COMPlus_EnableAlternateStackCheck=1"]
+    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0", "COMPlus_EnableAlternateStackCheck=1",
+    "COMPlus_GCHeapHardLimit=0x0400000"]
 }

--- a/solutions/coreclr/config.json
+++ b/solutions/coreclr/config.json
@@ -13,7 +13,7 @@
     // Mystikos specific values
 
     // The heap size of the user application. Increase this setting if your app experienced OOM.
-    "MemorySize": "1g",
+    "MemorySize": "768M",
     // The path to the entry point application in rootfs
     "ApplicationPath": "/coreclr-tests-all/Tests/Core_Root/corerun",
     // The parameters to the entry point application

--- a/solutions/coreclr/run-single-test.sh
+++ b/solutions/coreclr/run-single-test.sh
@@ -4,18 +4,19 @@ USAGE="$0 path-to-myst exec|exec-sgx|exec-linux ext2|cpio <path-to-test-dll>"
 HEAP_SIZE="1G"
 ret_val=-1
 t0=$(date +"%s")
+TIMEOUT=60
 
 if [[ "$3" == "ext2" ]]; then
-    timeout --kill-after=30s --signal=KILL 30 \
+    timeout --kill-after="${TIMEOUT}s" --signal=KILL $TIMEOUT \
         $1 $2 ext2fs \
-        --memory-size $HEAP_SIZE --app-config-path=config.json \
+        --app-config-path=config.json \
         --roothash=roothash \
         /coreclr-tests-all/Tests/Core_Root/corerun \
         /coreclr-tests-all/$4 > /dev/null 2>&1
 elif [[ "$3" == "cpio" ]]; then
-    timeout --kill-after=30s --signal=KILL 30 \
+    timeout --kill-after="${TIMEOUT}s" --signal=KILL $TIMEOUT \
         $1 $2 rootfs \
-        --memory-size $HEAP_SIZE --app-config-path=config.json \
+        --app-config-path=config.json \
         /coreclr-tests-all/Tests/Core_Root/corerun \
         /coreclr-tests-all/$4 > /dev/null 2>&1
 else

--- a/solutions/coreclr/run-single-test.sh
+++ b/solutions/coreclr/run-single-test.sh
@@ -4,7 +4,7 @@ USAGE="$0 path-to-myst exec|exec-sgx|exec-linux ext2|cpio <path-to-test-dll>"
 HEAP_SIZE="1G"
 ret_val=-1
 t0=$(date +"%s")
-TIMEOUT=60
+TIMEOUT=30
 
 if [[ "$3" == "ext2" ]]; then
     timeout --kill-after="${TIMEOUT}s" --signal=KILL $TIMEOUT \


### PR DESCRIPTION
Changed memory related settings to make .net less resource intensive -
 
Heap size: 256 MiB
COMPlus_GCHeapHardLimit=0x0400000

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>