### PR TITLE
enable and fix conversion warnings

### DIFF
--- a/include/myst/bits.h
+++ b/include/myst/bits.h
@@ -12,7 +12,7 @@ MYST_INLINE bool myst_test_bit(const uint8_t* data, size_t index)
 {
     const size_t byte = index / 8;
     const size_t bit = index % 8;
-    return ((size_t)(data[byte]) & (size_t)(1 << bit)) ? 1 : 0;
+    return (data[byte] & (uint8_t)(1 << bit)) ? 1 : 0;
 }
 
 MYST_INLINE void myst_set_bit(uint8_t* data, size_t index)

--- a/include/myst/bits.h
+++ b/include/myst/bits.h
@@ -12,21 +12,21 @@ MYST_INLINE bool myst_test_bit(const uint8_t* data, size_t index)
 {
     const size_t byte = index / 8;
     const size_t bit = index % 8;
-    return ((size_t)(data[byte]) & (1 << bit)) ? 1 : 0;
+    return ((size_t)(data[byte]) & (size_t)(1 << bit)) ? 1 : 0;
 }
 
 MYST_INLINE void myst_set_bit(uint8_t* data, size_t index)
 {
     const size_t byte = index / 8;
     const size_t bit = index % 8;
-    data[byte] |= (1 << bit);
+    data[byte] |= (uint8_t)(1 << bit);
 }
 
 MYST_INLINE void myst_clear_bit(uint8_t* data, size_t index)
 {
     const size_t byte = index / 8;
     const size_t bit = index % 8;
-    data[byte] &= ~(1 << bit);
+    data[byte] &= (uint8_t) ~(1 << bit);
 }
 
 #endif /* _MYST_BITS_H */

--- a/include/myst/mman.h
+++ b/include/myst/mman.h
@@ -144,9 +144,9 @@ void myst_mman_set_sanity(myst_mman_t* heap, bool sanity);
 
 bool myst_mman_is_sane(myst_mman_t* heap);
 
-int myst_mman_total_size(myst_mman_t* mman, size_t* size);
+ssize_t myst_mman_total_size(myst_mman_t* mman, size_t* size);
 
-int myst_mman_free_size(myst_mman_t* mman, size_t* size);
+ssize_t myst_mman_free_size(myst_mman_t* mman, size_t* size);
 
 void myst_mman_dump_vads(myst_mman_t* mman);
 

