### PR TITLE
EXPERIMENTAL: Mechanism for interrupting blocking socket calls

### DIFF
--- a/include/myst/asyncsyscall.h
+++ b/include/myst/asyncsyscall.h
@@ -8,7 +8,7 @@
 
 // Perform an fd-oriented "asynchronous" syscall that can be interrupted by
 // calling myst_interrupt_async_syscall().
-long myst_async_syscall(long num, int fd, ...);
+long myst_async_syscall(long num, int poll_flags, int fd, ...);
 
 // Interrupt the invocation of myst_async_syscall() that is currently blocked
 // on the given fd, forcing myst_async_syscall() to return -EINTR.

--- a/include/myst/asyncsyscall.h
+++ b/include/myst/asyncsyscall.h
@@ -6,12 +6,12 @@
 
 #include <stddef.h>
 
-// Perform an fd-oriented "asynchronous" syscall that can be interrupted by
-// calling myst_interrupt_async_syscall().
+// Perform an fd-oriented syscall that can be asynchronously interrupted by
+// myst_interrupt_async_syscall().
 long myst_async_syscall(long num, int poll_flags, int fd, ...);
 
 // Interrupt the invocation of myst_async_syscall() that is currently blocked
-// on the given fd, forcing myst_async_syscall() to return -EINTR.
+// on the given fd causing it to return -EINTR.
 long myst_interrupt_async_syscall(int fd);
 
 #endif /* _MYST_ASYNFDOPS_H */

--- a/include/myst/asyncsyscall.h
+++ b/include/myst/asyncsyscall.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_ASYNFDOPS_H
+#define _MYST_ASYNFDOPS_H
+
+#include <stddef.h>
+
+// Perform an fd-oriented "asynchronous" syscall that can be interrupted by
+// calling myst_interrupt_async_syscall().
+long myst_async_syscall(long num, int fd, ...);
+
+// Interrupt the invocation of myst_async_syscall() that is currently blocked
+// on the given fd, forcing myst_async_syscall() to return -EINTR.
+long myst_interrupt_async_syscall(int fd);
+
+#endif /* _MYST_ASYNFDOPS_H */

--- a/include/myst/tcall.h
+++ b/include/myst/tcall.h
@@ -56,6 +56,7 @@ typedef enum myst_tcall_number
     MYST_TCALL_GCOV,
     MYST_TCALL_GET_FILE_SIZE,
     MYST_TCALL_READ_FILE,
+    MYST_TCALL_INTERRUPT_ASYNC_SYSCALL
 } myst_tcall_number_t;
 
 long myst_tcall(long n, long params[6]);
@@ -162,5 +163,7 @@ long myst_gcov(const char* func, long params[6]);
 int myst_tcall_get_file_size(const char* pathname);
 
 int myst_tcall_read_file(const char* pathname, char* buf, size_t size);
+
+long myst_tcall_interrupt_async_syscall(int fd);
 
 #endif /* _MYST_TCALL_H */

--- a/kernel/asynsyscall.c
+++ b/kernel/asynsyscall.c
@@ -1,0 +1,7 @@
+#include <myst/asyncsyscall.h>
+#include <myst/tcall.h>
+
+long myst_interrupt_async_syscall(int fd)
+{
+    return myst_tcall_interrupt_async_syscall(fd);
+}

--- a/kernel/sockdev.c
+++ b/kernel/sockdev.c
@@ -671,7 +671,7 @@ static int _sd_close(myst_sockdev_t* sd, myst_sock_t* sock)
     if (!sd || !_valid_sock(sock))
         ERAISE(-EINVAL);
 
-    /* interrupt up any nested calls */
+    /* interrupt any nested calls */
     if (sock->nesting)
         myst_interrupt_async_syscall(sock->fd);
 

--- a/kernel/tcall.c
+++ b/kernel/tcall.c
@@ -256,3 +256,9 @@ int myst_tcall_read_file(const char* pathname, char* data, size_t size)
     long params[6] = {(long)pathname, (long)data, (long)size};
     return myst_tcall(MYST_TCALL_READ_FILE, params);
 }
