### PR TITLE
Reimplement pthread_getattr_np()

### DIFF
--- a/crt/pthread.c
+++ b/crt/pthread.c
@@ -1,0 +1,41 @@
+#define hidden __attribute__((__visibility__("hidden")))
+
+#include <myst/syscallext.h>
+#include <pthread_impl.h>
+#include <stdio.h>
+#include <string.h>
+#include <syscall.h>
+
+// Reimplement pthread_getattr_np() using the SYS_get_process_thread_stack
+// extended syscall. The musl libc version is less efficient since it uses
+// mremap() probing to find the guard page. Also, the musl libc version will
+// not work with Mystikos since the stack is obtained with malloc() rather
+// than mmap().
+int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr)
+{
+    uintptr_t stackaddr = 0;
+    size_t stacksize = 0;
+
+    if (!thread || !attr)
+        return EINVAL;
+
+    if (thread->stack) /* this thread was created by pthread_create() */
+    {
+        stackaddr = (uintptr_t)thread->stack;
+        stacksize = thread->stack_size;
+    }
+    else /* this is the main thread and was created by the program loader */
+    {
+        if (syscall(SYS_get_process_thread_stack, &stackaddr, &stacksize) != 0)
+            return ENOSYS;
+        stackaddr += stacksize;
+    }
+
+    *attr = (pthread_attr_t){0};
+    attr->_a_detach = (thread->detach_state >= DT_DETACHED) ? 1 : 0;
+    attr->_a_guardsize = thread->guard_size;
+    attr->_a_stackaddr = stackaddr;
+    attr->_a_stacksize = stacksize;
+
+    return 0;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -116,6 +116,7 @@ DIRS += synccall
 DIRS += python_subprocess
 DIRS += python_vfork
 DIRS += fcntl
+DIRS += stacksize
 
 .PHONY: $(DIRS)
 

--- a/tests/stacksize/.gitignore
+++ b/tests/stacksize/.gitignore
@@ -1,0 +1,1 @@
+stacksize

--- a/tests/stacksize/Makefile
+++ b/tests/stacksize/Makefile
@@ -1,0 +1,32 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC -I$(INCDIR)
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs: stacksize.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/stacksize stacksize.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+ifdef PERF
+OPTS = --perf
+endif
+
+tests: all
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/stacksize $(OPTS)
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs

--- a/tests/stacksize/stacksize.c
+++ b/tests/stacksize/stacksize.c
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <limits.h>
+#include <myst/syscallext.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/auxv.h>
+#include <unistd.h>
+
+int main(int argc, const char* argv[])
+{
+    register uint64_t sp __asm__("rsp");
+    void* stack1;
+    size_t size1;
+    void* stack2;
+    size_t size2;
+
+    /* Get the stack and stack size with an extended syscall */
+    assert(syscall(SYS_get_process_thread_stack, &stack1, &size1) == 0);
+
+    /* Get the stack and stack size with the pthread interface */
+    {
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        assert(pthread_getattr_np(pthread_self(), &attr) == 0);
+        assert(pthread_attr_getstack(&attr, &stack2, &size2) == 0);
+        pthread_attr_destroy(&attr);
+    }
+
+    printf("[%p:%zu]\n", stack2, size2);
+    printf("[%p:%zu]\n", stack1, size1);
+    assert(stack1 == stack2);
+    assert(size1 == size2);
+
+    printf("=== passed test (%s)\n", argv[0]);
+
+    return 0;
+}

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -1080,6 +1080,18 @@ index 5f491092..51c9fafb 100644
  	}
  
  	if (ret >= 0) {
+diff --git a/src/thread/pthread_getattr_np.c b/src/thread/pthread_getattr_np.c
+index 2881831f..26167cf7 100644
+--- a/src/thread/pthread_getattr_np.c
++++ b/src/thread/pthread_getattr_np.c
+@@ -3,6 +3,7 @@
+ #include "libc.h"
+ #include <sys/mman.h>
+ 
++__attribute__((__weak__))
+ int pthread_getattr_np(pthread_t t, pthread_attr_t *a)
+ {
+ 	*a = (pthread_attr_t){0};
 diff --git a/src/thread/pthread_mutex_consistent.c b/src/thread/pthread_mutex_consistent.c
 index 27c74e5b..efadeec8 100644
 --- a/src/thread/pthread_mutex_consistent.c


### PR DESCRIPTION
Reimplement ``pthread_getattr_np()`` using the ``SYS_get_process_thread_stack`` extended syscall. The musl libc version is less efficient since it uses ``mremap()`` probing to find the guard page. Also, the musl libc version will not work with Mystikos since the stack is obtained with ``malloc()`` rather than ``mmap()``.
