### PR TITLE
Fix race condition in procfs cleanup

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -5570,6 +5570,21 @@ done:
     return ret;
 }
 
+static int _ext2_release_tree(myst_fs_t* fs, const char* pathname)
+{
+    int ret = 0;
+    ext2_t* ext2 = (ext2_t*)fs;
+
+    if (!_ext2_valid(ext2) || !pathname)
+        ERAISE(-EINVAL);
+
+    ret = -ENOTSUP;
+
+done:
+
+    return ret;
+}
+
 static myst_fs_t _base = {
     {
         .fd_read = (void*)ext2_read,
@@ -5626,6 +5641,7 @@ static myst_fs_t _base = {
     .fs_fchmod = _ext2_fchmod,
     .fs_fdatasync = _ext2_fsync_and_fdatasync,
     .fs_fsync = _ext2_fsync_and_fdatasync,
+    .fs_release_tree = _ext2_release_tree,
 };
 
 int ext2_create(

--- a/hostfs/hostfs.c
+++ b/hostfs/hostfs.c
@@ -1223,6 +1223,20 @@ done:
     return ret;
 }
 
+static int _fs_release_tree(myst_fs_t* fs, const char* pathname)
+{
+    int ret = 0;
+    hostfs_t* hostfs = (hostfs_t*)fs;
+
+    if (!_hostfs_valid(hostfs) || !pathname)
+        ERAISE(-EINVAL);
+
+    ret = -ENOTSUP;
+
+done:
+    return ret;
+}
+
 int myst_init_hostfs(myst_fs_t** fs_out)
 {
     int ret = 0;
@@ -1285,6 +1299,7 @@ int myst_init_hostfs(myst_fs_t** fs_out)
         .fs_fchmod = _fs_fchmod,
         .fs_fdatasync = _fs_fdatasync,
         .fs_fsync = _fs_fsync,
+        .fs_release_tree = _fs_release_tree,
     };
     // clang-format on
 

--- a/include/myst/fs.h
+++ b/include/myst/fs.h
@@ -179,6 +179,9 @@ struct myst_fs
     int (*fs_fdatasync)(myst_fs_t* fs, myst_file_t* file);
 
     int (*fs_fsync)(myst_fs_t* fs, myst_file_t* file);
+
+    /* Recursively remove directory tree pointed at by pathname */
+    int (*fs_release_tree)(myst_fs_t* fs, const char* pathname);
 };
 
 int myst_remove_fd_link(int fd);

--- a/include/myst/ramfs.h
+++ b/include/myst/ramfs.h
@@ -64,8 +64,6 @@ int myst_create_virtual_file(
     myst_vcallback_t v_cb,
     myst_virtual_file_type_t v_type);
 
-int myst_release_tree(myst_fs_t* fs, const char* pathname);
-
 int set_overrides_for_special_fs(myst_fs_t* fs);
 
 #endif /* _MYST_RAMFS_H */

--- a/kernel/lockfs.c
+++ b/kernel/lockfs.c
@@ -769,6 +769,22 @@ done:
     return ret;
 }
 
+static int _fs_release_tree(myst_fs_t* fs, const char* pathname)
+{
+    int ret = 0;
+    lockfs_t* lockfs = (lockfs_t*)fs;
+
+    if (!_lockfs_valid(lockfs) || !pathname)
+        ERAISE(-EINVAL);
+
+    myst_mutex_lock(&lockfs->lock);
+    ret = (*lockfs->fs->fs_release_tree)(lockfs->fs, pathname);
+    myst_mutex_unlock(&lockfs->lock);
+
+done:
+    return ret;
+}
+
 int myst_lockfs_init(myst_fs_t* fs, myst_fs_t** lockfs_out)
 {
     int ret = 0;
@@ -829,6 +845,7 @@ int myst_lockfs_init(myst_fs_t* fs, myst_fs_t** lockfs_out)
         .fs_fchmod = _fs_fchmod,
         .fs_fdatasync = _fs_fdatasync,
         .fs_fsync = _fs_fsync,
+        .fs_release_tree = _fs_release_tree,
     };
 
     if (lockfs_out)

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -150,7 +150,7 @@ int procfs_pid_cleanup(pid_t pid)
 
     ECHECK(myst_snprintf(
         locals->pid_dir_path, sizeof(locals->pid_dir_path), "/%d", pid));
-    ECHECK(myst_release_tree(_procfs, locals->pid_dir_path));
+    ECHECK(_procfs->fs_release_tree(_procfs, locals->pid_dir_path));
 
 done:
 


### PR DESCRIPTION
procfs_pid_cleanup used to call a direct ramfs function for process cleanup.
Changing the cleanup function to a fs operation allows it to be wrapped in lockfs

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>