+
+long myst_tcall_interrupt_async_syscall(int fd)
+{
+    long params[6] = {(long)fd};
+    return myst_tcall(MYST_TCALL_INTERRUPT_ASYNC_SYSCALL, params);
+}

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -15,6 +15,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <myst/asyncsyscall.h>
 #include <myst/eraise.h>
 #include <myst/fssig.h>
 #include <myst/luks.h>
@@ -510,6 +511,10 @@ long myst_tcall(long n, long params[6])
         case MYST_TCALL_READ_FILE:
         {
             return myst_tcall_read_file((const char*)x1, (void*)x2, (size_t)x3);
+        }
+        case MYST_TCALL_INTERRUPT_ASYNC_SYSCALL:
+        {
+            return myst_interrupt_async_syscall((int)x1);
         }
         case SYS_ioctl:
         {

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -579,6 +579,10 @@ long myst_tcall(long n, long params[6])
         {
             return myst_tcall_read_file((const char*)x1, (void*)x2, (size_t)x3);
         }
+        case MYST_TCALL_INTERRUPT_ASYNC_SYSCALL:
+        {
+            return myst_tcall_interrupt_async_syscall((int)x1);
+        }
         case SYS_read:
         case SYS_write:
         case SYS_close:

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -1044,6 +1044,16 @@ int myst_tcall_read_file(const char* pathname, char* buf, size_t size)
     return retval;
 }
 
