### PR TITLE
Use wrfsbase/wrgsbase on Linux target

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -142,7 +142,12 @@ typedef struct myst_kernel_args
     /* Tracing options */
     bool trace_errors;
     bool trace_syscalls;
+
+    /* Whether the target supports the SYSCALL instruction */
     bool have_syscall_instruction;
+
+    /* Whether the target supports the WRFSBASE and WRGSBASE instructions */
+    bool have_fsgsbase_instructions;
 
     /* The event object for the main thread */
     uint64_t event;

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -14,6 +14,7 @@ typedef struct myst_options
     bool trace_errors;
     bool trace_syscalls;
     bool have_syscall_instruction;
+    bool have_fsgsbase_instructions;
     bool shell_mode;
     bool debug_symbols;
     bool memcheck;

--- a/kernel/fsgs.c
+++ b/kernel/fsgs.c
@@ -12,61 +12,46 @@
 
 void myst_set_fsbase(void* p)
 {
-    if (__options.have_syscall_instruction)
+    if (__myst_kernel_args.have_fsgsbase_instructions)
     {
-        const long n = SYS_arch_prctl;
-        myst_syscall2(n, ARCH_SET_FS, (long)p);
+        __asm__ volatile("wrfsbase %0" ::"r"(p));
+    }
+    else if (__options.have_syscall_instruction)
+    {
+        myst_syscall2(SYS_arch_prctl, ARCH_SET_FS, (long)p);
     }
     else
     {
-        __asm__ volatile("wrfsbase %0" ::"r"(p));
+        myst_panic("unsupported");
     }
 }
 
 void* myst_get_fsbase(void)
 {
-    if (__options.have_syscall_instruction)
-    {
-        const long n = SYS_arch_prctl;
-        void* p;
-        myst_syscall2(n, ARCH_GET_FS, (long)&p);
-        return p;
-    }
-    else
-    {
-        void* p;
-        __asm__ volatile("mov %%fs:0, %0" : "=r"(p));
-        return p;
-    }
+    void* p;
+    __asm__ volatile("mov %%fs:0, %0" : "=r"(p));
+    return p;
 }
 
 void myst_set_gsbase(void* p)
 {
-    if (__options.have_syscall_instruction)
+    if (__myst_kernel_args.have_fsgsbase_instructions)
     {
-        const long n = SYS_arch_prctl;
-        myst_syscall2(n, ARCH_SET_GS, (long)p);
+        __asm__ volatile("wrgsbase %0" ::"r"(p));
+    }
+    else if (__options.have_syscall_instruction)
+    {
+        myst_syscall2(SYS_arch_prctl, ARCH_SET_GS, (long)p);
     }
     else
     {
-        /* unsupported but not needed */
-        myst_panic("wrgsbase emulation is unsupported");
+        myst_panic("unsupported");
     }
 }
 
 void* myst_get_gsbase(void)
 {
-    if (__options.have_syscall_instruction)
-    {
-        const long n = SYS_arch_prctl;
-        void* p;
-        myst_syscall2(n, ARCH_GET_GS, (long)&p);
-        return p;
-    }
-    else
-    {
-        void* p;
-        __asm__ volatile("mov %%gs:0, %0" : "=r"(p));
-        return p;
-    }
+    void* p;
+    __asm__ volatile("mov %%gs:0, %0" : "=r"(p));
+    return p;
 }

--- a/kernel/fsgs.c
+++ b/kernel/fsgs.c
@@ -22,14 +22,28 @@ void myst_set_fsbase(void* p)
     }
     else
     {
-        myst_panic("unsupported");
+        /* attempt WRFSBASE emulation */
+        __asm__ volatile("wrfsbase %0" ::"r"(p));
     }
 }
 
 void* myst_get_fsbase(void)
 {
     void* p;
-    __asm__ volatile("mov %%fs:0, %0" : "=r"(p));
+
+    if (__options.have_fsgsbase_instructions)
+    {
+        __asm__ volatile("rdfsbase %0" : "=r"(p));
+    }
+    if (__options.have_syscall_instruction)
+    {
+        myst_syscall2(SYS_arch_prctl, ARCH_GET_FS, (long)&p);
+    }
+    else
+    {
+        __asm__ volatile("mov %%fs:0, %0" : "=r"(p));
+    }
+
     return p;
 }
 
