### PR TITLE
Create Nginx sample

### DIFF
--- a/samples/nginx/Dockerfile
+++ b/samples/nginx/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx
+
+COPY ./nginx.conf /etc/nginx/nginx.conf
+
+COPY ./index.html /usr/share/nginx/html/index.html
+
+# nginx image by default runs with daemon off
+# Turn daemon off to avoid forking
+# CMD ["nginx", "-g", "daemon off;"]

--- a/samples/nginx/Makefile
+++ b/samples/nginx/Makefile
@@ -1,0 +1,18 @@
+TOP = $(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+
+all: appdir rootfs
+
+appdir:
+	$(APPBUILDER) Dockerfile
+
+rootfs: appdir
+	$(MYST) mkcpio appdir rootfs
+
+run:
+	$(MYST_EXEC) $(OPTS) rootfs /usr/sbin/nginx --app-config-path config.json
+
+clean:
+	rm -rf rootfs appdir

--- a/samples/nginx/config.json
+++ b/samples/nginx/config.json
@@ -1,0 +1,8 @@
+{
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+    "MemorySize": "128m",
+    "CurrentWorkingDirectory": "/",
+    "ApplicationPath": "/usr/sbin/nginx"
+}

--- a/samples/nginx/index.html
+++ b/samples/nginx/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx running in Mystikos!</title>
+<style>
+    body {
+        width: 40em;
+        margin: 0 auto;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx running in Mystikos!</h1>
+
+<p>You can check the source code for this sample <a href="https://github.com/deislabs/mystikos/tree/main/samples/nginx">here</a></p>
+
+
+</body>
+</html>

--- a/samples/nginx/nginx.conf
+++ b/samples/nginx/nginx.conf
@@ -1,0 +1,17 @@
+# Set daemon off to avoid forking, which is not fully supported by Mystikos (as of August 2021)
+# See https://github.com/deislabs/mystikos/blob/main/doc/kernel-limitations.md
+daemon off;
+# Set master_process off to avoid using syscall SYS_rt_sigsuspend() which is not hanlded by Mystikos yet
+master_process off;
+
+events {}
+
+http {
+    server {
+        listen 8080 default_server;
+
+        location / {
+            root /usr/share/nginx/html;
+        }
+    }
+}


### PR DESCRIPTION
A simple nginx sample serving static content.

Certain configurations have to be used in order to avoid unsupported feature of Mystikos
1. Nginx needs to run with daemon off
2. Nginx needs to run with master_process off (however this option is only intended for nginx developers (http://nginx.org/en/docs/ngx_core_module.html#master_process))

Following error would occur if above configuration is not set:
1. If daemon set to on
`nginx: [emerg] fork() failed (95: Not supported)`

2. If master_process set to on
```
*** kernel panic: syscall.c(6339): _syscall(): unhandled syscall: SYS_rt_sigsuspend()
0xc3b7ca: __myst_panic()
0xc4b65e: _syscall()
0xc6a0f3: __morestack()
```