+long myst_tcall_interrupt_async_syscall(int fd)
+{
+    long retval;
+
+    if (myst_interrupt_async_syscall_ocall(&retval, fd) != OE_OK)
+        return -EINVAL;
+
+    return retval;
+}
+
 /* linking with openssl crypto library creates a dependency on this */
 int __vfprintf_chk(FILE* stream, int flag, const char* format, va_list ap)
 {

--- a/tools/myst/host/asyncsyscall.c
+++ b/tools/myst/host/asyncsyscall.c
@@ -144,7 +144,7 @@ long myst_async_syscall(long num, int poll_flags, int fd, ...)
         fds[1].fd = waker->pipefd[0];
         fds[1].events = POLLIN;
 
-        if ((r = poll(fds, 2, 0)) < 0)
+        if ((r = poll(fds, 2, -1)) < 0)
         {
             ret = -ENOSYS;
             goto done;

--- a/tools/myst/host/asyncsyscall.c
+++ b/tools/myst/host/asyncsyscall.c
@@ -1,0 +1,239 @@
+#define _GNU_SOURCE
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <myst/asyncsyscall.h>
+#include <myst/defs.h>
+
+#define PIPE_MAGIC_WORD 0x77d377455afc4838
+
+static pthread_mutex_t _mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static int _set_nonblock(int fd)
+{
+    int flags;
+
+    if ((flags = fcntl(fd, F_GETFL, 0)) == -1)
+        return -1;
+
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+        return -1;
+
+    return 0;
+}
+
+static int _set_block(int fd)
+{
+    int flags;
+
+    if ((flags = fcntl(fd, F_GETFL, 0)) == -1)
+        return -1;
+
+    if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) == -1)
+        return -1;
+
+    return 0;
+}
+
+static int _is_nonblock(int fd)
+{
+    int flags;
+
+    if ((flags = fcntl(fd, F_GETFL, 0)) == -1)
+        return -1;
+
+    return (flags & O_NONBLOCK) ? 0 : -1;
+}
+
+static int _init_nonblocking_pipe(int pipefd[2])
+{
+    int ret = 0;
+
+    pthread_mutex_lock(&_mutex);
+
+    /* if not initialized yet */
+    if (pipefd[0] == 0 && pipefd[1] == 0)
+    {
+        if (pipe(pipefd) < 0)
+        {
+            ret = -1;
+            goto done;
+        }
+
+        if (_set_nonblock(pipefd[0]) != 0)
+        {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            pipefd[0] = 0;
+            pipefd[1] = 0;
+            ret = -1;
+            goto done;
+        }
+
+        if (_set_nonblock(pipefd[1]) != 0)
+        {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            pipefd[0] = 0;
+            pipefd[1] = 0;
+            ret = -1;
+            goto done;
+        }
+    }
+
+done:
+    pthread_mutex_unlock(&_mutex);
+    return ret;
+}
+
+typedef struct waker
+{
+    int pipefd[2];
+} waker_t;
+
+#define MAX_WAKERS 16384
+static waker_t _wakers[MAX_WAKERS];
+
+long myst_async_syscall(long num, int fd, ...)
+{
+    long ret = 0;
+    struct pollfd fds[2];
+    bool reset_to_blocking = false;
+    int* pipefd;
+
+    va_list ap;
+    va_start(ap, fd);
+    long x2 = va_arg(ap, long);
+    long x3 = va_arg(ap, long);
+    long x4 = va_arg(ap, long);
+    long x5 = va_arg(ap, long);
+    long x6 = va_arg(ap, long);
+    va_end(ap);
+
+    if (fd >= MYST_COUNTOF(_wakers))
+    {
+        assert("unexpected" == NULL);
+        ret = -ENOSYS;
+        goto done;
+    }
+
+    pipefd = _wakers[fd].pipefd;
+
+    if (_is_nonblock(fd) == 0)
+    {
+        ret = syscall(num, fd, x2, x3, x4, x5, x6);
+        goto done;
+    }
+
+    _set_nonblock(fd);
+    reset_to_blocking = true;
+
+    if (_init_nonblocking_pipe(pipefd) != 0)
+    {
+        ret = -ENOSYS;
+        goto done;
+    }
+
+    /* Wait for events */
+    for (;;)
+    {
+        int r;
+
+        memset(fds, 0, sizeof(fds));
+        fds[0].fd = fd;
+        fds[0].events = POLLIN;
+        fds[1].fd = pipefd[0];
+        fds[1].events = POLLIN;
+
+        if ((r = poll(fds, 2, 0)) < 0)
+        {
+            ret = -ENOSYS;
+            goto done;
+        }
+
+        if (r > 0)
+        {
+            if (fds[0].revents & POLLIN)
+            {
+                r = syscall(num, fd, x2, x3, x4, x5, x6);
+
+                if (r >= 0)
+                {
+                    ret = r;
+                    goto done;
+                }
+
+                if (errno != EWOULDBLOCK)
+                {
+                    ret = -errno;
+                    goto done;
+                }
+            }
+            else if (fds[1].revents & POLLIN)
+            {
+                ssize_t n;
+                uint64_t x;
+
+                while ((n = read(pipefd[0], &x, sizeof(x))) == sizeof(x))
+                {
+                    if (x != PIPE_MAGIC_WORD)
+                    {
+                        ret = -ENOSYS;
+                        goto done;
+                    }
+                }
+
+                if (n == -1 && errno != EWOULDBLOCK)
+                {
+                    ret = -ENOSYS;
+                    goto done;
+                }
+
+                /* operation was interrupted so return -EINTR */
+                ret = -EINTR;
+                goto done;
+            }
+        }
+    }
+
+done:
+
+    if (reset_to_blocking)
+        _set_block(fd);
+
+    return ret;
+}
+
+long myst_interrupt_async_syscall(int fd)
+{
+    const uint64_t x = PIPE_MAGIC_WORD;
+    int* pipefd;
+
+    if (fd >= MYST_COUNTOF(_wakers))
+    {
+        assert("unexpected" == NULL);
+        return -EINVAL;
+    }
+
+    pipefd = _wakers[fd].pipefd;
+
+    if (_init_nonblocking_pipe(pipefd) != 0)
+        return -ENOSYS;
+
+    if (write(pipefd[1], &x, sizeof(x)) != sizeof(x))
+    {
+        // the write may fail if  the pipe is full, but the failure
+        // may safely be ignored since the thread will be awoken under
+        // this failure condition (since the pipe is ready for read).
+    }
+
+    return 0;
+}

