### PR TITLE
Fix open() to always return a lockfs-wrapped file system

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -3305,7 +3305,10 @@ int ext2_open(
     {
         /* i.e path was fully resolved
         the file resides in the current fs */
-        *fs_out = fs;
+        if (ext2->wrapper_fs)
+            *fs_out = ext2->wrapper_fs;
+        else
+            *fs_out = fs;
     }
 
     /* find the inode for this file (if it exists) */
@@ -5703,6 +5706,20 @@ done:
         free(ext2);
     }
 
+    return ret;
+}
+
+int ext2_set_wrapper_fs(myst_fs_t* fs, myst_fs_t* wrapper_fs)
+{
+    int ret = 0;
+    ext2_t* ext2 = (ext2_t*)fs;
+
+    if (!_ext2_valid(ext2) || !wrapper_fs)
+        ERAISE(-EINVAL);
+
+    ext2->wrapper_fs = wrapper_fs;
+
+done:
     return ret;
 }
 

--- a/hostfs/hostfs.c
+++ b/hostfs/hostfs.c
@@ -15,6 +15,7 @@
 #include <myst/eraise.h>
 #include <myst/fdtable.h>
 #include <myst/fs.h>
+#include <myst/hostfs.h>
 #include <myst/iov.h>
 #include <myst/realpath.h>
 #include <myst/strings.h>
@@ -1309,6 +1310,11 @@ done:
         free(hostfs);
 
     return ret;
+}
+
+bool myst_is_hostfs(const myst_fs_t* fs)
+{
+    return _hostfs_valid((hostfs_t*)fs);
 }
 
 #endif /* MYST_ENABLE_HOSTFS */

--- a/include/myst/ext2.h
+++ b/include/myst/ext2.h
@@ -201,6 +201,7 @@ struct ext2
     ext2_inode_t root_inode;
     char target[EXT2_PATH_MAX];
     myst_mount_resolve_callback_t resolve;
+    myst_fs_t* wrapper_fs;
 };
 
 /*
@@ -215,6 +216,8 @@ int ext2_create(
     myst_blkdev_t* dev,
     myst_fs_t** fs,
     myst_mount_resolve_callback_t resolve_cb);
+
+int ext2_set_wrapper_fs(myst_fs_t* fs, myst_fs_t* wrapper_fs);
 
 int ext2_release(myst_fs_t* fs);
 

--- a/include/myst/hostfs.h
+++ b/include/myst/hostfs.h
@@ -8,4 +8,6 @@
 
 int myst_init_hostfs(myst_fs_t** fs_out);
 
+bool myst_is_hostfs(const myst_fs_t* fs);
+
 #endif /* _MYST_HOSTFS_H */

--- a/include/myst/lockfs.h
+++ b/include/myst/lockfs.h
@@ -4,10 +4,14 @@
 #ifndef _MYST_LOCKFS_H
 #define _MYST_LOCKFS_H
 
+#include <stdbool.h>
+
 #include <myst/fs.h>
 
 int myst_lockfs_init(myst_fs_t* fs, myst_fs_t** lockfs);
 
 myst_fs_t* myst_lockfs_target(myst_fs_t* fs);
+
+bool myst_is_lockfs(const myst_fs_t* fs);
 
 #endif /* _MYST_LOCKFS_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -74,6 +74,8 @@ ifdef MYST_ENABLE_GCOV
 CFLAGS += $(GCOV_CFLAGS)
 endif
 
+#CFLAGS += -Wconversion
+
 LDFLAGS =
 LDFLAGS += -nostdlib
 LDFLAGS += -nodefaultlibs

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -183,6 +183,7 @@ int myst_load_fs(
     /* wrap ext2fs inside a lockfs */
     ECHECK(ext2_create(blkdev, &ext2fs, resolve_cb));
     ECHECK(myst_lockfs_init(ext2fs, &fs));
+    ECHECK(ext2_set_wrapper_fs(ext2fs, fs));
     ext2fs = NULL;
 
     blkdev = NULL;

--- a/kernel/lockfs.c
+++ b/kernel/lockfs.c
@@ -103,7 +103,7 @@ static off_t _fs_lseek(
     off_t offset,
     int whence)
 {
-    int ret = 0;
+    off_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
 
     if (!_lockfs_valid(lockfs))
@@ -123,7 +123,7 @@ static ssize_t _fs_read(
     void* buf,
     size_t count)
 {
-    int ret = 0;
+    ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
 
     if (!_lockfs_valid(lockfs))
@@ -143,7 +143,7 @@ static ssize_t _fs_write(
     const void* buf,
     size_t count)
 {
-    int ret = 0;
+    ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
 
     if (!_lockfs_valid(lockfs))
@@ -164,7 +164,7 @@ static ssize_t _fs_pread(
     size_t count,
     off_t offset)
 {
-    int ret = 0;
+    ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
 
     if (!_lockfs_valid(lockfs))
@@ -185,7 +185,7 @@ static ssize_t _fs_pwrite(
     size_t count,
     off_t offset)
 {
-    int ret = 0;
+    ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
 
     if (!_lockfs_valid(lockfs))
@@ -205,7 +205,7 @@ static ssize_t _fs_readv(
     const struct iovec* iov,
     int iovcnt)
 {
-    int ret = 0;
+    ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
 
     if (!_lockfs_valid(lockfs))
@@ -225,7 +225,7 @@ static ssize_t _fs_writev(
     const struct iovec* iov,
     int iovcnt)
 {
-    int ret = 0;
+    ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
 
     if (!_lockfs_valid(lockfs))
@@ -457,7 +457,7 @@ static ssize_t _fs_readlink(
     char* buf,
     size_t bufsiz)
 {
-    int ret = 0;
+    ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
 
     if (!_lockfs_valid(lockfs))

--- a/kernel/lockfs.c
+++ b/kernel/lockfs.c
@@ -855,3 +855,8 @@ myst_fs_t* myst_lockfs_target(myst_fs_t* fs)
     lockfs_t* lockfs = (lockfs_t*)fs;
     return _lockfs_valid(lockfs) ? lockfs->fs : fs;
 }
+
+bool myst_is_lockfs(const myst_fs_t* fs)
+{
+    return _lockfs_valid((lockfs_t*)fs);
+}

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -55,6 +55,7 @@
 #include <myst/kernel.h>
 #include <myst/kstack.h>
 #include <myst/libc.h>
+#include <myst/lockfs.h>
 #include <myst/lsr.h>
 #include <myst/mmanutils.h>
 #include <myst/mount.h>
@@ -818,6 +819,8 @@ long myst_syscall_open(const char* pathname, int flags, mode_t mode)
 
     ECHECK(myst_mount_resolve(pathname, locals->suffix, &fs));
     ECHECK((*fs->fs_open)(fs, locals->suffix, flags, mode, &fs_out, &file));
+
+    myst_assume(myst_is_hostfs(fs_out) || myst_is_lockfs(fs_out));
 
     if ((fd = myst_fdtable_assign(fdtable, fdtype, fs_out, file)) < 0)
     {


### PR DESCRIPTION
@vtikoo discoverd that the ``myst_syscall_open()`` function was resolving to file systems that were not wrapped by ``lockfs``. This change fixes the **ext2** and **ramfs** file systems to always produce a resolved file system that is lockfs-wrapped.

Note that hostfs does not use wrappers.