### PR TITLE
Make block I/O OCALLs switchless

### DIFF
--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -468,14 +468,16 @@ enclave
             int blkdev,
             uint64_t blkno,
             [in, count=num_blocks] const struct myst_block* blocks,
-            size_t num_blocks);
+            size_t num_blocks)
+            transition_using_threads;
 
         /* reads from the block device */
         ssize_t myst_read_block_device_ocall(
             int blkdev,
             uint64_t blkno,
             [out, count=num_blocks] struct myst_block* blocks,
-            size_t num_blocks);
+            size_t num_blocks)
+            transition_using_threads;
 
         /* load the file-system signature structure from the given image */
         int myst_load_fssig_ocall(


### PR DESCRIPTION
This PR makes `myst_write_block_device_ocall` and `myst_read_block_device_ocall` switchless. Based on the test locally, this change makes the `solutions/python_app` run ~0.6 second faster. Note that the timing spent on block I/Os currently are not captured with the `--perf` option as these operations do not go through the syscall interface.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>