--- a/tools/myst/host/asyncsyscall.c
+++ b/tools/myst/host/asyncsyscall.c
@@ -151,7 +151,7 @@ long myst_async_syscall(long num, int poll_flags, int fd, ...)
         fds[0].fd = fd;
         fds[0].events = poll_flags;
         fds[1].fd = pipefd[0];
-        fds[1].events = poll_flags;
+        fds[1].events = POLLIN;
 
         if ((r = poll(fds, 2, 0)) < 0)
         {

--- a/tools/myst/host/asyncsyscall.c
+++ b/tools/myst/host/asyncsyscall.c
@@ -102,7 +102,7 @@ typedef struct waker
 #define MAX_WAKERS 16384
 static waker_t _wakers[MAX_WAKERS];
 
-long myst_async_syscall(long num, int fd, ...)
+long myst_async_syscall(long num, int poll_flags, int fd, ...)
 {
     long ret = 0;
     struct pollfd fds[2];
@@ -149,9 +149,9 @@ long myst_async_syscall(long num, int fd, ...)
 
         memset(fds, 0, sizeof(fds));
         fds[0].fd = fd;
-        fds[0].events = POLLIN;
+        fds[0].events = poll_flags;
         fds[1].fd = pipefd[0];
-        fds[1].events = POLLIN;
+        fds[1].events = poll_flags;
 
         if ((r = poll(fds, 2, 0)) < 0)
         {
@@ -161,7 +161,7 @@ long myst_async_syscall(long num, int fd, ...)
 
         if (r > 0)
         {
-            if (fds[0].revents & POLLIN)
+            if (fds[0].revents & poll_flags)
             {
                 r = syscall(num, fd, x2, x3, x4, x5, x6);
 
@@ -177,7 +177,7 @@ long myst_async_syscall(long num, int fd, ...)
                     goto done;
                 }
             }
-            else if (fds[1].revents & POLLIN)
+            else if (fds[1].revents & poll_flags)
             {
                 ssize_t n;
                 uint64_t x;

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -242,6 +242,8 @@ enclave
             [in, out] socklen_t* optlen,
             socklen_t optval_size);
 
+        long myst_interrupt_async_syscall_ocall(int fd);
+
         // ATTN: If Host file system support is exclude in certain build mode,
         // consider excluding relevant OCALL proxy code too.
 


### PR DESCRIPTION
This PR provides a mechanism for interrupting blocking socket calls. It introduces two functions.

```
long myst_async_syscall(long num, int poll_flags, int fd, ...);
long myst_interrupt_async_syscall(int fd);
```

This ``myst_async_syscall`` function executes a file-descriptor oriented syscall using non-blocking I/O. The ``myst_interrupt_async_syscall`` function interrupts a thread that is blocking inside ``myst_async_syscall``, causing it to wake up and return ``-EINTR``. 

Prior work
------------

This PR builds on prior work by [Paul](https://github.com/paulcallen). Paul originally diagnosed to root cause of a hang in the ``sockperf`` test. The hang was caused by the following sequence of events.
- Process B calls ``recvmsg()``
- Process A calls ``close()`` on the same socket descriptor.
- Process A exits
- Process B continues to hang on ``recvmsg()``

Paul's earlier solution was to add reference counting to select socket device operations and to check whether any of these calls were active during the ``close`` operation. If so, ``shutdown()`` was called, which broke process B out of ``recvmsg``. Although this worked, it caused the peer to receive a shutdown exception instead of an end-of-file (to which the sockperf test complained). Paul intended this as a quick fix for the last release and suggested using asynchronous I/O operations (this PR).

Paul's earlier solution can be found here: [PR 597 (https://github.com/deislabs/mystikos/pull/597/files).

The new solution is similar except we call ``myst_interrupt_async_syscall()``. 