### PR TITLE
Fix the bug in myst_release_process_mappings()

### DIFF
--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -636,21 +636,9 @@ int myst_release_process_mappings(pid_t pid)
             if (p->pid == pid)
             {
 #if MYST_ENABLE_MMAN_PIDS
-                /* if the given process still owns the whole mapping */
-                if (myst_mman_pids_test(p->addr, p->size, pid) == 0)
-                {
-                    /* unmap the whole mapping */
-                    myst_munmap(p->addr, p->size);
-
-                    /* set ownership of these pages to nobody */
-                    myst_mman_pids_set(p->addr, p->size, 0);
-                }
-                else
-                {
-                    // perform a partial unmapping: unmap all pages in this
-                    // mapping that are owned by the given process.
-                    myst_mman_pids_munmap(p->addr, p->size, pid);
-                }
+                /* unmap all pages in this mapping that are owned by the given
+                 * process.*/
+                myst_mman_pids_munmap(p->addr, p->size, pid);
 #else
                 myst_munmap(p->addr, p->size);
 #endif


### PR DESCRIPTION
PR #635 missed one bug in `myst_release_process_mappings()`. `myst_mman_pids_test(p->addr, p->size, pid)` returns the length of the memory starting from `p->addr` that belongs to the process of `pid`. 0 return means the first page staring from `p->addr` does not belong to the process of `pid`, instead of a success flag indicating the whole memory range belongs to  the process of `pid`.

`myst_mman_pids_munmap()` can handle both the case of whole memory range belonging to the process and the case of only partial memory belonging tot he process. This PR call `myst_mman_pids_munmap()` for both cases.