### PR TITLE
Implement vfork() over fork()

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -17,6 +17,7 @@
 #include <myst/file.h>
 #include <myst/fsgs.h>
 #include <myst/futex.h>
+#include <myst/hex.h>
 #include <myst/kernel.h>
 #include <myst/lfence.h>
 #include <myst/mmanutils.h>
@@ -612,7 +613,7 @@ myst_thread_t* myst_find_thread(int tid)
     return target;
 }
 
-/* Find the thread that may be waiting for the fork-exec wait and weke it */
+/* Find the thread that may be waiting for the fork-exec wait and wake it */
 void myst_fork_exec_futex_wake(myst_thread_t* thread)
 {
     pid_t pid = thread->clone.vfork_parent_pid;
@@ -620,37 +621,43 @@ void myst_fork_exec_futex_wake(myst_thread_t* thread)
 
     myst_thread_t* our_process_thread =
         myst_find_process_thread(myst_thread_self());
-    myst_thread_t* find_thread = our_process_thread;
+    myst_thread_t* waiter = our_process_thread;
 
     myst_spin_lock(&myst_process_list_lock);
-    while (find_thread && find_thread->pid != pid)
+    while (waiter && waiter->pid != pid)
     {
-        find_thread = find_thread->main.prev_process_thread;
+        waiter = waiter->main.prev_process_thread;
     }
-    if (find_thread == NULL)
+    if (waiter == NULL)
     {
-        find_thread = our_process_thread->main.next_process_thread;
-        while (find_thread && find_thread->pid != pid)
+        waiter = our_process_thread->main.next_process_thread;
+        while (waiter && waiter->pid != pid)
         {
-            find_thread = find_thread->main.next_process_thread;
+            waiter = waiter->main.next_process_thread;
         }
     }
     myst_spin_unlock(&myst_process_list_lock);
 
-    if (find_thread == NULL)
+    if (waiter == NULL)
         goto done;
 
-    myst_spin_lock(find_thread->thread_lock);
-    while (find_thread && find_thread->tid != tid)
+    /* find the waiter */
     {
-        find_thread = find_thread->group_next;
-    }
-    myst_spin_unlock(find_thread->thread_lock);
+        myst_spinlock_t* thread_lock = waiter->thread_lock;
+        myst_spin_lock(thread_lock);
 
-    if (find_thread)
+        while (waiter && waiter->tid != tid)
+        {
+            waiter = waiter->group_next;
+        }
+
+        myst_spin_unlock(thread_lock);
+    }
+
+    if (waiter)
     {
-        __sync_val_compare_and_swap(&find_thread->fork_exec_futex_wait, 0, 1);
-        myst_futex_wake(&find_thread->fork_exec_futex_wait, 1);
+        __sync_val_compare_and_swap(&waiter->fork_exec_futex_wait, 0, 1);
+        myst_futex_wake(&waiter->fork_exec_futex_wait, 1);
     }
 
 done:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,6 +4,7 @@ include $(TOP)/defs.mak
 DIRS =
 
 DIRS += fork
+DIRS += vfork
 DIRS += myst
 DIRS += itimer
 DIRS += timeval
@@ -115,6 +116,7 @@ DIRS += tkillself
 DIRS += thread_abort
 DIRS += synccall
 DIRS += python_subprocess
+DIRS += python_vfork
 
 .PHONY: $(DIRS)
 

--- a/tests/ltp/README.md
+++ b/tests/ltp/README.md
@@ -1337,8 +1337,8 @@ FAILING
 | /ltp/testcases/kernel/syscalls/utime/utime06 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/utimensat/utimensat01 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/utimes/utimes01 | 0 | 0 | 0 |
-| /ltp/testcases/kernel/syscalls/vfork/vfork01 | 0 | 0 | 0 |
-| /ltp/testcases/kernel/syscalls/vfork/vfork02 | 0 | 0 | 0 |
+| /ltp/testcases/kernel/syscalls/vfork/vfork01 | 1 | 1 | 1 |
+| /ltp/testcases/kernel/syscalls/vfork/vfork02 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/vhangup/vhangup01 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/vhangup/vhangup02 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/vmsplice/vmsplice01 | 0 | 0 | 0 |

--- a/tests/ltp/hostfs_tests_passed.txt
+++ b/tests/ltp/hostfs_tests_passed.txt
@@ -305,6 +305,8 @@
 /ltp/testcases/kernel/syscalls/unlinkat/unlinkat01
 /ltp/testcases/kernel/syscalls/utime/utime04
 /ltp/testcases/kernel/syscalls/utime/utime05
+/ltp/testcases/kernel/syscalls/vfork/vfork01
+/ltp/testcases/kernel/syscalls/vfork/vfork02
 /ltp/testcases/kernel/syscalls/wait/wait01
 /ltp/testcases/kernel/syscalls/wait/wait02
 /ltp/testcases/kernel/syscalls/waitpid/waitpid01

--- a/tests/ltp/ramfs_fs_tests_passed.txt
+++ b/tests/ltp/ramfs_fs_tests_passed.txt
@@ -128,5 +128,7 @@
 /ltp/testcases/kernel/syscalls/utime/utime02
 /ltp/testcases/kernel/syscalls/utime/utime03
 /ltp/testcases/kernel/syscalls/unlinkat/unlinkat01
