### PR TITLE
Preserve file mode for cpio files

### DIFF
--- a/include/myst/cpio.h
+++ b/include/myst/cpio.h
@@ -96,7 +96,8 @@ int myst_cpio_next_entry(
 typedef int (*myst_cpio_create_file_function_t)(
     const char* path,
     const void* file_data,
-    size_t file_size);
+    size_t file_size,
+    uint32_t mode);
 
 int myst_cpio_mem_unpack(
     const void* cpio_data,

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -395,7 +395,8 @@ static const char* _getenv(const char** envp, const char* varname)
 static int _create_mem_file(
     const char* path,
     const void* file_data,
-    size_t file_size)
+    size_t file_size,
+    uint32_t file_mode)
 {
     int ret = 0;
     int fd = -1;
@@ -403,7 +404,7 @@ static int _create_mem_file(
     if (!path || !file_data)
         ERAISE(-EINVAL);
 
-    if ((fd = open(path, O_WRONLY | O_CREAT, 0444)) < 0)
+    if ((fd = open(path, O_WRONLY | O_CREAT, file_mode)) < 0)
     {
         myst_panic("kernel: open(): %s\n", path);
         ERAISE(-ENOENT);

--- a/utils/cpio.c
+++ b/utils/cpio.c
@@ -1107,8 +1107,11 @@ int myst_cpio_mem_unpack(
         {
             if (create_file)
             {
-                if ((*create_file)(locals->path, file_data, locals->ent.size) !=
-                    0)
+                if ((*create_file)(
+                        locals->path,
+                        file_data,
+                        locals->ent.size,
+                        locals->ent.mode) != 0)
                     GOTO(done);
             }
             else
@@ -1116,6 +1119,7 @@ int myst_cpio_mem_unpack(
                 int fd;
                 ssize_t n = (ssize_t)locals->ent.size;
 
+                // ATTN: Can we replace 0666 with locals->ent.mode?
                 if ((fd = open(locals->path, O_WRONLY | O_CREAT, 0666)) < 0)
                     GOTO(done);
 

--- a/utils/verityblkdev.c
+++ b/utils/verityblkdev.c
@@ -217,6 +217,7 @@ static void _cache_evict(blkdev_t* dev)
         cache_block_t* cb = dev->lru.head;
 
         assert(cb->dirty == false);
+        assert(cb->slot <= MAX_CHAINS);
 
         /* remove from the chain */
         myst_list_remove(&dev->chains[cb->slot], (myst_list_node_t*)cb);


### PR DESCRIPTION
cpio files are unpacked to have a static mode of 0444.
dotnet process API [checks for access(X_OK)](https://github.com/dotnet/runtime/blob/v5.0.0-rtm.20519.4/src/libraries/Native/Unix/System.Native/pal_process.c#L275) in its fork-exec code path.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>