### PR TITLE
Reenable waitpid03

### DIFF
--- a/crt/fork.c
+++ b/crt/fork.c
@@ -115,13 +115,9 @@ struct pthread* _create_child_pthread_and_copy_stack(
 
     myst_round_up(size, PAGE_SIZE, &size_rounded);
 
-    if (!(map = mmap(
-              NULL,
-              size_rounded,
-              PROT_READ | PROT_WRITE,
-              MAP_ANONYMOUS,
-              -1,
-              0)))
+    map =
+        mmap(NULL, size_rounded, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0);
+    if (map == MAP_FAILED)
         return NULL;
 
     /* [guard|stack|tls|tsd] */

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -542,7 +542,8 @@ long myst_signal_deliver(
         myst_spin_unlock(&thread->signal.lock);
 
         // Wake up target if necessary
-        if (thread->signal.waiting_on_event)
+        if (thread->thread_status == MYST_RUNNING &&
+            thread->signal.waiting_on_event)
         {
             myst_tcall_wake(thread->event);
         }

--- a/tests/ltp/README.md
+++ b/tests/ltp/README.md
@@ -1353,7 +1353,7 @@ FAILING
 | /ltp/testcases/kernel/syscalls/waitid/waitid02 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/waitpid/waitpid01 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/waitpid/waitpid02 | 1 | 1 | 1 |
-| /ltp/testcases/kernel/syscalls/waitpid/waitpid03 | 0 | 0 | 0 |
+| /ltp/testcases/kernel/syscalls/waitpid/waitpid03 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/waitpid/waitpid04 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/waitpid/waitpid05 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/waitpid/waitpid06 | 0 | 0 | 0 |

--- a/tests/ltp/config.json
+++ b/tests/ltp/config.json
@@ -8,7 +8,7 @@
     "SecurityVersion": 1,
 
     // Mystikos specific values
-    "MemorySize": "40m",
+    "MemorySize": "64m",
     "HostApplicationParameters": true,
     "ForkMode":"pseudo"
 }

--- a/tests/ltp/ext2fs_tests_other_errors.txt
+++ b/tests/ltp/ext2fs_tests_other_errors.txt
@@ -774,7 +774,6 @@
 /ltp/testcases/kernel/syscalls/vmsplice/vmsplice03
 /ltp/testcases/kernel/syscalls/wait4/wait401
 /ltp/testcases/kernel/syscalls/wait4/wait402
-/ltp/testcases/kernel/syscalls/waitpid/waitpid03
 /ltp/testcases/kernel/syscalls/waitpid/waitpid04
 /ltp/testcases/kernel/syscalls/waitpid/waitpid06
 /ltp/testcases/kernel/syscalls/waitpid/waitpid07

--- a/tests/ltp/ext2fs_tests_passed.txt
+++ b/tests/ltp/ext2fs_tests_passed.txt
@@ -300,6 +300,7 @@
 /ltp/testcases/kernel/syscalls/wait/wait02
 /ltp/testcases/kernel/syscalls/waitpid/waitpid01
 /ltp/testcases/kernel/syscalls/waitpid/waitpid02
+/ltp/testcases/kernel/syscalls/waitpid/waitpid03
 /ltp/testcases/kernel/syscalls/waitpid/waitpid05
 /ltp/testcases/kernel/syscalls/waitpid/waitpid09
 /ltp/testcases/kernel/syscalls/waitpid/waitpid11

--- a/tests/ltp/hostfs_tests_other_errors.txt
+++ b/tests/ltp/hostfs_tests_other_errors.txt
@@ -757,7 +757,6 @@
 /ltp/testcases/kernel/syscalls/vmsplice/vmsplice03
 /ltp/testcases/kernel/syscalls/wait4/wait401
 /ltp/testcases/kernel/syscalls/wait4/wait402
-/ltp/testcases/kernel/syscalls/waitpid/waitpid03
 /ltp/testcases/kernel/syscalls/waitpid/waitpid04
 /ltp/testcases/kernel/syscalls/waitpid/waitpid06
 /ltp/testcases/kernel/syscalls/waitpid/waitpid07

--- a/tests/ltp/hostfs_tests_passed.txt
+++ b/tests/ltp/hostfs_tests_passed.txt
@@ -321,6 +321,7 @@
 /ltp/testcases/kernel/syscalls/wait/wait02
 /ltp/testcases/kernel/syscalls/waitpid/waitpid01
 /ltp/testcases/kernel/syscalls/waitpid/waitpid02
+/ltp/testcases/kernel/syscalls/waitpid/waitpid03
 /ltp/testcases/kernel/syscalls/waitpid/waitpid05
 /ltp/testcases/kernel/syscalls/waitpid/waitpid09
 /ltp/testcases/kernel/syscalls/waitpid/waitpid11

--- a/tests/ltp/ramfs_tests_other_errors.txt
+++ b/tests/ltp/ramfs_tests_other_errors.txt
@@ -790,7 +790,6 @@
 /ltp/testcases/kernel/syscalls/vmsplice/vmsplice03
 /ltp/testcases/kernel/syscalls/wait4/wait401
 /ltp/testcases/kernel/syscalls/wait4/wait402
-/ltp/testcases/kernel/syscalls/waitpid/waitpid03
 /ltp/testcases/kernel/syscalls/waitpid/waitpid04
 /ltp/testcases/kernel/syscalls/waitpid/waitpid06
 /ltp/testcases/kernel/syscalls/waitpid/waitpid07

--- a/tests/ltp/ramfs_tests_passed.txt
+++ b/tests/ltp/ramfs_tests_passed.txt
@@ -288,6 +288,7 @@
 /ltp/testcases/kernel/syscalls/wait/wait02
 /ltp/testcases/kernel/syscalls/waitpid/waitpid01
 /ltp/testcases/kernel/syscalls/waitpid/waitpid02
+/ltp/testcases/kernel/syscalls/waitpid/waitpid03
 /ltp/testcases/kernel/syscalls/waitpid/waitpid05
 /ltp/testcases/kernel/syscalls/waitpid/waitpid09
 /ltp/testcases/kernel/syscalls/waitpid/waitpid11


### PR DESCRIPTION
## Summary
- Fix mmap return check in crt/fork.c
- waitpid03 creates 25 process threads, which exceeds the 40m mman size
for ltp tests. Increasing memory size config to 64m.
- Deliver signal only to running threads.