+/ltp/testcases/kernel/syscalls/vfork/vfork01
+/ltp/testcases/kernel/syscalls/vfork/vfork02
 /ltp/testcases/kernel/syscalls/write/write01
 /ltp/testcases/kernel/syscalls/write/write02

--- a/tests/ltp/ramfs_tests_passed.txt
+++ b/tests/ltp/ramfs_tests_passed.txt
@@ -270,6 +270,8 @@
 /ltp/testcases/kernel/syscalls/utime/utime02
 /ltp/testcases/kernel/syscalls/utime/utime03
 /ltp/testcases/kernel/syscalls/unlinkat/unlinkat01
+/ltp/testcases/kernel/syscalls/vfork/vfork01
+/ltp/testcases/kernel/syscalls/vfork/vfork02
 /ltp/testcases/kernel/syscalls/wait/wait01
 /ltp/testcases/kernel/syscalls/wait/wait02
 /ltp/testcases/kernel/syscalls/waitpid/waitpid01

--- a/tests/python_vfork/Dockerfile
+++ b/tests/python_vfork/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-rc-slim
+WORKDIR /app
+COPY ./test_vfork.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["/usr/local/bin/python3", "/app/test_vfork.py"]

--- a/tests/python_vfork/Makefile
+++ b/tests/python_vfork/Makefile
@@ -1,0 +1,28 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+all: rootfs
+
+appdir:
+	$(APPBUILDER) Dockerfile
+
+rootfs: appdir
+	$(MYST) mkext2 appdir rootfs
+
+APP_NAME=/usr/local/bin/python3
+APP_ARGS=/app/test_vfork.py
+
+tests:
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs $(APP_NAME) $(APP_ARGS)
+
+gdb:
+	$(MAKE) tests GDB=1
+
+clean:
+	rm -fr appdir rootfs

--- a/tests/python_vfork/test_vfork.py
+++ b/tests/python_vfork/test_vfork.py
@@ -1,0 +1,3 @@
+import subprocess
+
+subprocess.call(["/bin/ls", "-l"])

--- a/tests/vfork/Makefile
+++ b/tests/vfork/Makefile
@@ -1,0 +1,31 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs: vfork.c child.c
+	mkdir -p $(APPDIR)/bin
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/vfork vfork.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/child child.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+ifdef PERF
+OPTS += --perf
+endif
+
+tests: all
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/vfork $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/vfork/child.c
+++ b/tests/vfork/child.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(int argc, const char* argv[])
+{
+    printf("%s: started\n", argv[0]);
+    return 123;
+}

--- a/tests/vfork/vfork.c
+++ b/tests/vfork/vfork.c
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+const char* arg0;
+
+static bool _reached_parent;
+static bool _reached_child;
+
+#define STRING1 "\001\001\001\001\001\001\001\001"
+#define STRING2 "\002\002\002\002\002\002\002\002"
+#define STRING3 "Hello world!"
+#define STRING4 "Goodbye world!"
+
+#define VALUE ((uint64_t)0xcca906a5e5e7485a)
+
+void test(bool exec, uint64_t* ptr)
+{
+    _reached_parent = false;
+    _reached_child = false;
+    char buf[9];
+    char buf2[1024];
+
+    strcpy(buf, STRING1);
+    strcpy(buf2, STRING3);
+
+    pid_t pid = vfork();
+
+    if (pid < 0)
+    {
+        fprintf(
+            stderr, "%s: fork() failed: %d: %s\n", arg0, pid, strerror(errno));
+        assert(0);
+    }
+    else if (pid == 0) /* child */
+    {
+        printf("=== inside child\n");
+        _reached_child = true;
+        sleep(1);
+
+        strcpy(buf, STRING2);
+        strcpy(buf2, STRING4);
+
+        /* verify that vfork() suspended execution of the parent process */
+        assert(_reached_parent == false);
+
+        assert(pid == 0);
+
+        *ptr = VALUE;
+
+        if (exec)
+        {
+            char* args[] = {"/bin/child", NULL};
+            char* env[] = {NULL};
+            execve("/bin/child", args, env);
+            assert(false);
+        }
+
+        _exit(123);
+    }
+    else /* parent */
+    {
+        printf("=== inside parent\n");
+        int wstatus;
+        _reached_parent = true;
+
+        /* check that the child changed the parent's stack */
+        assert(strcmp(buf, STRING1) == 0);
+        assert(strcmp(buf2, STRING3) == 0);
+
+        assert(waitpid(pid, &wstatus, 0) == pid);
+        assert(WIFEXITED(wstatus));
+        assert(WEXITSTATUS(wstatus) == 123);
+        assert(pid != 0);
+    }
+
+    assert(_reached_child == true);
+    assert(_reached_parent == true);
+
+    printf("=== passed test (%s): %s\n", arg0, (exec ? "exec" : "exit"));
+}
+
+int main(int argc, const char* argv[])
+{
+    arg0 = argv[0];
+    uint64_t value;
+
+    test(true, &value);
+    test(false, &value);
+    assert(value == VALUE);
+
+    printf("=== passed test (%s)\n", argv[0]);
+
+    return 0;
+}


### PR DESCRIPTION
This PR implements ``vfork()`` by calling ``fork()`` and waiting for the child to call ``exec`` or ``_exit`` (as provided by Paul's earlier PR). See comments in ``./crt/fork.c`` for the ``vfork()`` function for a lengthy description of design choices.