### PR TITLE
Add myst_is_bad_addr

### DIFF
--- a/include/myst/config.h
+++ b/include/myst/config.h
@@ -21,4 +21,7 @@
 /* enable tracing of EINTR returns from nanosleep(), poll(), and epoll() */
 // #define MYST_TRACE_THREAD_INTERRUPTIONS 1
 
+/* enable to keep the crt pointer in the myst_thread_t */
+// #define MYST_THREAD_KEEP_CRT_PTR
+
 #endif /* _MYST_CONFIG_H */

--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -79,6 +79,17 @@ int myst_mman_pids_set(const void* addr, size_t length, pid_t pid);
 /* return the length in bytes that are owned by the given process */
 ssize_t myst_mman_pids_test(const void* addr, size_t length, pid_t pid);
 
+bool myst_is_bad_addr(const void* addr, size_t size, int prot);
+
+#define myst_is_bad_addr_read(addr, size) \
+    (myst_is_bad_addr(addr, size, PROT_READ))
+
+#define myst_is_bad_addr_write(addr, size) \
+    (myst_is_bad_addr(addr, size, PROT_WRITE))
+
+#define myst_is_bad_addr_read_write(addr, size) \
+    (myst_is_bad_addr(addr, size, PROT_READ | PROT_WRITE))
+
 void myst_mman_lock(void);
 
 void myst_mman_unlock(void);

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -12,6 +12,7 @@
 #include <unistd.h>
 
 #include <myst/assume.h>
+#include <myst/config.h>
 #include <myst/defs.h>
 #include <myst/fdtable.h>
 #include <myst/futex.h>
@@ -118,9 +119,11 @@ struct myst_process
     void* exec_stack;
     size_t exec_stack_size;
 
+#ifdef MYST_THREAD_KEEP_CRT_PTR
     /* the copy of the CRT data made by myst_exec() */
     void* exec_crt_data;
     size_t exec_crt_size;
+#endif
 
     /* lock when enumerating all threads in this process
         while enumerating over thread->group_prev/next */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -900,6 +900,29 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         /* now all the threads have shutdown we can retrieve the exit status */
         exit_status = process->exit_status;
 
+        /* release process mapping, including stack and crt */
+        myst_release_process_mappings(process->pid);
+
+        if (process->exec_stack)
+        {
+            /* The stack is released as part of
+             * myst_release_process_mappings. Clear the pointer and size
+             * value */
+            process->exec_stack = NULL;
+            process->exec_stack_size = 0;
+        }
+
+#ifdef MYST_THREAD_KEEP_CRT_PTR
+        if (process->exec_crt_data)
+        {
+            /* The crt data is released as part of
+             * myst_release_process_mappings. Clear the pointer and size
+             * value */
+            process->exec_crt_data = NULL;
+            process->exec_crt_size = 0;
+        }
+#endif
+
         /* release the fdtable */
         if (process->fdtable)
         {
@@ -924,22 +947,6 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         /* release signal related heap memory */
         myst_signal_free(process);
         myst_signal_free_siginfos(thread);
-
-        /* release the exec stack */
-        if (process->exec_stack)
-        {
-            myst_munmap(process->exec_stack, process->exec_stack_size);
-            process->exec_stack = NULL;
-            process->exec_stack_size = 0;
-        }
-
-        /* release the exec copy of the CRT data */
-        if (process->exec_crt_data)
-        {
-            myst_munmap(process->exec_crt_data, process->exec_crt_size);
-            process->exec_crt_data = NULL;
-            process->exec_crt_size = 0;
-        }
 
         /* Free CWD */
         free(process->cwd);

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -1150,13 +1150,10 @@ static long _handle_mman_pids_op(
     ECHECK((ssize_t)(index = _get_page_index(addr, length)));
     count = length / PAGE_SIZE;
 
-    assert(index < v.pids_count);
-    assert(index + count <= v.pids_count);
-
     if ((size_t)index >= v.pids_count)
         ERAISE(-ERANGE);
 
-    if (index + count >= v.pids_count)
+    if (index + count > v.pids_count)
         ERAISE(-ERANGE);
 
     /* ATTN: optimize to use 64bit ops */
@@ -1220,6 +1217,56 @@ int myst_mman_pids_set(const void* addr, size_t length, pid_t pid)
 ssize_t myst_mman_pids_test(const void* addr, size_t length, pid_t pid)
 {
     return _handle_mman_pids_op(MMAN_PIDS_OP_TEST, addr, length, pid);
+}
+
+bool myst_is_bad_addr(const void* addr, size_t length, int prot)
+{
+    bool ret = true;
+
+    if (!addr)
+        goto done;
+
+    if (__myst_kernel_args.nobrk)
+    {
+        /* pid test is only supported if the nobrk option is enabled as
+         * the pid vector does not track memory allocated via brk */
+
+        uint64_t page_addr = myst_round_down_to_page_size((uint64_t)addr);
+
+        if (myst_round_up(length, PAGE_SIZE, &length) < 0)
+            goto done;
+
+        /* check if the pages within the address range are unmapped (i.e.,
+         * associated pid is zero). */
+        if (myst_mman_pids_test((const void*)page_addr, length, 0) > 0)
+            goto done;
+
+        /* check for the page permissions */
+        {
+            bool consistent;
+            int prot_mask;
+
+            if (myst_mman_get_prot(
+                    &_mman, (void*)page_addr, length, &prot_mask, &consistent) <
+                0)
+                goto done;
+
+            if (!consistent || !(prot & prot_mask))
+                goto done;
+        }
+    }
+    else
+    {
+        /* fallback to simple memory range check if the nobrk option is not
+         * enabled */
+        if (!myst_is_addr_within_kernel(addr))
+            goto done;
+    }
+
+    ret = false;
+
+done:
+    return ret;
 }
 
 void myst_mman_lock(void)


### PR DESCRIPTION
This PR adds `myst_is_bad_addr`, which checks the following
- Whether the pages within the address range are mapped (based on the pid vectors)
   - The PR also extends the pid vectors to track both process stack and crt data
- Whether the address range has corresponding page permissions

The checks are based on the assumption of using the `--nobrk` option.

The PR also adds  `myst_is_bad_addr_read`,  `myst_is_bad_addr_write`, and `myst_is_bad_addr_read_write` for convenience  based on `myst_is_bad_addr`.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>