### PR TITLE
Use VSDO-based clock_gettime() on the Linux target

### DIFF
--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -87,18 +87,9 @@ static long _tcall_clock_getres(clockid_t clk_id, struct timespec* res)
 
 static long _tcall_clock_gettime(clockid_t clk_id, struct timespec* tp)
 {
-    // The C clock_gettime() function is much faster than the SYS_clock_gettime
-    // system call. The clock_gettime() function calls into the linux-vdso.so
-    // library, which executes the operation in user-space.
-    //
-    // Unfortunately some VMs fail when using the C clock_gettime() function.
-    // This optimization is disabled for the time being.
-#if 0
-    // ATTN: determine why this optimization fails on some VMs.
+    // The clock_gettime() function is much faster than the system call because
+    // it calls into linux-vdso.so and avoids the system call overhead.
     return clock_gettime(clk_id, tp);
-#else
-    return syscall(SYS_clock_gettime, clk_id, tp);
-#endif
 }
 
 static long _tcall_clock_settime(clockid_t clk_id, struct timespec* tp)


### PR DESCRIPTION
Use the ``clock_gettime()`` C function rather than the corresponding syscall. The C function calls into ``linux-vdso.so`` on Linux, which is much faster because it utilizes a user-space clock and avoids the syscall context switch.

It was so much faster that the elapsed time during a syscall could be zero (for fast syscalls), so we had to tolerate a zero elapsed time.