### PR TITLE
Fixed the bug related to handling the last ext2 dirent in a block

### DIFF
--- a/ext2/ext2dump.c
+++ b/ext2/ext2dump.c
@@ -413,7 +413,7 @@ static void _DumpDirectoryEntries(
     const uint8_t* p = (uint8_t*)data;
     const uint8_t* end = (uint8_t*)data + size;
 
-    while (p < end)
+    while (p + sizeof(ext2_dirent_t) - EXT2_PATH_MAX < end)
     {
         uint32_t n;
         const ext2_dirent_t* ent = (const ext2_dirent_t*)p;


### PR DESCRIPTION
The existing ext2 implementation assumes the last dirent entry always fill to the end of the disk block. In a loop to traverse the dirent list within a buffer, the implementation can read beyond the boundary of the buffer. 

Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>