### PR TITLE
Clear pid vector for "unmap_on_exit" memory

### DIFF
--- a/crt/fork.c
+++ b/crt/fork.c
@@ -115,6 +115,13 @@ struct pthread* _create_child_pthread_and_copy_stack(
 
     myst_round_up(size, PAGE_SIZE, &size_rounded);
 
+    /* The mmapped memory will be marked by Mystikos kernel as owned by the
+     * parent process, instead of the child process, or the kernel. During child
+     * process exit, the memory will be unmapped. The process memory management
+     * logic that unmaps memory regions still owned by the parent process at
+     * parent process exit relies specific logic during child process exit to
+     * clear the ownership indication. If any part of the relevant design
+     * changes, the implementaiton needs to be reconsidered */
     if (!(map = mmap(
               NULL,
               size_rounded,

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -938,6 +938,8 @@ int myst_enter_kernel(myst_kernel_args_t* args)
                 myst_munmap(
                     thread->unmap_on_exit[i - 1].ptr,
                     thread->unmap_on_exit[i - 1].size);
+                /* main process/thread is shuting down; skip pid vector update,
+                 * as no more pid vector reference is expected */
                 i--;
             }
         }

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -692,13 +692,11 @@ int myst_release_process_mappings(pid_t pid)
                          * by the parent process, and released as part of parent
                          * process shutdown, with the expectation that the child
                          * process shut downs first  */
-                        // ATTN: several tests triggered the assert
-                        // unexpectedly, roll back to original implementaiton of
-                        // ignoring the error
-#if 0
+
+                        // myst_eprintf("myst_munmap() %p failed, pid=%d.
+                        // len=0x%lx\n", addr, pid, len);
                         assert("myst_munmap() failed" == NULL);
                         ERAISE(-EINVAL);
-#endif
                     }
                     /* always clear the pid vector */
                     myst_mman_pids_set(addr, len, 0);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -993,9 +993,20 @@ static long _run_thread(void* arg_)
             size_t i = thread->unmap_on_exit_used;
             while (i)
             {
-                myst_munmap(
-                    thread->unmap_on_exit[i - 1].ptr,
-                    thread->unmap_on_exit[i - 1].size);
+                if (!myst_munmap(
+                        thread->unmap_on_exit[i - 1].ptr,
+                        thread->unmap_on_exit[i - 1].size))
+                {
+                    /* App process might have invoked SYS_mmap, which marks the
+                     * memory as owned by the calling app process, and then
+                     * SYS_myst_unmap_on_exit on the memory region. Clear the
+                     * pid vector to make sure the unmapped memory is marked as
+                     * not owned by any app process */
+                    myst_mman_pids_set(
+                        thread->unmap_on_exit[i - 1].ptr,
+                        thread->unmap_on_exit[i - 1].size,
+                        0);
+                }
                 i--;
             }
         }


### PR DESCRIPTION
Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>

This PR addresses the unexpected munmap() failure in myst_release_process_mappings().  Certain memory region owned by an app process gets unmapped at thread exit, but the existing code does not clear the corresponding pid vector values. As a result, when the app process exits, myst_release_process_mappings() attempts to unmap those region again, based on pid vector.