### PR TITLE
Remove exiting non-process thread from pipe wait queues

### DIFF
--- a/include/myst/fdops.h
+++ b/include/myst/fdops.h
@@ -46,6 +46,8 @@ struct myst_fdops
 
     /* returns POLLIN | POLLOUT | POLLERR */
     int (*fd_get_events)(void* device, void* object);
+
+    int (*fd_remove_thread)(void* device, void* object);
 };
 
 ssize_t myst_fdops_readv(

--- a/include/myst/fdtable.h
+++ b/include/myst/fdtable.h
@@ -54,6 +54,8 @@ int myst_fdtable_free(myst_fdtable_t* fdtable);
 
 int myst_fdtable_interrupt(myst_fdtable_t* fdtable);
 
+int myst_fdtable_remove_thread(myst_fdtable_t* fdtable);
+
 /* returns a file descriptor */
 int myst_fdtable_assign(
     myst_fdtable_t* fdtable,

--- a/kernel/fdtable.c
+++ b/kernel/fdtable.c
@@ -201,6 +201,28 @@ done:
     return ret;
 }
 
+int myst_fdtable_remove_thread(myst_fdtable_t* fdtable)
+{
+    int ret = 0;
+
+    if (!fdtable)
+        ERAISE(-EINVAL);
+
+    for (int i = 0; i < MYST_FDTABLE_SIZE; i++)
+    {
+        myst_fdtable_entry_t* entry = &fdtable->entries[i];
+
+        if (entry->type == MYST_FDTABLE_TYPE_PIPE)
+        {
+            myst_fdops_t* fdops = entry->device;
+            (*fdops->fd_remove_thread)(fdops, entry->object);
+        }
+    }
+
+done:
+    return ret;
+}
+
 int myst_fdtable_assign(
     myst_fdtable_t* fdtable,
     myst_fdtable_type_t type,

--- a/kernel/pipedev.c
+++ b/kernel/pipedev.c
@@ -631,6 +631,21 @@ done:
     return ret;
 }
 
+static int _pd_remove_thread(myst_pipedev_t* pipedev, myst_pipe_t* pipe)
+{
+    int ret = 0;
+
+    if (!pipedev || !_valid_pipe(pipe))
+        ERAISE(-EBADF);
+
+    _lock(pipe);
+    myst_cond_signal_thread(&pipe->impl->cond, myst_thread_self());
+    _unlock(pipe);
+
+done:
+    return ret;
+}
+
 static int _pd_close(myst_pipedev_t* pipedev, myst_pipe_t* pipe)
 {
     int ret = 0;
@@ -744,6 +759,7 @@ extern myst_pipedev_t* myst_pipedev_get(void)
             .fd_interrupt = (void*)_pd_interrupt,
             .fd_target_fd = (void*)_pd_target_fd,
             .fd_get_events = (void*)_pd_get_events,
+            .fd_remove_thread = (void*)_pd_remove_thread,
         },
         .pd_pipe2 = _pd_pipe2,
         .pd_read = _pd_read,

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1095,8 +1095,8 @@ long myst_syscall_close(int fd)
     }
 
     myst_mman_close_notify(fd);
-    ECHECK((*fdops->fd_close)(device, object));
     ECHECK(myst_fdtable_remove(fdtable, fd));
+    ECHECK((*fdops->fd_close)(device, object));
 
 done:
     return ret;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -958,12 +958,15 @@ static long _run_thread(void* arg_)
             thread->exec_kstack = NULL;
         }
 
-        /* Wake up any thread waiting on ctid */
         if (is_child_thread)
         {
+            /* Wake up any thread waiting on ctid */
             myst_atomic_exchange(thread->clone.ctid, 0);
             const int futex_op = FUTEX_WAKE | FUTEX_PRIVATE;
             myst_syscall_futex(thread->clone.ctid, futex_op, 1, 0, NULL, 0);
+
+            /* Remove thread as a waiter on open pipes */
+            myst_fdtable_remove_thread(thread->fdtable);
         }
 
         /* Release memory objects owned by the main/process thread */


### PR DESCRIPTION
If a non-process thread is killed by a SIGKILL while on a pipe operation
it exits without removing itself from the wait queue associated with the
pipe's conditional variable.
`myst_fdtable_remove_thread` iterates over the open pipedev file
descriptors and if the thread exists on the pipe's wait queue removes it.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>