### PR TITLE
Forward terminating signal to main process thread

### DIFF
--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -888,10 +888,6 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         /* Send SIGHUP to all other active processes */
         myst_send_sighup_child_processes(thread);
 
-        /* Put the thread on the zombie list, although no one will be doing a
-         * waitpid on this top-level process, but it will make it consistent */
-        //        myst_zombify_thread(thread);
-
         /* Wait for all other processes to exit */
         {
             myst_spin_lock(&myst_process_list_lock);

--- a/scripts/runtest
+++ b/scripts/runtest
@@ -30,7 +30,8 @@ test_passed()
     local cmd=$*
     local subtest=${cmd##*/}
     echo -e "${green}    passed (${TESTNAME}/${subtest})${reset}"
-    echo "" >> ${TESTSUBDIR}/passed
+    mkdir -p "${TESTSUBDIR}/${subtest}"
+    echo "" >> "${TESTSUBDIR}/${subtest}/passed"
 }
 
 test_failed()
@@ -38,7 +39,8 @@ test_failed()
     local cmd=$*
     local subtest=${cmd##*/}
     echo -e "${red}    failed (${TESTNAME}/${subtest})${reset}"
-    echo "" >> ${TESTSUBDIR}/failed
+    mkdir -p "${TESTSUBDIR}/${subtest}"
+    echo "" >> "${TESTSUBDIR}/${subtest}/failed"
 }
 
 test_timedout()
@@ -46,7 +48,8 @@ test_timedout()
     local cmd=$*
     local subtest=${cmd##*/}
     echo -e "${red}    timedout (${TESTNAME}/${subtest})${reset}"
-    echo "" >> ${TESTSUBDIR}/failed
+    mkdir -p "${TESTSUBDIR}/${subtest}"
+    echo "" >> "${TESTSUBDIR}/${subtest}/failed"
 }
 
 if [ -z "${TIMEOUT}" ]; then

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -170,7 +170,7 @@ sort:
 
 ifeq ($(FS),ext2fs)
 one:
-	sudo -E $(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) $(TEST) $(NL)
+	subtest=$(TEST) sudo -E $(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) $(TEST) $(NL)
 endif
 
 ##==============================================================================
@@ -186,7 +186,7 @@ one:
 	cp appdir/$(TEST) $(HOSTFS)/$(TEST)
 	cp -r appdir/etc $(HOSTFS)/
 	sudo chown -R 0.0 $(HOSTFS)
-	sudo -E $(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) $(TEST) $(NL)
+	subtest=$(TEST) sudo -E $(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) $(TEST) $(NL)
 endif
 
 ##==============================================================================
@@ -202,7 +202,7 @@ one:
 	cp appdir/$(TEST) ramfs.appdir/$(TEST)
 	cp -r appdir/etc  ramfs.appdir/
 	$(MYST) mkcpio ramfs.appdir ramfs
-	sudo -E $(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) $(TEST) $(NL)
+	subtest=$(TEST) sudo -E $(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) $(TEST) $(NL)
 endif
 
 t:

--- a/tests/shutdown/Makefile
+++ b/tests/shutdown/Makefile
@@ -23,7 +23,9 @@ tests:
 	$(MAKE) test2
 	$(MAKE) test3
 	$(MAKE) test4
-	
+	$(MAKE) test5
+	$(MAKE) test6
+
 # main parent waits for spawned child to shutdown before exiting
 # no sighup handler
 test1: rootfs
@@ -47,6 +49,14 @@ test3: rootfs
 test4: rootfs
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs --app-config-path config-fork.json /bin/parent parent-wait-child-fork-exit-with-sighup-handler | tee test.output
 	diff test.output test4.output
+
+# main process waits for child fork to throw assert (SIGABRT) on child forked child thread
+test5: rootfs
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs --app-config-path config-fork.json /bin/parent child-process-child-thread-assert
+
+# main process waits for child fork to throw SIGSEGV on child forked child thread
+test6: rootfs
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs --app-config-path config-fork.json /bin/parent child-process-child-thread-crash
 
 clean:
 	rm -rf $(APPDIR) rootfs test.output

--- a/tests/shutdown/parent.c
+++ b/tests/shutdown/parent.c
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 #include <assert.h>
+#include <pthread.h>
 #include <signal.h>
 #include <spawn.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -120,6 +122,114 @@ int test4(const char* test_name)
     return 0;
 }
 
