### PR TITLE
Remove the workaround in the EDL for the GCOV build

### DIFF
--- a/tools/myst/enc/Makefile
+++ b/tools/myst/enc/Makefile
@@ -57,9 +57,5 @@ EDGER8R_OPTS += --trusted
 EDGER8R_OPTS += --search-path $(OE_INCDIR)
 EDGER8R_OPTS += --trusted-dir $(SUBOBJDIR)
 
-ifdef MYST_ENABLE_GCOV
-EDGER8R_OPTS += -DGCOV
-endif
-
 $(SUBOBJDIR)/myst_t.c: ../myst.edl
 	$(EDGER8R) $(EDGER8R_OPTS) ../myst.edl

--- a/tools/myst/host/Makefile
+++ b/tools/myst/host/Makefile
@@ -56,9 +56,5 @@ EDGER8R_OPTS += --untrusted
 EDGER8R_OPTS += --search-path $(OE_INCDIR)
 EDGER8R_OPTS += --untrusted-dir $(SUBOBJDIR)
 
-ifdef MYST_ENABLE_GCOV
-EDGER8R_OPTS += -DGCOV
-endif
-
 $(SUBOBJDIR)/myst_u.c: ../myst.edl
 	$(EDGER8R) $(EDGER8R_OPTS) ../myst.edl

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -270,17 +270,7 @@ enclave
             mode_t mode,
             uid_t uid,
             gid_t gid);
-#ifdef GCOV
-        long myst_read_ocall(
-            int fd,
-            [out, size=count] void* buf,
-            size_t count);
 
-        long myst_write_ocall(
-            int fd,
-            [in, size=count] const void* buf,
-            size_t count);
-#else
         long myst_read_ocall(
             int fd,
             [out, size=count] void* buf,
@@ -292,7 +282,6 @@ enclave
             [in, size=count] const void* buf,
             size_t count)
             transition_using_threads;
-#endif
 
         long myst_close_ocall(int fd);
 


### PR DESCRIPTION
With the fix on the Mystikos OE branch, now the switchless read and write OCALLs should work with the GCOV build.
Remove the workaround introduced by #699.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>