### PR TITLE
Poll revent fixes

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -4815,7 +4815,9 @@ static int _ext2_get_events(myst_fs_t* fs, myst_file_t* file)
     if (!_ext2_valid(ext2) || !_file_valid(file))
         ERAISE(-EINVAL);
 
-    ret = -ENOTSUP;
+    /* Regular files always poll TRUE for reads and writes */
+    ret |= POLLIN;
+    ret |= POLLOUT;
 
 done:
     return ret;


### PR DESCRIPTION
The PR addresses 3 issues:

- The existing implementation can return event not requested by the poll syscall (not part of the pollfd.events mask), which can cause problem such as issue #512. The PR makes sure the revents returned can include any of those specified in events, or one of the values POLLERR, POLLHUP, or POLLNVAL, following [Linux manual](https://www.man7.org/linux/man-pages/man2/poll.2.html).
- Added poll support for ext2fs open files, always returning POLLIN|POLLOUT, in the same manner as ramfs handling in PR #586 
- Return POLLNVAL event on closed or invalid fds