### PR TITLE
mmap and mremap fixes

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -3691,8 +3691,8 @@ static long _syscall(void* args_)
             /* this can return (void*)-errno */
             long ret = (long)myst_mmap(addr, length, prot, flags, fd, offset);
 
-            // ATTN : always translating errors to ENOMEM is probably incorrect
-            if (ret <= 0)
+            // ATTN : temporary workaround for myst_mmap()  inaccurate return value issue
+            if (ret == -1 || !ret)
             {
                 ret = -ENOMEM;
             }


### PR DESCRIPTION
- Preserve ENOMEM error return behavior for mmap.
- Fix pids ownership check in mremap.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>