### PR TITLE
Temp workaround for gcov issue

### DIFF
--- a/tools/myst/enc/Makefile
+++ b/tools/myst/enc/Makefile
@@ -57,5 +57,9 @@ EDGER8R_OPTS += --trusted
 EDGER8R_OPTS += --search-path $(OE_INCDIR)
 EDGER8R_OPTS += --trusted-dir $(SUBOBJDIR)
 
+ifdef MYST_ENABLE_GCOV
+EDGER8R_OPTS += -DGCOV
+endif
+
 $(SUBOBJDIR)/myst_t.c: ../myst.edl
 	$(EDGER8R) $(EDGER8R_OPTS) ../myst.edl

--- a/tools/myst/host/Makefile
+++ b/tools/myst/host/Makefile
@@ -19,7 +19,7 @@ INCLUDES = $(OEHOST_INCLUDES) -I$(SUBOBJDIR) -I$(INCDIR) -I../
 CFLAGS = $(OEHOST_CFLAGS)
 
 ifdef MYST_ENABLE_GCOV
-DEFINES += $(GCOV_CFLAGS)
+CFLAGS += $(GCOV_CFLAGS)
 endif
 
 ifdef MYST_ENABLE_ZERO_BASE_ENCLAVES
@@ -55,6 +55,10 @@ include $(TOP)/rules.mak
 EDGER8R_OPTS += --untrusted
 EDGER8R_OPTS += --search-path $(OE_INCDIR)
 EDGER8R_OPTS += --untrusted-dir $(SUBOBJDIR)
+
+ifdef MYST_ENABLE_GCOV
+EDGER8R_OPTS += -DGCOV
+endif
 
 $(SUBOBJDIR)/myst_u.c: ../myst.edl
 	$(EDGER8R) $(EDGER8R_OPTS) ../myst.edl

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -270,7 +270,17 @@ enclave
             mode_t mode,
             uid_t uid,
             gid_t gid);
+#ifdef GCOV
+        long myst_read_ocall(
+            int fd,
+            [out, size=count] void* buf,
+            size_t count);
 
+        long myst_write_ocall(
+            int fd,
+            [in, size=count] const void* buf,
+            size_t count);
+#else
         long myst_read_ocall(
             int fd,
             [out, size=count] void* buf,
@@ -282,6 +292,7 @@ enclave
             [in, size=count] const void* buf,
             size_t count)
             transition_using_threads;
+#endif
 
         long myst_close_ocall(int fd);
 


### PR DESCRIPTION
Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>

- Fix the bug in /tools/myst/host/Makefile that caused gcov build failure
- Temporary workaroud to address the  gcov test timeout issue due to switchless read/writer hostfs OCALLs, switching off the "switchless" configuration for those two OCALLs in gcov build