### PR TITLE
Pin cpython test suite to python3.8.11 release

### DIFF
--- a/tests/cpython-tests/Dockerfile
+++ b/tests/cpython-tests/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -y build-essential libssl-dev zlib1g-dev libncurse
         libreadline-dev libsqlite3-dev libgdbm-dev libdb5.3-dev libbz2-dev \
         libexpat1-dev liblzma-dev libffi-dev git
 
-RUN git clone --branch 3.8 https://github.com/python/cpython
+RUN git clone -b v3.8.11 https://github.com/python/cpython
 WORKDIR /cpython
 RUN ./configure --with-pydebug && make -j -s
 

--- a/tests/cpython-tests/Makefile
+++ b/tests/cpython-tests/Makefile
@@ -3,7 +3,7 @@ include $(TOP)/defs.mak
 
 APPBUILDER=$(TOP)/scripts/appbuilder
 HEAP_SIZE="4G"
-OPTS += --memory-size $(HEAP_SIZE)
+OPTS += --memory-size $(HEAP_SIZE) --nobrk
 ifdef STRACE
 OPTS += --strace
 endif


### PR DESCRIPTION
Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>

Current implementation of /tests/cpython attempts to use the tip of the 3.8 branch of cpython github repo. Some recent commit ot the branch broke the Mytikos test suite. This PR pins the test suite to v3.8.11 release, and adds --nobrk to Mystikos configuration.