### PR TITLE
Create init and build Makefile steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TARBALL=$(PKGNAME).tar.gz
 
 all:
 	$(MAKE) .git/hooks/pre-commit
+	$(MAKE) init
 	$(MAKE) dirs
 
 .git/hooks/pre-commit:
@@ -77,6 +78,34 @@ world:
 
 clean:
 	$(MAKE) __clean MYST_WORLD=1
+
+##==============================================================================
+##
+## init:
+##
+##==============================================================================
+
+init:
+	make init -C $(TOP)/third_party/
+
+##==============================================================================
+##
+## build:
+##
+##==============================================================================
+
+build:
+	make dirs MYST_IGNORE_PREREQS=1
+
+##==============================================================================
+##
+## release-build:
+##
+##==============================================================================
+
+release-build:
+	make build
+	make bindist
 
 ##==============================================================================
 ##
@@ -237,6 +266,9 @@ oelicense:
 help:
 	@ echo ""
 	@ echo "make -- build everything"
+	@ echo "make init -- initialize all dependencies"
+	@ echo "make build -- build everything except for prereqs"
+	@ echo "make release-build -- runs 'build' followed by 'bindist'"
 	@ echo "make clean -- remove generated binaries"
 	@ echo "make distclean -- remove build configuration and binaries"
 	@ echo "make tests -- run critical tests"

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -15,3 +15,9 @@ clean:
 
 distclean:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) distclean $(NL) )
+
+init:
+	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) $(i) $(NL) )
+
+build:
+	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) build $(NL) )

--- a/third_party/musl/Makefile
+++ b/third_party/musl/Makefile
@@ -7,3 +7,6 @@ include $(TOP)/rules.mak
 
 distclean:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) distclean $(NL) )
+
+musl:
+	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) musl $(NL) )

--- a/third_party/musl/pristine/Makefile
+++ b/third_party/musl/pristine/Makefile
@@ -18,13 +18,13 @@ PREFIX=$(BUILDDIR)/musl
 
 all:
 ifeq ($(CACHE_CHECK),)
+	$(MAKE) musl
 	$(MAKE) build
 else
 	$(MAKE) fetch_cache
 endif
 
 build:
-	$(MAKE) musl
 	$(MAKE) musl/config.mak
 	( cd musl; make install )
 	$(MAKE) cache

--- a/third_party/openenclave/Makefile
+++ b/third_party/openenclave/Makefile
@@ -27,11 +27,14 @@ endif
 $(BUILDDIR)/include/openenclave:
 ifeq ($(CACHE_CHECK),)
 	$(MAKE) openenclave
-	$(MAKE) configure_oe
-	$(MAKE) install_oe
+	$(MAKE) build
 else
 	$(MAKE) fetch_oecache
 endif
+
+build:
+	$(MAKE) configure_oe
+	$(MAKE) install_oe
 
 fetch_oecache: $(TOP)/build/openenclave $(TOP)/build/bin/myst-gdb
 


### PR DESCRIPTION
Introduced `init`,`build`, and `release-build` makefile steps. The goal is to decouple the initialization of prerequisites and building of Mystikos.

Added a makefile to the `ltp` directory; it seemed to be a "hanging submodule" when submodule references were removed.