### PR TITLE
Pipe fix and a python subprocess test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -113,6 +113,7 @@ DIRS += dotnet-sos
 DIRS += tkillself
 DIRS += thread_abort
 DIRS += synccall
+DIRS += python_subprocess
 
 .PHONY: $(DIRS)
 

--- a/tests/python_subprocess/Dockerfile
+++ b/tests/python_subprocess/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:18.04
+
+RUN apt update && apt install -y wget &&\
+    wget -q https://repo.continuum.io/miniconda/Miniconda3-py39_4.9.2-Linux-x86_64.sh &&\
+    chmod 755 Miniconda3-py39_4.9.2-Linux-x86_64.sh &&\
+    ./Miniconda3-py39_4.9.2-Linux-x86_64.sh -b -p /miniconda &&\
+    /miniconda/bin/python3 --version
+
+WORKDIR /app
+COPY ./test_subprocess.py .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["/miniconda/bin/python3", "/app/test_subprocess.py"]

--- a/tests/python_subprocess/Makefile
+++ b/tests/python_subprocess/Makefile
@@ -1,0 +1,30 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+all: ext2fs
+
+appdir:
+	$(APPBUILDER) Dockerfile
+
+ext2fs: appdir
+	$(MYST) mkext2 appdir ext2fs
+
+tests:
+	$(RUNTEST) $(MYST_EXEC) ext2fs \
+	/miniconda/bin/python3 /app/test_subprocess.py \
+	--app-config-path config.json
+
+gdb:
+	$(MYST_GDB) --args $(MYST_EXEC) $(OPTS) ext2fs \
+	/miniconda/bin/python3 /app/test_subprocess.py \
+	--app-config-path config.json
+
+clean:
+	rm -fr appdir ext2fs
+

--- a/tests/python_subprocess/config.json
+++ b/tests/python_subprocess/config.json
@@ -1,0 +1,13 @@
+{
+    "Debug": 1,
+    "StackMemSize": "800k",
+    "NumUserThreads": 8,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+    "UserMemSize": "256m",
+    "ForkMode":"pseudo_wait_for_exit_exec",
+    "ApplicationPath": "/miniconda/bin/python3",
+    "ApplicationParameters": ["/app/test_subprocess.py"],
+    "HostApplicationParameters": false,
+    "EnvironmentVariables": [""]
+}

--- a/tests/python_subprocess/test_subprocess.py
+++ b/tests/python_subprocess/test_subprocess.py
@@ -1,0 +1,20 @@
+import subprocess
+# Define command as string and then split() into list format
+cmd = '/bin/ls -ltr'.split()
+
+# Check the list value of cmd
+print('command in list format:',cmd,'\n')
+
+# Use shell=False to execute the command
+sp = subprocess.Popen(cmd,shell=False,stdout=subprocess.PIPE,stderr=subprocess.PIPE,universal_newlines=True)
+print('Popen returned\n')
+# Store the return code in rc variable
+rc=sp.wait()
+print('Return Code:',rc,'\n')
+# Separate the output and error.
+# This is similar to Tuple where we store two values to two different variables
+out,err=sp.communicate()
+
+
+print('output is: \n', out)
+print('error is: \n', err)


### PR DESCRIPTION
The PR fixed the following issues:

- The current pipe implementation returns EPIPE on read() after the write side closes the pipe. According to Linux manual, in this case, end-of-file (value of 0) should be returned. 
- The current implementation of _pd_get_event()  does not set any event when the other end of the pipe is closed. 

The PR also adds a python_subprocess test. The test invokes python.subprocess module to create a child process to execute `ls` command, and returns the result to the parent process through pipes. The code flow exercises the relevant pipe scenario.