### PR TITLE
Defer fdmappings cleanup from file descriptor close to munmap

### DIFF
--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -10,12 +10,14 @@
 #include <sys/types.h>
 
 #define MYST_FDMAPPING_USED 0x1ca0597f
+#define MYST_FDMAPPING_FD_CLOSED 0x73a840d4
 
 /* defines a file-page to memory-page mapping */
 typedef struct myst_fdmapping
 {
-    uint32_t used;           /* whether entry is used */
-    int32_t fd;              /* fd that page is mapped to */
+    uint32_t used; /* whether entry is unused, or used. Used has two substates:
+                      active fd & fd closed */
+    int32_t fd;    /* fd that page is mapped to */
     uint64_t offset;         /* offset of page within file */
     myst_refstr_t* pathname; /* full pathname associated with fd */
 } myst_fdmapping_t;

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -987,8 +987,8 @@ void myst_mman_close_notify(int fd)
     struct stat buf;
     bool locked = false;
 
-    /* only do this for regular files */
-    if (myst_syscall_fstat(fd, &buf) != 0 || !S_ISREG(buf.st_mode))
+    /* only do this for valid fds & regular files */
+    if (fd < 0 || myst_syscall_fstat(fd, &buf) != 0 || !S_ISREG(buf.st_mode))
         return;
 
     _rlock(&locked);

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -1014,11 +1014,10 @@ void myst_mman_close_notify(int fd)
             if ((p = myst_memcchr(p, '\0', bytes_remaining)) == NULL)
                 break;
 
+            // /proc/[pid]/maps depends on the fdmapping vector for pathname
+            // information. Defer fdmapping cleanup to munmap.
             if (p->used == MYST_FDMAPPING_USED && p->fd == fd)
-            {
-                myst_refstr_unref(p->pathname);
-                memset(p, 0, sizeof(myst_fdmapping_t));
-            }
+                p->used = MYST_FDMAPPING_FD_CLOSED;
 
             p++;
             bytes_remaining -= sizeof(myst_fdmapping_t);

--- a/solutions/coreclr/pr0-256m
+++ b/solutions/coreclr/pr0-256m
@@ -2364,6 +2364,7 @@ baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r/BasicTest_QuickJitOn_R2r
 baseservices/typeequivalence/simple/Simple/Simple.dll
 baseservices/threading/coverage/OSThreadId/osthreadid/osthreadid.dll
 baseservices/compilerservices/RuntimeWrappedException/RuntimeWrappedException/RuntimeWrappedException.dll
+readytorun/crossgen2/crossgen2smoke/crossgen2smoke.dll
 readytorun/DynamicMethodGCStress/DynamicMethodGCStress/DynamicMethodGCStress.dll
 baseservices/varargs/varargsupport/varargsupport.dll
 baseservices/varargs/varargsupport_r/varargsupport_r.dll

--- a/solutions/coreclr/pr0-FAILED
+++ b/solutions/coreclr/pr0-FAILED
@@ -6,7 +6,6 @@ JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314/b425314.dll, potential-han
 JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654/b426654.dll, potential-hang, 1g
 JIT/Regression/JitBlue/Runtime_40444/Runtime_40444/Runtime_40444.dll, Error-255, 1g
 Loader/binding/tracing/BinderTracingTest.ResolutionFlow/BinderTracingTest.ResolutionFlow.dll, SIGSEGV, 3g
-readytorun/crossgen2/crossgen2smoke/crossgen2smoke.dll, System.UnauthorizedAccessException, 256m
 tracing/eventpipe/buffersize/buffersize/buffersize.dll
 tracing/eventpipe/diagnosticport/diagnosticport/diagnosticport.dll
 tracing/eventpipe/eventsourceerror/eventsourceerror/eventsourceerror.dll


### PR DESCRIPTION
@bodzhang and I encountered following sequence of syscalls from different dotnet applications:

1. file opened for reading and mmapped
2. file is closed
3. msync is called in the mmap address range

Because [we don't cleanup fdmappings when read-only files are closed](https://github.com/deislabs/mystikos/blob/main/kernel/mmanutils.c#L1000), msync finds an "in-use" fdmapping, but with a closed fd.
This causes msync to fail with an `EPERM`.

#### Summary of changes:

- fdmappings cleanup at file descriptor close time is deferred to munmap. This allows functionalities relying on fdmappings vector - /proc/[pid]/maps and msync, to function.
- Added new state to fdmapping `used` field - MYST_FDMAPPING_FD_CLOSED. A fdmapping is in this state between the time close is called on a descriptor associated with a file mapping, and munmap is called on the file mapping.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>