### PR TITLE
Optimize dotnet solution

### DIFF
--- a/solutions/dotnet/Makefile
+++ b/solutions/dotnet/Makefile
@@ -4,22 +4,28 @@ include $(TOP)/defs.mak
 APPBUILDER=$(TOP)/scripts/appbuilder
 APPNAME=HelloWorld
 
-#ifdef STRACE
-#OPTS += --strace
-#endif
+OPTS =
 
-all: appdir private.pem
+ifdef STRACE
+OPTS += --strace
+endif
 
-run-unsigned:
-	$(MYST) mkcpio appdir rootfs
-	$(MYST_EXEC) $(OPTS) --memory-size=1024m rootfs /app/HelloWorld
+#OPTS += --perf
 
-run: appdir private.pem
-	timeout 45m $(MYST) package appdir private.pem config.json
+all: rootfs private.pem
+
+export MYST_ROOTFS_PATH=$(CURDIR)/rootfs
+
+rootfs: appdir
+	$(MYST) mkext2 appdir rootfs
+	$(MYST) fssig --roothash rootfs > roothash
+
+run: all
+	timeout 45m $(MYST) package --roothash=roothash private.pem config.json
 	myst/bin/$(APPNAME) $(OPTS)
-	
-gdb: appdir private.pem
-	$(MYST) package appdir private.pem config.json
+
+gdb: all
+	$(MYST) package --roothash=roothash private.pem config.json
 	$(MYST_GDB) --args myst/bin/$(APPNAME) $(OPTS)
 
 appdir:
@@ -29,4 +35,4 @@ private.pem:
 	openssl genrsa -out private.pem -3 3072
 
 clean:
-	sudo rm -fr appdir rootfs HelloWorld/build HelloWorld/obj HelloWorld/bin myst private.pem
+	sudo rm -rf appdir rootfs HelloWorld/build HelloWorld/obj HelloWorld/bin myst private.pem

--- a/solutions/dotnet/Makefile
+++ b/solutions/dotnet/Makefile
@@ -10,8 +10,6 @@ ifdef STRACE
 OPTS += --strace
 endif
 
-#OPTS += --perf
-
 all: rootfs private.pem
 
 export MYST_ROOTFS_PATH=$(CURDIR)/rootfs

--- a/solutions/dotnet/config.json
+++ b/solutions/dotnet/config.json
@@ -3,17 +3,12 @@
 
     // Whether we are running myst+OE+app in debug mode
     "Debug": 1,
-    // The stack size of each ethread
-    "StackMemSize": "400k",
-    // The number of ethreads
-    "NumUserThreads": 32,
     "ProductID": 1,
     "SecurityVersion": 1,
-
     // Mystikos specific values
 
     // The heap size of the user application. Increase this setting if your app experienced OOM.
-    "MemorySize": "1g",
+    "MemorySize": "256m",
     // The path to the entry point application in rootfs
     "ApplicationPath": "/app/HelloWorld",
     // The parameters to the entry point application
@@ -21,7 +16,7 @@
     // Whether we allow "ApplicationParameters" to be overridden by command line options of "myst exec"
     "HostApplicationParameters": false,
     // The environment variables accessible inside the enclave.
-    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0", "MYST_WANT_TEE_CREDENTIALS=CERT_PEMKEY_REPORT"],
+    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0", "MYST_WANT_TEE_CREDENTIALS=CERT_PEMKEY_REPORT", "COMPlus_GCHeapHardLimit=0x0400000"],
     // The environment variables we get from the host
     "HostEnvironmentVariables": ["MAA_ENDPOINT"]
 }


### PR DESCRIPTION
This PR converts the ``dotnet`` solution to use EXT2 and tunes the configuration settings to reduce the run time from **60 seconds** to **8 seconds**.

The magic formula seems to be:
- COMPlus_GCHeapHardLimit=0x0400000
- MemorySize=256m

[@vtikoo](https://github.com/vtikoo) and I determined that these settings work well for the ``coreclr`` solution too.