### PR TITLE
Add procfs entry for /proc/[pid]/stat 

### DIFF
--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -66,7 +66,7 @@ typedef struct myst_mman_stats
 
 void myst_mman_stats(myst_mman_stats_t* buf);
 
-int proc_pid_maps_vcallback(myst_buf_t* vbuf, char* entrypath);
+int proc_pid_maps_vcallback(myst_buf_t* vbuf, const char* entrypath);
 
 /* marks all pages in the mapping as owned by the given process */
 int myst_mman_pids_set(const void* addr, size_t length, pid_t pid);

--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -66,7 +66,7 @@ typedef struct myst_mman_stats
 
 void myst_mman_stats(myst_mman_stats_t* buf);
 
-int proc_pid_maps_vcallback(myst_buf_t* vbuf);
+int proc_pid_maps_vcallback(myst_buf_t* vbuf, char* entrypath);
 
 /* marks all pages in the mapping as owned by the given process */
 int myst_mman_pids_set(const void* addr, size_t length, pid_t pid);

--- a/include/myst/procfs.h
+++ b/include/myst/procfs.h
@@ -11,7 +11,7 @@
 int create_proc_root_entries();
 
 /* For callbacks implementing /proc/[pid]/xxx entries */
-myst_thread_t* myst_procfs_path_to_process(char* entrypath);
+myst_thread_t* myst_procfs_path_to_process(const char* entrypath);
 
 /*
 **==============================================================================

--- a/include/myst/procfs.h
+++ b/include/myst/procfs.h
@@ -10,6 +10,9 @@
 
 int create_proc_root_entries();
 
+/* For callbacks implementing /proc/[pid]/xxx entries */
+myst_thread_t* myst_procfs_path_to_process(char* entrypath);
+
 /*
 **==============================================================================
 **

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -39,7 +39,7 @@ typedef enum myst_virtual_file_type
 } myst_virtual_file_type_t;
 
 typedef union myst_vcallback {
-    int (*open_cb)(myst_buf_t* buf, char* entrypath);
+    int (*open_cb)(myst_buf_t* buf, const char* entrypath);
     struct
     {
         int (*read_cb)(void* buf, size_t count);

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -39,7 +39,7 @@ typedef enum myst_virtual_file_type
 } myst_virtual_file_type_t;
 
 typedef union myst_vcallback {
-    int (*open_cb)(myst_buf_t* buf);
+    int (*open_cb)(myst_buf_t* buf, char* realpath);
     struct
     {
         int (*read_cb)(void* buf, size_t count);

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -39,7 +39,7 @@ typedef enum myst_virtual_file_type
 } myst_virtual_file_type_t;
 
 typedef union myst_vcallback {
-    int (*open_cb)(myst_buf_t* buf, char* realpath);
+    int (*open_cb)(myst_buf_t* buf, char* entrypath);
     struct
     {
         int (*read_cb)(void* buf, size_t count);

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -415,6 +415,8 @@ size_t myst_get_num_threads(void);
 
 myst_thread_t* myst_find_thread(int tid);
 
+myst_thread_t* myst_find_process(pid_t pid);
+
 void myst_fork_exec_futex_wake(myst_thread_t* thread);
 
 size_t myst_kill_thread_group();

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -415,6 +415,10 @@ size_t myst_get_num_threads(void);
 
 myst_thread_t* myst_find_thread(int tid);
 
+/* Caller should hold myst_process_list_lock before calling this function. And
+ * release it once its done with its use of the process thread pointer.
+ * This is done to protect from the process thread descriptor being cleaned up
+ * by some other thread.*/
 myst_thread_t* myst_find_process(pid_t pid);
 
 void myst_fork_exec_futex_wake(myst_thread_t* thread);

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -757,7 +757,7 @@ done:
     return ret;
 }
 
-int proc_pid_maps_vcallback(myst_buf_t* vbuf)
+int proc_pid_maps_vcallback(myst_buf_t* vbuf, char* entrypath)
 {
     int ret = 0;
     bool locked = false;
@@ -767,6 +767,8 @@ int proc_pid_maps_vcallback(myst_buf_t* vbuf)
         char realpath[PATH_MAX];
         char maps_entry[48 + PATH_MAX];
     }* locals = NULL;
