### PR TITLE
Fix for vfork test failure in release mode

### DIFF
--- a/defs.mak
+++ b/defs.mak
@@ -58,7 +58,7 @@ DEFAULT_INCLUDES = -I$(INCDIR)
 DEFAULT_CFLAGS = -Wall -Werror -g -fPIC
 
 ifeq ($(MYST_RELEASE),1)
-OPTIMIZATION_CFLAGS += -O3
+OPTIMIZATION_CFLAGS += -O3 -fno-omit-frame-pointer
 endif
 
 ifdef MYST_ENABLE_GCOV

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -59,6 +59,7 @@ CFLAGS += -m64
 CFLAGS += -fPIC
 CFLAGS += -ftls-model=local-exec
 CFLAGS += -fstack-protector-strong
+CFLAGS += -fno-omit-frame-pointer
 ifdef USE_GC_SECTIONS
 CFLAGS += -ffunction-sections
 CFLAGS += -fdata-sections

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -59,7 +59,6 @@ CFLAGS += -m64
 CFLAGS += -fPIC
 CFLAGS += -ftls-model=local-exec
 CFLAGS += -fstack-protector-strong
-CFLAGS += -fno-omit-frame-pointer
 ifdef USE_GC_SECTIONS
 CFLAGS += -ffunction-sections
 CFLAGS += -fdata-sections

--- a/third_party/musl/crt/Makefile
+++ b/third_party/musl/crt/Makefile
@@ -26,7 +26,7 @@ WHICH_GCC = $(shell which gcc)
 CFLAGS = -g -Werror -fPIC
 
 ifeq ($(MYST_RELEASE),1)
-CFLAGS += -O3
+CFLAGS += $(OPTIMIZATION_CFLAGS)
 endif
 
 THISDIR=$(CURDIR)


### PR DESCRIPTION
@paulcallen found the problem. The ``-O2`` option omit the stack frame (which we need to properly fixup base pointers in the child process's stack).