+// main parent waits for spawned child to shutdown before exiting
+// Child has no SIGGHUP handler
+// Child throws an assert on a child thread
+
+static void* _test5_thread_assert(void* arg)
+{
+    printf("hello from asserting thread\n");
+    assert(0);
+    return NULL;
+}
+
+int test5(const char* test_name)
+{
+    int r;
+    pid_t pid = 0;
+    char* child_argv[] = {"/bin/child", (char*)test_name, NULL};
+    int wstatus;
+
+    r = fork();
+    if (r < 0)
+    {
+        printf("r=%d\n", r);
+        assert("failed to fork child" == NULL);
+    }
+    else if (r == 0)
+    {
+        pthread_t thread;
+        int r;
+
+        printf("=== start test (%s)\n", __FUNCTION__);
+
+        if ((r = pthread_create(&thread, NULL, _test5_thread_assert, NULL)))
+        {
+            printf("pthread_create() failed: %d", r);
+            abort();
+        }
+
+        if (pthread_join(thread, NULL) != 0)
+        {
+            printf("pthread_join() failed");
+            abort();
+        }
+    }
+    else
+    {
+        int wstate = 0;
+        r = waitpid(r, &wstate, 0);
+        assert(r > 0);
+        assert(WTERMSIG(wstate));
+        assert(WTERMSIG(wstate) == SIGABRT);
+    }
+    return 0;
+}
+
+// main parent waits for spawned child to shutdown before exiting
+// Child has no SIGGHUP handler
+// Child throws an SEGV on a child thread
+static void* _test6_thread_assert(void* arg)
+{
+    printf("hello from crashing thread\n");
+    char* crash = NULL;
+    crash[0] = 'a';
+    return NULL;
+}
+
+int test6(const char* test_name)
+{
+    int r;
+    pid_t pid = 0;
+    char* child_argv[] = {"/bin/child", (char*)test_name, NULL};
+    int wstatus;
+
+    r = fork();
+    if (r < 0)
+    {
+        printf("r=%d\n", r);
+        assert("failed to fork child" == NULL);
+    }
+    else if (r == 0)
+    {
+        pthread_t thread;
+        int r;
+
+        printf("=== start test (%s)\n", __FUNCTION__);
+
+        if ((r = pthread_create(&thread, NULL, _test6_thread_assert, NULL)))
+        {
+            printf("pthread_create() failed: %d", r);
+            abort();
+        }
+
+        if (pthread_join(thread, NULL) != 0)
+        {
+            printf("pthread_join() failed");
+            abort();
+        }
+    }
+    else
+    {
+        int wstate = 0;
+        r = waitpid(r, &wstate, 0);
+        assert(r > 0);
+        assert(WTERMSIG(wstate));
+        assert(WTERMSIG(wstate) == SIGSEGV);
+    }
+    return 0;
+}
+
 int main(int argc, const char* argv[])
 {
     assert(argc == 2);
@@ -137,6 +247,10 @@ int main(int argc, const char* argv[])
     else if (
         strcmp("parent-wait-child-fork-exit-with-sighup-handler", argv[1]) == 0)
         test4(argv[1]);
+    else if (strcmp("child-process-child-thread-assert", argv[1]) == 0)
+        test5(argv[1]);
+    else if (strcmp("child-process-child-thread-crash", argv[1]) == 0)
+        test6(argv[1]);
     else
         assert("invalid option" == NULL);
 


### PR DESCRIPTION
If the process thread has not already got an exit status, forward a signal
from a child thread to it.

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>