### PR TITLE
Remove obsolete NumUserThreads and StackMemSize configurations

### DIFF
--- a/doc/sign-package.md
+++ b/doc/sign-package.md
@@ -55,8 +55,6 @@ Included is a sample JSON configuration where the elements will be described nex
     "version": "0.1",
 
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 
@@ -95,8 +93,6 @@ Next we have settings specific to configuring the SGX enclave itself.
 Setting | Description
 -|-
 Debug | Enable debugging within the SGX enclave, turn off for release builds
-StackMemSize | Stack size for kernel
-NumUserThreads | Number of threads allowed within the enclave. If more threads are created than this number thread creation will fail
 ProductID | The product ID of your application. This is an integer value
 SecurityVersion | Security version of your application. This is an integer value.
 

--- a/doc/user-getting-started-tee-aware.md
+++ b/doc/user-getting-started-tee-aware.md
@@ -217,8 +217,6 @@ First we declare the desire in the config.json:
 
     // Whether we are running myst+OE+app in debug mode
     "Debug": 1,
-    // The number of ethreads
-    "NumUserThreads": 32,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/samples/java_hello_world/config.json
+++ b/samples/java_hello_world/config.json
@@ -1,7 +1,5 @@
 {
     "Debug": 1,
-    "StackMemSize": "800k",
-    "NumUserThreads": 8,
     "ProductID": 1,
     "SecurityVersion": 1,
     "UserMemSize": "4096m",

--- a/samples/pytorch/config.json
+++ b/samples/pytorch/config.json
@@ -1,7 +1,5 @@
 {
     "Debug": 1,
-    "StackMemSize": "800k",
-    "NumUserThreads": 8,
     "ProductID": 1,
     "SecurityVersion": 1,
     "UserMemSize": "1024m",

--- a/samples/redis/config.json
+++ b/samples/redis/config.json
@@ -3,10 +3,6 @@
 
     // Whether we are running in debug mode
     "Debug": 1,
-    // The stack size of each ethread
-    "StackMemSize": "400k",
-    // The number of ethreads
-    "NumUserThreads": 32,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/solutions/coreclr/config.json
+++ b/solutions/coreclr/config.json
@@ -3,10 +3,6 @@
 
     // Whether we are running myst+OE+app in debug mode
     "Debug": 1,
-    // The stack size of each ethread
-    "StackMemSize": "400k",
-    // The number of ethreads
-    "NumUserThreads": 32,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/solutions/dotnet/config.json
+++ b/solutions/dotnet/config.json
@@ -3,10 +3,6 @@
 
     // Whether we are running myst+OE+app in debug mode
     "Debug": 1,
-    // The stack size of each ethread
-    "StackMemSize": "400k",
-    // The number of ethreads
-    "NumUserThreads": 32,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/solutions/dotnet_azure_sdk/Identity_Resource_Management_and_Storage/config.json
+++ b/solutions/dotnet_azure_sdk/Identity_Resource_Management_and_Storage/config.json
@@ -2,8 +2,6 @@
     "version": "0.1",
 
     "Debug": 1,
-    "StackMemSize": "400k",
-    "NumUserThreads": 16,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/solutions/dotnet_azure_sdk/KeyVault_Certificates/config.json
+++ b/solutions/dotnet_azure_sdk/KeyVault_Certificates/config.json
@@ -2,8 +2,6 @@
     "version": "0.1",
 
     "Debug": 1,
-    "StackMemSize": "400k",
-    "NumUserThreads": 16,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/solutions/dotnet_azure_sdk/KeyVault_Keys/config.json
+++ b/solutions/dotnet_azure_sdk/KeyVault_Keys/config.json
@@ -2,8 +2,6 @@
     "version": "0.1",
 
     "Debug": 1,
-    "StackMemSize": "400k",
-    "NumUserThreads": 16,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/solutions/dotnet_azure_sdk/KeyVault_Secrets/config.json
+++ b/solutions/dotnet_azure_sdk/KeyVault_Secrets/config.json
@@ -2,8 +2,6 @@
     "version": "0.1",
 
     "Debug": 1,
-    "StackMemSize": "400k",
-    "NumUserThreads": 16,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/solutions/memcached/config.json
+++ b/solutions/memcached/config.json
@@ -1,8 +1,6 @@
 {
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "400k",
-    "NumUserThreads": 32,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/fork/config-kill-children.json
+++ b/tests/fork/config-kill-children.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/fork/config-none.json
+++ b/tests/fork/config-none.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/fork/config-wait-children.json
+++ b/tests/fork/config-wait-children.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/fork/config-wait-exec.json
+++ b/tests/fork/config-wait-exec.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/ltp/config.json
+++ b/tests/ltp/config.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/auto-mount/config1.json
+++ b/tests/myst/auto-mount/config1.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/cwd-config/config1.json
+++ b/tests/myst/cwd-config/config1.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/dump-package/config.json
+++ b/tests/myst/dump-package/config.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/exec-not-signed/config.json
+++ b/tests/myst/exec-not-signed/config.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/exec-package-ext2/config.json
+++ b/tests/myst/exec-package-ext2/config.json
@@ -1,9 +1,6 @@
 {
     "version": "0.1",
     "Debug": 1,
-    "KernelMemSize": "4m",
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
     "MemorySize": "40m",

--- a/tests/myst/exec-package/config.json
+++ b/tests/myst/exec-package/config.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/exec-signed-1/config.json
+++ b/tests/myst/exec-signed-1/config.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/exec-signed-2/config.json
+++ b/tests/myst/exec-signed-2/config.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/hostname-config/config1.json
+++ b/tests/myst/hostname-config/config1.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/mkcpio/config.json
+++ b/tests/myst/mkcpio/config.json
@@ -4,8 +4,6 @@
 
     // OpenEnclave specific values
     "Debug": 1,
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
 

--- a/tests/myst/package/config.json
+++ b/tests/myst/package/config.json
@@ -1,9 +1,6 @@
 {
     "version": "0.1",
     "Debug": 0,
-    "KernelMemSize": "4m",
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
     "MemorySize": "40m",

--- a/tests/myst/package/config_debug.json
+++ b/tests/myst/package/config_debug.json
@@ -1,9 +1,6 @@
 {
     "version": "0.1",
     "Debug": 1,
-    "KernelMemSize": "4m",
-    "StackMemSize": "256k",
-    "NumUserThreads": 2,
     "ProductID": 1,
     "SecurityVersion": 1,
     "MemorySize": "40m",

--- a/tests/python_subprocess/config.json
+++ b/tests/python_subprocess/config.json
@@ -1,7 +1,5 @@
 {
     "Debug": 1,
-    "StackMemSize": "800k",
-    "NumUserThreads": 8,
     "ProductID": 1,
     "SecurityVersion": 1,
     "UserMemSize": "256m",

--- a/tools/myst/config.c
+++ b/tools/myst/config.c
@@ -114,22 +114,6 @@ static json_result_t _json_read_callback(
                 else
                     CONFIG_RAISE(JSON_TYPE_MISMATCH);
             }
-            else if (json_match(parser, "StackMemSize") == JSON_OK)
-            {
-                ret = _extract_mem_size(
-                    type, un, &parsed_data->oe_num_stack_pages);
-                if (ret != JSON_OK)
-                    CONFIG_RAISE(ret);
-            }
-            else if (json_match(parser, "NumUserThreads") == JSON_OK)
-            {
-                if (type == JSON_TYPE_INTEGER)
-                {
-                    parsed_data->oe_num_user_threads = (uint64_t)un->integer;
-                }
-                else
-                    CONFIG_RAISE(JSON_TYPE_MISMATCH);
-            }
             else if (json_match(parser, "ProductID") == JSON_OK)
             {
                 if (type == JSON_TYPE_INTEGER)
@@ -367,7 +351,7 @@ int parse_config(config_parsed_data_t* parsed_data)
         free,
     };
 
-    /* set default settings (where settings are missing from config file) */
+    /* set default settings */
     {
         parsed_data->oe_num_user_threads = ENCLAVE_MAX_THREADS;
         parsed_data->oe_num_stack_pages = ENCLAVE_STACK_SIZE / PAGE_SIZE;


### PR DESCRIPTION
Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>

As pointed out in issue #242, NumTCS/NumStackPages or NumUserThreads/StackMemSize configuration is not needed anymore. This PR removes the obsolete configuration from config.json files, and makes sure the packaged mode also ignore  NumUserThreads/StackMemSize configuration even if they are present in config.json