### PR TITLE
Publish myst-lldb. Add tests/lldb

### DIFF
--- a/.azure_pipelines/ci-pipeline-makefile-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-makefile-nightly.yml
@@ -32,6 +32,7 @@ jobs:
         sudo apt-get install build-essential python3-setuptools python3-pip llvm-7 libmbedtls-dev docker-ce -y
         sudo chmod 666 /var/run/docker.sock
         sudo apt install python3-pip -y
+        sudo apt install lldb-10 -y
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
         docker system prune -a -f
         df

--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -43,6 +43,7 @@ jobs:
           sudo apt-get install build-essential python3-setuptools libmbedtls-dev docker-ce -y
           sudo chmod 666 /var/run/docker.sock
           sudo apt install python3-pip -y
+          sudo apt install lldb-10 -y
         displayName: 'minimum init config'
 
       # build all source files

--- a/.azure_pipelines/ci-pipeline-release.yml
+++ b/.azure_pipelines/ci-pipeline-release.yml
@@ -41,6 +41,7 @@ jobs:
           sudo apt-get install build-essential python3-setuptools libmbedtls-dev docker-ce -y 
           sudo chmod 666 /var/run/docker.sock
           sudo apt install python3-pip -y
+          sudo apt install lldb-10 -y
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           docker system prune -a -f
           df

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ tests/libc/appdir/
 tests/thread/appdir/
 tests/gdb/appdir/
 tests/gdb/myst_gdb_out.log
+tests/lldb/appdir/
+tests/lldb/myst_lldb_out.log
 tests/dlopen/appdir/
 .gdb_history
 tests/pthread/appdir/

--- a/defs.mak
+++ b/defs.mak
@@ -144,7 +144,15 @@ MBEDTLS_LIBS += $(MBEDTLS_LIBDIR)/libmbedx509.a
 
 MYST_GDB=$(BUILDDIR)/bin/myst-gdb
 OEGDB=$(BUILDDIR)/openenclave/bin/oegdb
-MYST_LLDB=$(BUILDDIR)/openenclave/bin/oelldb
+
+##==============================================================================
+##
+## lldb definitions
+##
+##==============================================================================
+
+MYST_LLDB=$(BUILDDIR)/bin/myst-lldb
+OELLDB=$(BUILDDIR)/openenclave/bin/oelldb
 
 ##==============================================================================
 ##
@@ -223,6 +231,19 @@ endif
 
 ##==============================================================================
 ##
+## LLDB
+##     Use "make LLDB=1" to run debugger
+##
+##==============================================================================
+
+LLDDB_COMMAND = $(BINDIR)/myst-lldb --
+
+ifdef LLDB
+__LLDB_COMMAND = $(LLDB_COMMAND)
+endif
+
+##==============================================================================
+##
 ## MEMCHECK
 ##     Use "make MEMCHECK=1" to check for memory leaks.
 ##
@@ -295,6 +316,10 @@ endif
 
 ifdef __GDB_COMMAND
 PREFIX += $(__GDB_COMMAND)
+endif
+
+ifdef __LLDB_COMMAND
+PREFIX += $(__LLDB_COMMAND)
 endif
 
 ifdef __MEMCHECK_COMMAND

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -35,6 +35,7 @@ DIRS += conf
 DIRS += nbio
 DIRS += thread
 DIRS += gdb
+DIRS += lldb
 
 DIRS += dlopen
 DIRS += pipe

--- a/tests/lldb/Makefile
+++ b/tests/lldb/Makefile
@@ -1,0 +1,43 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC -g
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+LLDB_LOG_FILE = myst_lldb_out.log
+
+LLDB_CMDS=-o "b print_hello" \
+	-o "run" \
+	-o "process handle SIGILL -s false -n false" \
+	-o "bt" \
+	-o "c" \
+	-o "q"
+
+LLDB_MATCH=helloworld\`print_hello\(count\=4\) at helloworld.c:10
+
+# runtest timeouts causes gdb to hang. Do no use timeouts for lldb too.
+export NOTIMEOUT=1
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs: helloworld.c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/helloworld helloworld.c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+tests:
+	$(RUNTEST) $(MAKE) __tests
+
+__tests:rootfs
+	${MYST_LLDB} ${LLDB_CMDS} -- ${MYST} ${EXEC} rootfs /bin/helloworld ${OPTS} 2>&1 > ${LLDB_LOG_FILE} 2> /dev/null \
+           || echo "Failure running myst_lldb"
+	@cat ${LLDB_LOG_FILE} | grep -E "$(LLDB_MATCH)" > /dev/null || (cat ${LLDB_LOG_FILE} && exit 1)
+	@ echo "=== passed test (lldb)"
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs $(LLDB_LOG_FILE)

--- a/tests/lldb/helloworld.c
+++ b/tests/lldb/helloworld.c
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void print_hello(int count)
+{
+    for (int i = 0; i < count; i++)
+    {
+        fprintf(stdout, "%d: Hello world!\n", i);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    print_hello(4);
+    return 0;
+}

--- a/third_party/openenclave/Makefile
+++ b/third_party/openenclave/Makefile
@@ -34,6 +34,7 @@ else
 endif
 
 fetch_oecache: $(TOP)/build/openenclave $(TOP)/build/bin/myst-gdb
+	$(TOP)/build/bin/myst-lldb
 
 $(TOP)/build/openenclave:
 	mkdir -p $(BUILDDIR)
@@ -44,6 +45,11 @@ $(TOP)/build/bin/myst-gdb:
 	mkdir -p $(BUILDDIR)/bin
 	rm -f $(BUILDDIR)/bin/myst-gdb
 	ln -s $(BUILDDIR)/openenclave/bin/oegdb $(BUILDDIR)/bin/myst-gdb
+
+$(TOP)/build/bin/myst-lldb:
+	mkdir -p $(BUILDDIR)/bin
+	rm -f $(BUILDDIR)/bin/myst-lldb
+	ln -s $(BUILDDIR)/openenclave/bin/oelldb $(BUILDDIR)/bin/myst-lldb
 
 FETCH_SUBMODULE = git submodule update --init --progress
 
@@ -87,10 +93,13 @@ endif
 	mkdir -p $(TOP)/build/bin
 	rm -f $(TOP)/build/bin/myst-gdb
 	ln -s $(TOP)/build/openenclave/bin/oegdb $(TOP)/build/bin/myst-gdb
+	rm -f $(TOP)/build/bin/myst-lldb
+	ln -s $(TOP)/build/openenclave/bin/oelldb $(TOP)/build/bin/myst-lldb
 
 clean:
 	rm -rf $(TOP)/build/openenclave
 	rm -f $(TOP)/build/bin/myst-gdb
+	rm -f $(TOP)/build/bin/myst-lldb
 
 distclean: clean
 	rm -rf openenclave


### PR DESCRIPTION
The test for myst-lldb is basic and performs exactly the
same checsk that gdb test does: ensure that a break point is hit,
and that we are able to print the backtrace and continue execution
until program termination.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>