### PR TITLE
make world

### DIFF
--- a/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
@@ -42,7 +42,7 @@ jobs:
         # remove all untracked files and directories in the git repository
         sudo rm -rf `git ls-files --others --directory`
         make distclean
-        make -j
+        make -j world
       displayName: 'build repo source'
       workingDirectory: $(Build.SourcesDirectory)
       env:

--- a/.azure_pipelines/ci-pipeline-dotnet-test-suite.yml
+++ b/.azure_pipelines/ci-pipeline-dotnet-test-suite.yml
@@ -37,7 +37,7 @@ jobs:
           sudo rm -rf `git ls-files --others --directory`
           make distclean
           make distclean -C third_party/openenclave/
-          make -j
+          make -j world
         displayName: 'build repo source'
         workingDirectory: $(Build.SourcesDirectory)
 

--- a/.azure_pipelines/ci-pipeline-makefile-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-makefile-nightly.yml
@@ -41,7 +41,7 @@ jobs:
         # remove all untracked files and directories in the git repository
         sudo rm -rf `git ls-files --others --directory`
         make distclean
-        make -j
+        make -j world
       displayName: 'build repo source'
       workingDirectory: $(Build.SourcesDirectory)
       env:

--- a/.azure_pipelines/ci-pipeline-makefile.yml
+++ b/.azure_pipelines/ci-pipeline-makefile.yml
@@ -49,7 +49,7 @@ jobs:
           # remove all untracked files and directories in the git repository
           sudo rm -rf `git ls-files --others --directory`
           make distclean
-          make -j
+          make -j world
         displayName: 'build repo source'
         workingDirectory: $(Build.SourcesDirectory)
 

--- a/.azure_pipelines/ci-pipeline-release.yml
+++ b/.azure_pipelines/ci-pipeline-release.yml
@@ -58,7 +58,7 @@ jobs:
           touch mystikos-$VERSION.tar.gz
           tar -czf mystikos-$VERSION.tar.gz --exclude=mystikos-$VERSION.tar.gz .
           
-          make -j MYST_RELEASE=1 && make bindist
+          make -j MYST_RELEASE=1 world && make bindist
           exit 0
         displayName: 'Generate release v${{ parameters.VERSION }} artifact'
         condition: eq(variables['Agent.JobStatus'], 'succeeded')

--- a/.azure_pipelines/master-branch-pipeline.yml
+++ b/.azure_pipelines/master-branch-pipeline.yml
@@ -42,7 +42,7 @@ jobs:
 
       # build all source files
       - script: |
-          make
+          make world
         displayName: 'build repo source'
         workingDirectory: $(Build.SourcesDirectory)
 

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,6 @@ clean:
 distclean: clean
 	sudo rm -rf $(TOP)/build
 	make distclean -C $(TOP)/third_party/
-	make clean -C tests
-	make clean -C solutions
 
 ##==============================================================================
 ##

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,6 @@ DIRS += prereqs
 
 DIRS += third_party
 
-ifndef MYST_PRODUCT_BUILD
-endif
-
 ifdef MYST_ENABLE_GCOV
 DIRS += gcov
 endif
@@ -50,7 +47,7 @@ DIRS += crt
 DIRS += oe
 DIRS += tools
 
-ifndef MYST_PRODUCT_BUILD
+ifdef MYST_WORLD
 DIRS += alpine/docker
 DIRS += tests
 endif
@@ -59,6 +56,15 @@ CLEAN = $(BUILDDIR) $(TARBALL)
 
 REDEFINE_TESTS=1
 include $(TOP)/rules.mak
+
+##==============================================================================
+##
+## world: build the whole world (third-party + Mystikos + tests)
+##
+##==============================================================================
+
+world:
+	$(MAKE) MYST_WORLD=1
 
 ##==============================================================================
 ##
@@ -159,6 +165,7 @@ summary:
 	@ SUMMARY=1 $(RUNTEST_COMMAND) /bin/true
 
 tests:
+	@ $(MAKE) world
 	@ $(MAKE) -C tests tests RUNTEST=$(RUNTEST_COMMAND)
 	@ $(MAKE) -s summary
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ all:
 ##==============================================================================
 
 # CAUTION: this must be run before all other targets
+ifndef MYST_IGNORE_PREREQS
 DIRS += prereqs
+endif
 
 DIRS += third_party
 
@@ -55,6 +57,7 @@ endif
 CLEAN = $(BUILDDIR) $(TARBALL)
 
 REDEFINE_TESTS=1
+REDEFINE_CLEAN=1
 include $(TOP)/rules.mak
 
 ##==============================================================================
@@ -68,6 +71,15 @@ world:
 
 ##==============================================================================
 ##
+## clean:
+##
+##==============================================================================
+
+clean:
+	$(MAKE) __clean MYST_WORLD=1
+
+##==============================================================================
+##
 ## distclean:
 ##
 ##==============================================================================
@@ -75,6 +87,8 @@ world:
 distclean: clean
 	sudo rm -rf $(TOP)/build
 	make distclean -C $(TOP)/third_party/
+	make clean -C tests
+	make clean -C solutions
 
 ##==============================================================================
 ##
@@ -165,7 +179,6 @@ summary:
 	@ SUMMARY=1 $(RUNTEST_COMMAND) /bin/true
 
 tests:
-	@ $(MAKE) world
 	@ $(MAKE) -C tests tests RUNTEST=$(RUNTEST_COMMAND)
 	@ $(MAKE) -s summary
 

--- a/rules.mak
+++ b/rules.mak
@@ -55,10 +55,14 @@ ifdef DIRS
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) $(NL) )
 endif
 
-clean:
+__clean:
 	sudo rm -rf $(__OBJECTS) $(__PROGRAM) $(__SHLIB) $(__ARCHIVE) $(CLEAN)
 ifdef DIRS
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) clean $(NL) )
+endif
+
+ifndef REDEFINE_CLEAN
+clean: __clean
 endif
 
 tests:


### PR DESCRIPTION
This PR removes the building of the tests from the top-level build by default so that ``make`` now builds just Mystikos (without tests). To build Mystikos and the tests use ``make world``.

For background see https://github.com/deislabs/mystikos/issues/486.