--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -33,9 +33,9 @@ void* myst_mremap(
 
 int myst_mprotect(const void* addr, const size_t len, const int prot);
 
-int myst_get_total_ram(size_t* size);
+ssize_t myst_get_total_ram(size_t* size);
 
-int myst_get_free_ram(size_t* size);
+ssize_t myst_get_free_ram(size_t* size);
 
 int myst_register_process_mapping(
     pid_t pid,

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -42,8 +42,8 @@ typedef union myst_vcallback {
     int (*open_cb)(myst_buf_t* buf);
     struct
     {
-        int (*read_cb)(void* buf, size_t count);
-        int (*write_cb)(const void* buf, size_t count);
+        ssize_t (*read_cb)(void* buf, size_t count);
+        ssize_t (*write_cb)(const void* buf, size_t count);
     } rw_callbacks;
 } myst_vcallback_t;
 

--- a/include/myst/signal.h
+++ b/include/myst/signal.h
@@ -17,7 +17,7 @@ void myst_signal_free(myst_thread_t* t);
 void myst_signal_free_siginfos(myst_thread_t* t);
 
 long myst_signal_sigaction(
-    unsigned signum,
+    int signum,
     const posix_sigaction_t* new_action,
     posix_sigaction_t* old_action);
 
@@ -25,10 +25,7 @@ long myst_signal_sigprocmask(int how, const sigset_t* set, sigset_t* oldset);
 
 long myst_signal_process(myst_thread_t* thread);
 
-long myst_signal_deliver(
-    myst_thread_t* thread,
-    unsigned signum,
-    siginfo_t* siginfo);
+long myst_signal_deliver(myst_thread_t* thread, int signum, siginfo_t* siginfo);
 
 long myst_signal_sigpending(sigset_t* set, unsigned size);
 

--- a/include/myst/sockdev.h
+++ b/include/myst/sockdev.h
@@ -72,13 +72,13 @@ struct myst_sockdev
         struct sockaddr* src_addr,
         socklen_t* addrlen);
 
-    int (*sd_sendmsg)(
+    ssize_t (*sd_sendmsg)(
         myst_sockdev_t* sd,
         myst_sock_t* sock,
         const struct msghdr* msg,
         int flags);
 
-    int (*sd_recvmsg)(
+    ssize_t (*sd_recvmsg)(
         myst_sockdev_t* sd,
         myst_sock_t* sock,
         struct msghdr* msg,

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -106,7 +106,7 @@ struct myst_thread
     int exit_status;
 
     /* Terminating signal value */
-    unsigned terminating_signum;
+    int terminating_signum;
 
     /* Timespec at process creation */
     struct timespec start_ts;

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -44,7 +44,6 @@ WARNINGS += -Wconversion
 WARNINGS += -Wextra
 WARNINGS += -Wno-missing-field-initializers
 WARNINGS += -Wno-type-limits
-WARNINGS += -Wno-conversion
 WARNINGS += -Wstack-usage=512
 WARNINGS += -Winit-self
 
@@ -67,7 +66,6 @@ endif
 CFLAGS += $(WARNINGS)
 
 # suppress conversion errors in musl lib headers
-CFLAGS += -Wno-conversion
 CFLAGS += -Wno-parentheses
 
 ifdef MYST_ENABLE_GCOV

--- a/kernel/cond.c
+++ b/kernel/cond.c
@@ -171,7 +171,7 @@ int myst_cond_signal(myst_cond_t* c)
 
 int myst_cond_broadcast(myst_cond_t* c, size_t n)
 {
-    size_t num_awoken = 0;
+    int num_awoken = 0;
     myst_thread_queue_t waiters = {NULL, NULL};
 
     if (!c)

--- a/kernel/debugmalloc.c
+++ b/kernel/debugmalloc.c
@@ -257,7 +257,7 @@ MYST_INLINE bool _check_multiply_overflow(size_t x, size_t y)
     return true;
 }
 
-static void _malloc_dump(size_t size, void* addrs[], int num_addrs)
+static void _malloc_dump(size_t size, void* addrs[], size_t num_addrs)
 {
     myst_eprintf("%lu bytes\n", size);
     myst_dump_backtrace(addrs, num_addrs);
@@ -285,7 +285,7 @@ static void _dump(void)
             "=== blocks in use: %zu bytes in %zu blocks\n", bytes, blocks);
 
         for (header_t* p = list->head; p; p = p->next)
-            _malloc_dump(p->size, p->addrs, (int)p->num_addrs);
+            _malloc_dump(p->size, p->addrs, p->num_addrs);
 
         myst_eprintf("\n");
     }

--- a/kernel/devfs.c
+++ b/kernel/devfs.c
@@ -28,7 +28,7 @@ static myst_fs_t* _devfs;
 /*************************************
  * callbacks
  * ***********************************/
-static int _ignore_read_cb(void* buf, size_t count)
+static ssize_t _ignore_read_cb(void* buf, size_t count)
 {
     (void)buf;
     (void)count;
@@ -36,15 +36,15 @@ static int _ignore_read_cb(void* buf, size_t count)
     return 0; // EOF
 }
 
-static int _ignore_write_cb(const void* buf, size_t count)
+static ssize_t _ignore_write_cb(const void* buf, size_t count)
 {
     (void)buf;
     (void)count;
 
-    return count;
+    return (ssize_t)count;
 }
 
-static int _zero_read_cb(void* buf, size_t count)
+static ssize_t _zero_read_cb(void* buf, size_t count)
 {
     ssize_t ret = 0;
 
@@ -56,13 +56,13 @@ static int _zero_read_cb(void* buf, size_t count)
 
     memset(buf, 0, count);
 
-    ret = count;
+    ret = (ssize_t)count;
 
 done:
     return ret;
 }
 
-static int _urandom_read_cb(void* buf, size_t count)
+static ssize_t _urandom_read_cb(void* buf, size_t count)
 {
     ssize_t ret = 0;
 

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -75,7 +75,7 @@ static int _process_mount_configuration(myst_mounts_config_t* mounts)
 
     for (i = 0; i < mounts->mounts_count; i++)
     {
-        ret = myst_syscall_mount(
+        ret = (int)myst_syscall_mount(
             mounts->mounts[i].source,
             mounts->mounts[i].target,
             mounts->mounts[i].fs_type,
@@ -632,8 +632,8 @@ static void _print_boottime(void)
     if (myst_syscall_clock_gettime(CLOCK_REALTIME, &now) == 0)
     {
         struct timespec start;
-        start.tv_sec = __myst_kernel_args.start_time_sec;
-        start.tv_nsec = __myst_kernel_args.start_time_nsec;
+        start.tv_sec = (time_t)__myst_kernel_args.start_time_sec;
+        start.tv_nsec = (long int)__myst_kernel_args.start_time_nsec;
 
         long nsec = myst_lapsed_nsecs(&start, &now);
 

--- a/kernel/epolldev.c
+++ b/kernel/epolldev.c
@@ -99,7 +99,7 @@ static int _ed_epoll_ctl(
     int fd,
     struct epoll_event* event)
 {
-    ssize_t ret = 0;
+    int ret = 0;
     bool locked = false;
 
     if (!epolldev || !_valid_epoll(epoll) || !event)
@@ -202,7 +202,7 @@ static int _ed_epoll_wait(
     if (!epolldev || !epoll || !events || maxevents < 0)
         ERAISE(-EINVAL);
 
-    memset(events, 0, maxevents * sizeof(struct epoll_event));
+    memset(events, 0, (size_t)maxevents * sizeof(struct epoll_event));
 
     myst_spin_lock(&epoll->lock);
     locked = true;
@@ -290,7 +290,7 @@ static int _ed_epoll_wait(
     myst_spin_unlock(&epoll->lock);
     locked = false;
 
-    ECHECK((n = myst_syscall_poll(fds, nfds, timeout)));
+    ECHECK((n = (int)myst_syscall_poll(fds, nfds, timeout)));
 
     /* this should never happen */
     if ((size_t)n > nfds)

--- a/kernel/eventfddev.c
+++ b/kernel/eventfddev.c
@@ -246,7 +246,7 @@ static ssize_t _write(
         }
     }
 
-    ret = count;
+    ret = (ssize_t)count;
 
 done:
 
@@ -351,7 +351,7 @@ static int _fcntl(
             if (arg != FD_CLOEXEC && arg != 0)
                 ERAISE(-EINVAL);
 
-            eventfd->fdflags = arg;
+            eventfd->fdflags = (int)arg;
             goto done;
         }
         case F_GETFD:

--- a/kernel/fdtable.c
+++ b/kernel/fdtable.c
@@ -72,7 +72,7 @@ int myst_fdtable_clone(myst_fdtable_t* fdtable, myst_fdtable_t** fdtable_out)
                 myst_fdtable_entry_t* new_entry = &new_fdtable->entries[i];
                 myst_fdops_t* fdops = entry->device;
                 void* object;
-                long r;
+                int r;
 
                 if ((r = (*fdops->fd_dup)(fdops, entry->object, &object)) != 0)
                 {
@@ -250,7 +250,7 @@ int myst_fdtable_dup(
     bool locked = false;
     bool use_next_available_fd = false;
     bool set_cloexec = false;
-    size_t start_fd = 0;
+    int start_fd = 0;
 
     if (!fdtable)
         ERAISE(-EINVAL);
@@ -331,7 +331,7 @@ int myst_fdtable_dup(
         if (use_next_available_fd)
         {
             /* find the first free file descriptor */
-            for (size_t i = start_fd; i < MYST_COUNTOF(fdtable->entries); i++)
+            for (int i = start_fd; i < (int)MYST_COUNTOF(fdtable->entries); i++)
             {
                 myst_fdtable_entry_t* p = &fdtable->entries[i];
 

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -176,7 +176,8 @@ int myst_load_fs(
             (keysize = myst_ascii_to_bin(
                  key, locals->keybuf, sizeof(locals->keybuf))));
 
-        ECHECK(myst_luksblkdev_open(blkdev, locals->keybuf, keysize, &tmp));
+        ECHECK(myst_luksblkdev_open(
+            blkdev, locals->keybuf, (uint32_t)keysize, &tmp));
         blkdev = tmp;
     }
 

--- a/kernel/hostfile.c
+++ b/kernel/hostfile.c
@@ -31,7 +31,7 @@ static int _host_open(const char* pathname, int flags, mode_t mode)
     long params[6] = {
         (long)pathname, (long)flags, (long)mode, (long)uid, (long)gid};
 
-    ECHECK(ret = myst_tcall(SYS_open, params));
+    ECHECK(ret = (int)myst_tcall(SYS_open, params));
 
 done:
     return ret;
@@ -88,7 +88,7 @@ int myst_load_host_file(const char* path, void** data_out, size_t* size_out)
         if (n == 0)
             break;
 
-        if (myst_buf_append(&buf, locals->buf, n) != 0)
+        if (myst_buf_append(&buf, locals->buf, (size_t)n) != 0)
             ERAISE(-ENOMEM);
     }
 

--- a/kernel/inotifydev.c
+++ b/kernel/inotifydev.c
@@ -85,9 +85,9 @@ static int _put_wd(int wd)
 
     myst_spin_lock(&_wds_lock);
     {
-        if (myst_test_bit(_wds, wd))
+        if (myst_test_bit(_wds, (size_t)wd))
         {
-            myst_clear_bit(_wds, wd);
+            myst_clear_bit(_wds, (size_t)wd);
         }
         else
         {

--- a/kernel/itimer.c
+++ b/kernel/itimer.c
@@ -92,8 +92,8 @@ long myst_syscall_run_itimer(void)
                     min = _it.real_value;
 
                 to = &buf;
-                to->tv_sec = min / 1000000;
-                to->tv_nsec = (min * 1000) % NANO_IN_SECOND;
+                to->tv_sec = (time_t)(min / 1000000);
+                to->tv_nsec = (time_t)((min * 1000) % NANO_IN_SECOND);
             }
 
             uint64_t start = _get_current_time();

--- a/kernel/malloc.c
+++ b/kernel/malloc.c
@@ -52,7 +52,7 @@ static void* _dlmalloc_mmap(
 
     if (r < 0)
     {
-        errno = -r;
+        errno = (int)-r;
         return MAP_FAILED;
     }
 
@@ -71,7 +71,7 @@ static void* _dlmalloc_mremap(
 
     if (r < 0)
     {
-        errno = -r;
+        errno = (int)-r;
         return MAP_FAILED;
     }
 
@@ -103,7 +103,11 @@ static int _dlmalloc_munmap(void* addr, size_t length)
 #define fprintf(STREAM, ...) myst_eprintf(__VA_ARGS__)
 #define USE_DL_PREFIX 0
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include "../third_party/dlmalloc/malloc.c"
+#pragma GCC diagnostic pop
 
 #define MAX_BACKTRACE_ADDRS 16
 

--- a/kernel/mman.c
+++ b/kernel/mman.c
@@ -469,15 +469,15 @@ done:
  */
 static int _mman_get_prot(
     uint8_t* prot_vector,
-    uint32_t offset,
-    uint32_t num_pages,
+    size_t offset,
+    size_t num_pages,
     int* prot_out)
 {
     const uint8_t* start = prot_vector + offset;
     const uint8_t* end = start + num_pages;
     const uint8_t* p = start;
-    const uint8_t prot = (*p & ~MYST_PENDING_ZEROING_FLAG);
-    const uint8_t protz = (*p | MYST_PENDING_ZEROING_FLAG);
+    const uint8_t prot = (*p & (uint8_t)~MYST_PENDING_ZEROING_FLAG);
+    const uint8_t protz = (*p | (uint8_t)MYST_PENDING_ZEROING_FLAG);
 
     /* set the output protection parameter */
     *prot_out = *p++;
@@ -488,12 +488,12 @@ static int _mman_get_prot(
     {
         if (*p == prot)
         {
-            if ((p = myst_memcchr(p, prot, end - p)) == NULL)
+            if ((p = myst_memcchr(p, prot, (size_t)(end - p))) == NULL)
                 return ret;
         }
         else if (*p == protz)
         {
-            if ((p = myst_memcchr(p, protz, end - p)) == NULL)
+            if ((p = myst_memcchr(p, protz, (size_t)(end - p))) == NULL)
                 return ret;
         }
         else
@@ -2023,7 +2023,7 @@ void myst_mman_set_sanity(myst_mman_t* mman, bool sanity)
 }
 
 /* return the total size of the mman region */
-int myst_mman_total_size(myst_mman_t* mman, size_t* size)
+ssize_t myst_mman_total_size(myst_mman_t* mman, size_t* size)
 {
     ssize_t ret = 0;
 
@@ -2045,7 +2045,7 @@ done:
 }
 
 /* return the amount of free space */
-int myst_mman_free_size(myst_mman_t* mman, size_t* size_out)
+ssize_t myst_mman_free_size(myst_mman_t* mman, size_t* size_out)
 {
     ssize_t ret = 0;
     size_t size;

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -303,7 +303,7 @@ long myst_mmap(
         }
     }
 
-    void* end = (void*)(ret + length);
+    void* end = (void*)((size_t)ret + length);
     assert((void*)ret >= _mman_start && (void*)ret <= _mman_end);
     assert(end >= _mman_start && end <= _mman_end);
 

--- a/kernel/msg.c
+++ b/kernel/msg.c
@@ -56,7 +56,7 @@ long myst_syscall_sendmmsg(
         ret = (*sd->sd_sendmsg)(sd, sock, &msgvec[cnt].msg_hdr, flags);
         if (ret < 0)
             break;
-        msgvec[cnt].msg_len = ret;
+        msgvec[cnt].msg_len = (uint32_t)ret;
     }
     // Only return err when zero msg was sent
     ret = cnt ? (long)cnt : ret;
@@ -99,7 +99,7 @@ long myst_syscall_recvmmsg(
             sd, sock, &msgvec[cnt].msg_hdr, flags & ~MSG_WAITFORONE);
         if (ret < 0)
             break;
-        msgvec[cnt].msg_len = ret;
+        msgvec[cnt].msg_len = (uint32_t)ret;
         // Turns on MSG_DONTWAIT after the first message has been
         // received.
         if (cnt == 1 && flags & MSG_WAITFORONE)

--- a/kernel/pipedev.c
+++ b/kernel/pipedev.c
@@ -181,7 +181,7 @@ static ssize_t _pd_read(
                 if (rem < count)
                 {
                     /* return short count */
-                    ret = count - rem;
+                    ret = (ssize_t)(count - rem);
                     goto done;
                 }
 
@@ -195,7 +195,7 @@ static ssize_t _pd_read(
                 _unlock(pipe);
 
                 /* rem<=count */
-                ret = count - rem;
+                ret = (ssize_t)(count - rem);
                 goto done;
             }
 
@@ -204,7 +204,7 @@ static ssize_t _pd_read(
             {
                 _unlock(pipe);
                 /* return short count */
-                ret = count - rem;
+                ret = (ssize_t)(count - rem);
                 goto done;
             }
 
@@ -241,7 +241,7 @@ static ssize_t _pd_read(
     }
 
     _unlock(pipe);
-    ret = count;
+    ret = (ssize_t)count;
 
 done:
 
@@ -317,7 +317,7 @@ static ssize_t _pd_write(
                 if (rem < count)
                 {
                     /* return short count */
-                    ret = count - rem;
+                    ret = (ssize_t)(count - rem);
                     goto done;
                 }
 
@@ -333,7 +333,7 @@ static ssize_t _pd_write(
                 if (rem < count)
                 {
                     /* return short count */
-                    ret = count - rem;
+                    ret = (ssize_t)(count - rem);
                     goto done;
                 }
 
@@ -375,7 +375,7 @@ static ssize_t _pd_write(
     }
 
     _unlock(pipe);
-    ret = count;
+    ret = (ssize_t)count;
 
 done:
 
@@ -479,7 +479,7 @@ static int _pd_fcntl(
             if (arg != FD_CLOEXEC && arg != 0)
                 ERAISE(-EINVAL);
 
-            pipe->fdflags = arg;
+            pipe->fdflags = (int)arg;
             goto done;
         }
         case F_GETFD:
@@ -495,7 +495,7 @@ static int _pd_fcntl(
             if (arg <= 0)
                 arg = PIPE_BUF;
 
-            ECHECK(myst_round_up(arg, PIPE_BUF, &pipesz));
+            ECHECK(myst_round_up((size_t)arg, PIPE_BUF, &pipesz));
 
             if (!(data = calloc(pipesz, 1)))
                 ERAISE(-ENOMEM);
@@ -506,12 +506,12 @@ static int _pd_fcntl(
             p->data = data;
             p->pipesz = pipesz;
 
-            ret = (long)pipesz;
+            ret = (int)pipesz;
             goto done;
         }
         case F_GETPIPE_SZ:
         {
-            ret = p->pipesz;
+            ret = (int)p->pipesz;
             goto done;
         }
         case F_GETFL:

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -49,7 +49,7 @@ long _poll_kernel(struct pollfd* fds, nfds_t nfds)
             if (events =
                     events & ((fds[i].events) | (POLLERR | POLLHUP | POLLNVAL)))
             {
-                fds[i].revents = events;
+                fds[i].revents = (short)events;
                 total++;
             }
         }
@@ -90,7 +90,7 @@ static long _syscall_poll(struct pollfd* fds, nfds_t nfds, int timeout)
     if (nfds == 0)
     {
         long r;
-        long params[6] = {(long)NULL, nfds, timeout};
+        long params[6] = {(long)NULL, (long)nfds, timeout};
         ECHECK((r = myst_tcall(SYS_poll, params)));
         ret = r;
         goto done;
@@ -213,7 +213,7 @@ static long _syscall_poll(struct pollfd* fds, nfds_t nfds, int timeout)
             break;
 
         if (original_timeout > 0)
-            timeout = original_timeout - lapsed;
+            timeout = original_timeout - (int)lapsed;
         else
             timeout = 500;
 

--- a/kernel/pubkey.c
+++ b/kernel/pubkey.c
@@ -37,7 +37,7 @@ int myst_pubkey_verify(
     /* for each entry in the pubkeys region */
     while (p < end)
     {
-        size_t rem = end - p;
+        size_t rem = (size_t)(end - p);
         size_t len = strnlen(p, rem);
 
         if (len == rem)

--- a/kernel/select.c
+++ b/kernel/select.c
@@ -1,9 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 #include <errno.h>
 #include <poll.h>
 #include <stddef.h>
@@ -17,6 +14,8 @@
 #include <myst/sockdev.h>
 #include <myst/syscall.h>
 #include <myst/tcall.h>
+
+#pragma GCC diagnostic pop
 
 typedef struct _poll_fds
 {
@@ -61,7 +60,7 @@ int _fdset_to_fds(poll_fds_t* fds, short events, fd_set* set, int nfds)
 
     for (fd = 0; fd < nfds; fd++)
     {
-        if (FD_ISSET(fd, set))
+        if (FD_ISSET((uint32_t)fd, set))
             ECHECK(_update_fds(fds, fd, events));
     }
 
@@ -80,7 +79,7 @@ int _fds_to_fdset(poll_fds_t* fds, short revents, fd_set* set)
 
         if ((p->revents & revents))
         {
-            FD_SET(p->fd, set);
+            FD_SET((uint32_t)p->fd, set);
             num_ready++;
         }
     }

--- a/kernel/sendfile.c
+++ b/kernel/sendfile.c
@@ -39,14 +39,14 @@ long myst_syscall_sendfile(int out_fd, int in_fd, off_t* offset, size_t count)
 
         while (r > 0 && (n = read(in_fd, locals->buf, sizeof(locals->buf))) > 0)
         {
-            ssize_t m = write(out_fd, locals->buf, n);
+            ssize_t m = write(out_fd, locals->buf, (size_t)n);
             ECHECK(m);
 
             if (m != n)
                 ERAISE(EIO);
 
             nwritten += m;
-            r -= m;
+            r -= (size_t)m;
         }
     }
 

--- a/kernel/shell.c
+++ b/kernel/shell.c
@@ -43,7 +43,7 @@ static long _readline(const char* prompt, char* buf, size_t count)
         buf[n] = '\0';
     }
 
-    return n;
+    return (long)n;
 }
 
 __attribute__((__unused__)) static void _dump_args(size_t argc, char** argv)
@@ -307,11 +307,11 @@ void myst_start_shell(const char* msg)
 
         if (strcmp(argv[0], "help") == 0)
         {
-            _help_command(argc, argv);
+            _help_command((int)argc, argv);
         }
         else if (strcmp(argv[0], "ls") == 0)
         {
-            _ls_command(argc, argv);
+            _ls_command((int)argc, argv);
         }
         else if (strcmp(argv[0], "pwd") == 0)
         {
@@ -319,11 +319,11 @@ void myst_start_shell(const char* msg)
         }
         else if (strcmp(argv[0], "cd") == 0)
         {
-            _cd_command(argc, argv);
+            _cd_command((int)argc, argv);
         }
         else if (strcmp(argv[0], "mem") == 0)
         {
-            _mem_command(argc, argv);
+            _mem_command((int)argc, argv);
         }
         else if (strcmp(argv[0], "fds") == 0)
         {
@@ -359,11 +359,11 @@ void myst_start_shell(const char* msg)
         }
         else if (strcmp(argv[0], "env") == 0)
         {
-            _env_command(argc, argv);
+            _env_command((int)argc, argv);
         }
         else if (strcmp(argv[0], "args") == 0)
         {
-            _args_command(argc, argv);
+            _args_command((int)argc, argv);
         }
         else if (strcmp(argv[0], "cont") == 0)
         {

--- a/kernel/tcall.c
+++ b/kernel/tcall.c
@@ -127,20 +127,20 @@ long myst_tcall_poll_wake(void)
 
 long myst_tcall_poll(struct pollfd* fds, nfds_t nfds, int timeout)
 {
-    long params[6] = {(long)fds, nfds, timeout};
+    long params[6] = {(long)fds, (long)nfds, timeout};
     return myst_tcall(SYS_poll, params);
 }
 
 int myst_open_block_device(const char* path, bool read_only)
 {
     long params[6] = {(long)path, read_only};
-    return myst_tcall(MYST_TCALL_OPEN_BLOCK_DEVICE, params);
+    return (int)myst_tcall(MYST_TCALL_OPEN_BLOCK_DEVICE, params);
 }
 
 int myst_close_block_device(int blkdev)
 {
     long params[6] = {blkdev};
-    return myst_tcall(MYST_TCALL_CLOSE_BLOCK_DEVICE, params);
+    return (int)myst_tcall(MYST_TCALL_CLOSE_BLOCK_DEVICE, params);
 }
 
 ssize_t myst_read_block_device(
@@ -149,7 +149,7 @@ ssize_t myst_read_block_device(
     struct myst_block* blocks,
     size_t num_blocks)
 {
-    long params[6] = {blkdev, blkno, (long)blocks, num_blocks};
+    long params[6] = {blkdev, (long)blkno, (long)blocks, (long)num_blocks};
     return myst_tcall(MYST_TCALL_READ_BLOCK_DEVICE, params);
 }
 
@@ -159,8 +159,8 @@ int myst_write_block_device(
     const struct myst_block* blocks,
     size_t num_blocks)
 {
-    long params[6] = {blkdev, blkno, (long)blocks, num_blocks};
-    return myst_tcall(MYST_TCALL_WRITE_BLOCK_DEVICE, params);
+    long params[6] = {blkdev, (long)blkno, (long)blocks, (long)num_blocks};
+    return (int)myst_tcall(MYST_TCALL_WRITE_BLOCK_DEVICE, params);
 }
 
 int myst_luks_encrypt(
@@ -171,8 +171,9 @@ int myst_luks_encrypt(
     size_t size,
     uint64_t secno)
 {
-    long params[6] = {(long)phdr, (long)key, (long)in, (long)out, size, secno};
-    return myst_tcall(MYST_TCALL_LUKS_ENCRYPT, params);
+    long params[6] = {
+        (long)phdr, (long)key, (long)in, (long)out, (long)size, (long)secno};
+    return (int)myst_tcall(MYST_TCALL_LUKS_ENCRYPT, params);
 }
 
 int myst_luks_decrypt(
@@ -183,26 +184,27 @@ int myst_luks_decrypt(
     size_t size,
     uint64_t secno)
 {
-    long params[6] = {(long)phdr, (long)key, (long)in, (long)out, size, secno};
-    return myst_tcall(MYST_TCALL_LUKS_DECRYPT, params);
+    long params[6] = {
+        (long)phdr, (long)key, (long)in, (long)out, (long)size, (long)secno};
+    return (int)myst_tcall(MYST_TCALL_LUKS_DECRYPT, params);
 }
 
 int myst_sha256_start(myst_sha256_ctx_t* ctx)
 {
     long params[6] = {(long)ctx};
-    return myst_tcall(MYST_TCALL_SHA256_START, params);
+    return (int)myst_tcall(MYST_TCALL_SHA256_START, params);
 }
 
 int myst_sha256_update(myst_sha256_ctx_t* ctx, const void* data, size_t size)
 {
-    long params[6] = {(long)ctx, (long)data, size};
-    return myst_tcall(MYST_TCALL_SHA256_UPDATE, params);
+    long params[6] = {(long)ctx, (long)data, (long)size};
+    return (int)myst_tcall(MYST_TCALL_SHA256_UPDATE, params);
 }
 
 int myst_sha256_finish(myst_sha256_ctx_t* ctx, myst_sha256_t* sha256)
 {
     long params[6] = {(long)ctx, (long)sha256};
-    return myst_tcall(MYST_TCALL_SHA256_FINISH, params);
+    return (int)myst_tcall(MYST_TCALL_SHA256_FINISH, params);
 }
 
 int myst_tcall_verify_signature(
@@ -216,25 +218,25 @@ int myst_tcall_verify_signature(
 {
     long args[7] = {(long)pem_public_key,
                     (long)hash,
-                    hash_size,
+                    (long)hash_size,
                     (long)signer,
-                    signer_size,
+                    (long)signer_size,
                     (long)signature,
-                    signature_size};
+                    (long)signature_size};
     long params[6] = {(long)args};
-    return myst_tcall(MYST_TCALL_VERIFY_SIGNATURE, params);
+    return (int)myst_tcall(MYST_TCALL_VERIFY_SIGNATURE, params);
 }
 
 int myst_tcall_load_fssig(const char* path, myst_fssig_t* fssig)
 {
     long params[6] = {(long)path, (long)fssig};
-    return myst_tcall(MYST_TCALL_LOAD_FSSIG, params);
+    return (int)myst_tcall(MYST_TCALL_LOAD_FSSIG, params);
 }
 
 int myst_tcall_mprotect(void* addr, size_t len, int prot)
 {
     long params[6] = {(long)addr, (long)len, (long)prot};
-    return myst_tcall(SYS_mprotect, params);
+    return (int)myst_tcall(SYS_mprotect, params);
 }
 
 #ifdef MYST_ENABLE_GCOV

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -408,11 +408,11 @@ long myst_syscall_waitid(
     int pid = 0;
     if (idtype == P_PID)
     {
-        pid = id;
+        pid = (pid_t)id;
     }
     else if (idtype == P_PGID)
     {
-        pid = -id;
+        pid = -(pid_t)id;
     }
     else if (idtype == P_ALL)
     {

--- a/kernel/times.c
+++ b/kernel/times.c
@@ -186,14 +186,14 @@ void myst_print_syscall_times(const char* message, size_t count)
         if (myst_syscall_clock_gettime(CLOCK_REALTIME, &now) == 0)
         {
             struct timespec start;
-            start.tv_sec = __myst_kernel_args.start_time_sec;
-            start.tv_nsec = __myst_kernel_args.start_time_nsec;
+            start.tv_sec = (long)__myst_kernel_args.start_time_sec;
+            start.tv_nsec = (long)__myst_kernel_args.start_time_nsec;
             long nsec = myst_lapsed_nsecs(&start, &now);
             elapsed_secs = (double)nsec / (double)NANO_IN_SECOND;
         }
     }
 
-    for (size_t i = 0; i < MYST_MAX_SYSCALLS; i++)
+    for (long i = 0; i < MYST_MAX_SYSCALLS; i++)
     {
         if (_syscall_times[i].nsec)
         {
@@ -236,7 +236,7 @@ void myst_print_syscall_times(const char* message, size_t count)
             nsec_width = n;
 
         if (len > (size_t)name_width)
-            name_width = len;
+            name_width = (int)len;
     }
 
     if (ntimes > count)
@@ -246,9 +246,10 @@ void myst_print_syscall_times(const char* message, size_t count)
     for (size_t i = 0; i < ntimes; i++)
     {
         const times_t* p = &locals->times[i];
-        double percent = (p->nsec / nsecs) * 100.0;
+        double percent = ((double)p->nsec / nsecs) * 100.0;
         const char* name = myst_syscall_str(p->num);
-        double percent2 = ((p->nsec / p->ncalls) / nsecs) * 100.0;
+        double percent2 =
+            (((double)p->nsec / (double)p->ncalls) / nsecs) * 100.0;
         char buf[128];
 
         int n = snprintf(
@@ -271,16 +272,17 @@ void myst_print_syscall_times(const char* message, size_t count)
     }
 
     myst_eprintf(COLOR_YELLOW "\n");
-    _print_line(nchars);
+    _print_line((size_t)nchars);
     myst_eprintf("%s: %.4lf seconds elapsed\n", message, elapsed_secs);
-    _print_line(nchars);
+    _print_line((size_t)nchars);
 
     for (size_t i = 0; i < ntimes; i++)
     {
         const times_t* p = &locals->times[i];
-        double percent = (p->nsec / nsecs) * 100.0;
+        double percent = ((double)p->nsec / nsecs) * 100.0;
         const char* name = myst_syscall_str(p->num);
-        double percent2 = ((p->nsec / p->ncalls) / nsecs) * 100.0;
+        double percent2 =
+            (((double)p->nsec / (double)p->ncalls) / nsecs) * 100.0;
 
         myst_eprintf(
             fmt,

--- a/kernel/ttydev.c
+++ b/kernel/ttydev.c
@@ -192,7 +192,7 @@ static int _td_fcntl(myst_ttydev_t* ttydev, myst_tty_t* tty, int cmd, long arg)
             if (arg != FD_CLOEXEC && arg != 0)
                 ERAISE(-EINVAL);
 
-            tty->fdflags = arg;
+            tty->fdflags = (int)arg;
             goto done;
         }
         case F_GETFD:

--- a/kernel/uid_gid.c
+++ b/kernel/uid_gid.c
@@ -156,17 +156,17 @@ long myst_valid_uid_against_passwd_file(uid_t uid)
 
     file_length = file_stat.st_size;
 
-    buffer = malloc(file_length + 1);
+    buffer = malloc((size_t)file_length + 1);
     if (buffer == NULL)
         goto done;
     buffer[file_length] = '\0';
 
-    fd = myst_syscall_open("/etc/passwd", O_RDONLY, 0);
+    fd = (int)myst_syscall_open("/etc/passwd", O_RDONLY, 0);
     if (fd == -1)
         goto done;
 
     /* read into buffer */
-    if (myst_syscall_read(fd, buffer, file_length) != file_length)
+    if (myst_syscall_read(fd, buffer, (size_t)file_length) != file_length)
         goto done;
 
     /* Failures from now are not found errors */
@@ -248,7 +248,7 @@ done:
 
     if (buffer)
     {
-        memset(buffer, 0, file_length);
+        memset(buffer, 0, (size_t)file_length);
         free(buffer);
     }
     return ret;
@@ -290,17 +290,17 @@ long myst_valid_gid_against_group_file(gid_t gid)
 
     file_length = file_stat.st_size;
 
-    buffer = malloc(file_length + 1);
+    buffer = malloc((size_t)file_length + 1);
     if (buffer == NULL)
         goto done;
     buffer[file_length] = '\0';
 
-    fd = myst_syscall_open("/etc/group", O_RDONLY, 0);
+    fd = (int)myst_syscall_open("/etc/group", O_RDONLY, 0);
     if (fd == -1)
         goto done;
 
     /* read into buffer */
-    if (myst_syscall_read(fd, buffer, file_length) != file_length)
+    if (myst_syscall_read(fd, buffer, (size_t)file_length) != file_length)
         goto done;
 
     /* Failures from now are not found errors */
@@ -361,7 +361,7 @@ done:
 
     if (buffer)
     {
-        memset(buffer, 0, file_length);
+        memset(buffer, 0, (size_t)file_length);
         free(buffer);
     }
     return ret;
@@ -464,7 +464,7 @@ gid_t myst_syscall_getegid()
 
 long myst_syscall_setreuid(uid_t ruid, uid_t euid)
 {
-    uid_t sav_uid = -1;
+    uid_t sav_uid = (uid_t)-1;
     long ret = 0;
     myst_thread_t* thread = myst_thread_self();
 
@@ -547,7 +547,7 @@ long myst_syscall_setreuid(uid_t ruid, uid_t euid)
 
 long myst_syscall_setregid(gid_t rgid, gid_t egid)
 {
-    gid_t sav_gid = -1;
+    gid_t sav_gid = (gid_t)-1;
     long ret = 0;
     myst_thread_t* thread = myst_thread_self();
 
@@ -829,7 +829,7 @@ long myst_syscall_getgroups(int size, gid_t list[])
 
     /* if size if 0 return number of supguid */
     if (size == 0)
-        return thread->num_supgid;
+        return (long)thread->num_supgid;
 
     /* validate parameters */
     if ((thread->num_supgid > (size_t)size) || (size < 0))
@@ -842,7 +842,7 @@ long myst_syscall_getgroups(int size, gid_t list[])
 
     memcpy(list, thread->supgid, thread->num_supgid * sizeof(gid_t));
 
-    return thread->num_supgid;
+    return (long)thread->num_supgid;
 }
 
 long myst_syscall_setgroups(size_t size, const gid_t* list)

--- a/third_party/musl/pristine/Makefile
+++ b/third_party/musl/pristine/Makefile
@@ -51,5 +51,7 @@ musl/config.mak:
 
 musl:
 	git clone $(URL) -b $(BRANCH)
+	./wrap.sh musl/include/endian.h
+	./wrap.sh musl/include/sys/select.h
 
 tests:

--- a/third_party/musl/pristine/wrap.sh
+++ b/third_party/musl/pristine/wrap.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+##==============================================================================
+##
+## Wrap the given source file with a preamble and postamble
+##
+##==============================================================================
+
+if [ "$#" != "1" ]; then
+    echo "Usage: $0 <source-file>"
+    exit 1
+fi
+
+if [ ! -f "$1" ]; then
+    echo "$0: no such file: $1"
+    exit 1
+fi
+
+cp $1 $1.bak
+
+cat > $1 <<EOF
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+EOF
+
+cat $1.bak >> $1
+
+cat >> $1 <<EOF
+#pragma GCC diagnostic pop
+EOF
+
+rm -f $1.bak


### PR DESCRIPTION
This PR fixes conversion warnings that were exposed by enabling ``-Wconversion`` in the kernel.