### PR TITLE
Revert the switchless poll OCALL

### DIFF
--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -126,8 +126,7 @@ enclave
         long myst_poll_ocall(
             [in, out, count=nfds] struct pollfd* fds,
             unsigned long nfds,
-            int timeout)
-            transition_using_threads;
+            int timeout);
 
         long myst_poll_wake_ocall();
 


### PR DESCRIPTION
We did not get performance gain by making the poll OCALL switchless (the socket I/O dominates the execution time). Revert the change to make poll OCALL non-switchless.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>