+
+    (void)entrypath;
 
     if (!vbuf)
         ERAISE(-EINVAL);

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -759,7 +759,7 @@ done:
     return ret;
 }
 
-int proc_pid_maps_vcallback(myst_buf_t* vbuf, char* entrypath)
+int proc_pid_maps_vcallback(myst_buf_t* vbuf, const char* entrypath)
 {
     int ret = 0;
     bool locked = false;

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+
 #include <unistd.h>
 
 #include <myst/atexit.h>
@@ -770,6 +771,8 @@ int proc_pid_maps_vcallback(myst_buf_t* vbuf, char* entrypath)
         myst_thread_t* process_thread;
     }* locals = NULL;
 
+    myst_spin_lock(&myst_process_list_lock);
+
     if (!vbuf && !entrypath)
         ERAISE(-EINVAL);
 
@@ -892,6 +895,8 @@ int proc_pid_maps_vcallback(myst_buf_t* vbuf, char* entrypath)
 
 done:
     _runlock(&locked);
+
+    myst_spin_unlock(&myst_process_list_lock);
 
     if (ret != 0)
         myst_buf_release(vbuf);

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -429,7 +429,7 @@ static int _stat_vcallback(myst_buf_t* vbuf, char* entrypath)
     if (!vbuf)
         ERAISE(-EINVAL);
 
-    locals->process_thread = myst_find_thread(parse_pid(entrypath));
+    locals->process_thread = myst_find_process(parse_pid(entrypath));
     assert(myst_is_process_thread(locals->process_thread));
 
     myst_buf_clear(vbuf);

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -302,6 +302,8 @@ static int _status_vcallback(myst_buf_t* vbuf, char* entrypath)
     void* buf = NULL;
     size_t buf_size;
 
+    myst_spin_lock(&myst_process_list_lock);
+
     if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
@@ -385,6 +387,9 @@ static int _status_vcallback(myst_buf_t* vbuf, char* entrypath)
     /* TODO: memory, signal, capability and cpu related fields*/
 
 done:
+
+    myst_spin_unlock(&myst_process_list_lock);
+
     if (locals && locals->_host_status_buf)
         free(locals->_host_status_buf);
 
@@ -424,6 +429,8 @@ static int _stat_vcallback(myst_buf_t* vbuf, char* entrypath)
         myst_thread_t* process_thread;
     };
     struct locals* locals = NULL;
+
+    myst_spin_lock(&myst_process_list_lock);
 
     if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
@@ -500,6 +507,8 @@ static int _stat_vcallback(myst_buf_t* vbuf, char* entrypath)
     ECHECK(myst_buf_append(vbuf, tmp, strlen(tmp)));
 
 done:
+
+    myst_spin_unlock(&myst_process_list_lock);
 
     if (locals)
         free(locals);

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -414,6 +414,25 @@ done:
     return ret;
 }
 
+static char get_process_status(myst_thread_t* process_thread)
+{
+    if (process_thread->signal.waiting_on_event)
+    {
+        return 'S';
+    }
+
+    switch (process_thread->status)
+    {
+        case MYST_ZOMBIE:
+            return 'Z';
+        default:
+            // default to running
+            return 'R';
+    }
+
+    // ATTN: Support other process states
+}
+
 static int _stat_vcallback(myst_buf_t* vbuf, char* entrypath)
 {
     int ret = 0;
@@ -438,10 +457,10 @@ static int _stat_vcallback(myst_buf_t* vbuf, char* entrypath)
     ECHECK(myst_snprintf(
         tmp,
         sizeof(tmp),
-        "%d (%s) V %d %d %d ",
+        "%d (%s) %c %d %d %d ",
         locals->process_thread->pid,
         locals->process_thread->name,
-        // state
+        get_process_status(locals->process_thread),
         locals->process_thread->ppid,
         locals->process_thread->main.pgid,
         locals->process_thread->sid));

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -708,13 +708,12 @@ myst_thread_t* myst_find_thread(int tid)
     return target;
 }
 