@@ -45,13 +59,27 @@ void myst_set_gsbase(void* p)
     }
     else
     {
-        myst_panic("unsupported");
+        /* attempt WRGSBASE emulation */
+        __asm__ volatile("wrgsbase %0" ::"r"(p));
     }
 }
 
 void* myst_get_gsbase(void)
 {
     void* p;
-    __asm__ volatile("mov %%gs:0, %0" : "=r"(p));
+
+    if (__options.have_fsgsbase_instructions)
+    {
+        __asm__ volatile("rdgsbase %0" : "=r"(p));
+    }
+    if (__options.have_syscall_instruction)
+    {
+        myst_syscall2(SYS_arch_prctl, ARCH_GET_GS, (long)&p);
+    }
+    else
+    {
+        __asm__ volatile("mov %%gs:0, %0" : "=r"(p));
+    }
+
     return p;
 }

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -750,6 +750,10 @@ static long _enter(void* arg_)
         _kargs.start_time_nsec = arg->start_time_nsec;
         _kargs.report_native_tids = report_native_tids;
 
+        // SGX unconditionally supports the WRFSBASE/WRGSBASE instructions,
+        // either through hardware or by emulation.
+        _kargs.have_fsgsbase_instructions = true;
+
         /* set ehdr and verify that the kernel is an ELF image */
         {
             ehdr = (const Elf64_Ehdr*)_kargs.kernel_data;

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -750,9 +750,8 @@ static long _enter(void* arg_)
         _kargs.start_time_nsec = arg->start_time_nsec;
         _kargs.report_native_tids = report_native_tids;
 
-        // SGX unconditionally supports the WRFSBASE/WRGSBASE instructions,
-        // either through hardware or by emulation.
-        _kargs.have_fsgsbase_instructions = true;
+        /* whether user-space FSGSBASE instructions are supported */
+        _kargs.have_fsgsbase_instructions = options->have_fsgsbase_instructions;
 
         /* set ehdr and verify that the kernel is an ELF image */
         {

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -36,6 +36,7 @@
 
 #include "../shared.h"
 #include "exec.h"
+#include "fsgsbase.h"
 #include "myst_u.h"
 #include "process.h"
 #include "pubkeys.h"
@@ -414,6 +415,10 @@ int exec_action(int argc, const char* argv[], const char* envp[])
 
     const char* rootfs = argv[2];
     const char* program = argv[3];
+
+    /* check whether FSGSBASE instructions are supported */
+    if (test_user_space_fsgsbase() == 0)
+        options.have_fsgsbase_instructions = true;
 
     if (extract_roothashes_from_ext2_images(
             rootfs, &mount_mapping, &roothash_buf) != 0)

--- a/tools/myst/host/fsgsbase.c
+++ b/tools/myst/host/fsgsbase.c
@@ -1,0 +1,125 @@
+#define _GNU_SOURCE
+#include <myst/getopt.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "utils.h"
+
+static int _called_sigill_handler;
+
+static void _sigill_handler(int signum, siginfo_t* siginfo, void* ucontext)
+{
+    /* advance to next instruction (after WRFSBASE) */
+    ((ucontext_t*)ucontext)->uc_mcontext.gregs[REG_RIP] += 5;
+
+    _called_sigill_handler = 1;
+}
+
+int test_user_space_fsgsbase(void)
+{
+    void* save;
+    struct sigaction act;
+    struct sigaction oldact;
+
+    /* save the oldact fsbase */
+    __asm__ volatile("mov %%fs:0, %0" : "=r"(save));
+
+    /* install SIGILL handler */
+    memset(&act, 0, sizeof(act));
+    act.sa_sigaction = _sigill_handler;
+    sigaction(SIGILL, &act, &oldact);
+
+    /* attempt the WRFSBASE instruction (possibly raising SIGILL) */
+    __asm__ volatile("wrfsbase %0" ::"r"(NULL));
+
+    /* if WRFSBASE instruction worked, then restore the orignal fsbase value */
+    if (!_called_sigill_handler)
+        __asm__ volatile("wrfsbase %0" ::"r"(save));
+
+    /* restore the original SIGILL handler */
+    sigaction(SIGILL, &oldact, NULL);
+
+    return _called_sigill_handler ? -1 : 0;
+}
+
+static int _getopt(
+    int* argc,
+    const char* argv[],
+    const char* opt,
+    const char** optarg)
+{
+    char err[128];
+    int ret;
+
+    ret = myst_getopt(argc, argv, opt, optarg, err, sizeof(err));
+
+    if (ret < 0)
+        _err("%s", err);
+
+    return ret;
+}
+
+#define FSGSBASE_USAGE \
+    "\n\
+Usage: %s %s [options]\n\
+\n\
+Synopsis:\n\
+    This command checks whether a user-mode program may execute the FSGSBASE\n\
+    instructions (RDFSBASE, WRFSBASE, RDGSBASE, and WRGSBASE). If so, the\n\
+    exit code is zero. If not, the exit code is one.\n\
+\n\
+Options:\n\
+    -h, --help  Print this help message\n\
+    --quiet     Do not write anything to standard output\n\
+\n"
+
+int fsgsbase_action(int argc, const char* argv[])
+{
+    bool help = false;
+    bool quiet = false;
+
+    /* get the --help option */
+    if (_getopt(&argc, argv, "--help", NULL) == 0 ||
+        _getopt(&argc, argv, "-h", NULL) == 0)
+    {
+        help = true;
+    }
+
+    if (help)
+    {
+        printf(FSGSBASE_USAGE, argv[0], argv[1]);
+        exit(0);
+    }
+
+    /* get the --quiet option */
+    if (_getopt(&argc, argv, "--quiet", NULL) == 0 ||
+        _getopt(&argc, argv, "-q", NULL) == 0)
+    {
+        quiet = true;
+    }
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s %s\n", argv[0], argv[1]);
+        exit(1);
+    }
+
+    if (test_user_space_fsgsbase() == 0)
+    {
+        if (!quiet)
+            printf("FSGSBASE instructions are supported\n");
+
+        exit(0);
+    }
+    else
+    {
+        if (!quiet)
+            printf("FSGSBASE instructions are not supported\n");
+
+        exit(1);
+    }
+
+    return 0;
+}

--- a/tools/myst/host/fsgsbase.h
+++ b/tools/myst/host/fsgsbase.h
@@ -1,0 +1,11 @@
+#ifndef _MYST_TOOLS_MYST_HOST_FSGSBASE_H
+#define _MYST_TOOLS_MYST_HOST_FSGSBASE_H
+
+// Return zero if user-space FSGSBASE instructions are supported, which
+// includes RDFSBASE, WRGSBASE, WRFSBASE, and WRGSBASE.
+int test_user_space_fsgsbase(void);
+
+/* The "myst fsgsbase" command */
+int fsgsbase_action(int argc, const char* argv[]);
+
+#endif /* _MYST_TOOLS_MYST_HOST_FSGSBASE_H */

--- a/tools/myst/host/host.c
+++ b/tools/myst/host/host.c
@@ -383,6 +383,7 @@ Where <action> is one of:\n\
                      pieces during in the process\n\
     dump-sgx      -- dump the SGX enclave configuration along with the\n\
                      packaging configuration from an SGX packaged executable\n\
+    fsgsbase      -- tests whether the FSGSBASE instructions are supported\n\
 \n\
 "
 
@@ -458,6 +459,11 @@ static int _main(int argc, const char* argv[], const char* envp[])
     {
         extern int fssig_action(int argc, const char* argv[]);
         return fssig_action(argc, argv);
+    }
+    else if (strcmp(argv[1], "fsgsbase") == 0)
+    {
+        extern int fsgsbase_action(int argc, const char* argv[]);
+        return fsgsbase_action(argc, argv);
     }
     else
     {


### PR DESCRIPTION
When run under the Linux target, the ``redis`` sample suffers a 75% performance penalty when compared with SGX. This is due to the overhead of executing the following system calls.

```
myst_syscall2(SYS_arch_prctl, ARCH_SET_FS, fsbase);
myst_syscall2(SYS_arch_prctl, ARCH_GET_FS);
```

This PR detects whether ``/proc/cpuinfo`` defines the ``fsgsbase`` flag. If so, then the Linux uses the **WRFSBASE** instruction rather than the syscall.