+// Caller should hold myst_proces_list_lock!
 myst_thread_t* myst_find_process(pid_t pid)
 {
     myst_thread_t* curr_process = myst_find_process_thread(myst_thread_self());
     myst_thread_t* target = NULL;
     myst_thread_t* t = NULL;
-
-    myst_spin_lock(&myst_process_list_lock);
 
     // Search forward in the doubly linked list for a match
     for (t = curr_process; t != NULL; t = t->main.next_process_thread)
@@ -740,7 +739,6 @@ myst_thread_t* myst_find_process(pid_t pid)
         }
     }
 
-    myst_spin_unlock(&myst_process_list_lock);
     return target;
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -887,10 +887,10 @@ static long _run_thread(void* arg_)
             const int futex_op = FUTEX_WAKE | FUTEX_PRIVATE;
             myst_syscall_futex(thread->clone.ptid, futex_op, 1, 0, NULL, 0);
         }
-
-        /* Start time tracking for this thread */
-        myst_times_start();
     }
+
+    /* Start time tracking for this thread */
+    myst_times_start();
 
     /* Jump back here from exit */
     if (myst_setjmp(&thread->jmpbuf) != 0)

--- a/tests/dotnet-proc-maps/Makefile
+++ b/tests/dotnet-proc-maps/Makefile
@@ -11,7 +11,7 @@ endif
 all: rootfs
 
 tests:
-	$(RUNTEST) ./exec.sh $(MYST_EXEC) $(OPTS) --app-config-path config.json rootfs /app/HelloWorld
+	COMPlus_EnableDiagnostics=0 $(RUNTEST) ./exec.sh $(MYST_EXEC) $(OPTS) --app-config-path config.json rootfs /app/HelloWorld
 	@ echo "=== passed test (dotnet-proc-maps)"
 
 gdb: rootfs

--- a/tests/procfs/Makefile
+++ b/tests/procfs/Makefile
@@ -27,4 +27,4 @@ myst:
 	$(MAKE) -C $(TOP)/tools/myst
 
 clean:
-	rm -rf $(APPDIR) rootfs export ramfs *.o
+	rm -rf $(APPDIR) rootfs ramfs *.o

--- a/tests/procfs/Makefile
+++ b/tests/procfs/Makefile
@@ -9,6 +9,8 @@ ifdef STRACE
 OPTS += --strace
 endif
 
+OPTS += --fork-mode pseudo_wait_for_exit_exec
+
 all: myst rootfs
 
 rootfs: procfs.c maps.c ../../host/maps.c
@@ -25,4 +27,4 @@ myst:
 	$(MAKE) -C $(TOP)/tools/myst
 
 clean:
-	rm -rf $(APPDIR) rootfs export ramfs
+	rm -rf $(APPDIR) rootfs export ramfs *.o

--- a/tests/procfs/procfs.c
+++ b/tests/procfs/procfs.c
@@ -13,6 +13,7 @@
 #include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -312,7 +313,8 @@ int test_stat_from_child()
     }
     else // parent
     {
-        wait();
+        int status;
+        wait(&status);
     }
 }
 
@@ -325,8 +327,7 @@ int main(int argc, const char* argv[])
     test_cpuinfo();
     test_fdatasync();
     test_stat();
-    // ATTN: Enable after Paul's shutdown PR goes in
-    // test_stat_from_child();
+    test_stat_from_child();
 
     printf("\n=== passed test (%s)\n", argv[0]);
     return 0;


### PR DESCRIPTION
### Summary
- Adds support for /proc/[pid]/support.
- Fixes pid specific entries - /proc/[pid]/maps and /proc/[pid]/status, when called from a different process.
- Adds lookup function for a process thread by pid. Returns pointer to process thread on success, NULL on failure -
```C
myst_thread_t* myst_find_process(pid_t pid);
```