### PR TITLE
Return EINVAL on setrlimit, silent for NOFILE and STACK

### DIFF
--- a/kernel/limit.c
+++ b/kernel/limit.c
@@ -152,7 +152,8 @@ int myst_limit_set_rlimit(pid_t pid, int resource, struct rlimit* rlim)
     // ATTN: Setting rlimit value is currently unsupported
     // Returning a failure will break solutions/memcached (RLIMIT_NOFILE)
     // and tests/glibc (RLIMIT_STACK)
-    // ERAISE(-ENOTSUP);
+    if (resource != RLIMIT_NOFILE && resource != RLIMIT_STACK)
+        ERAISE(-EINVAL);
 done:
     return ret;
 }

--- a/kernel/limit.c
+++ b/kernel/limit.c
@@ -150,9 +150,9 @@ int myst_limit_set_rlimit(pid_t pid, int resource, struct rlimit* rlim)
         ERAISE(-EINVAL);
 
     // ATTN: Setting rlimit value is currently unsupported
-    // Returning a failure will break solutions/memcached
-    if (resource != RLIMIT_NOFILE)
-        ERAISE(-ENOTSUP);
+    // Returning a failure will break solutions/memcached (RLIMIT_NOFILE)
+    // and tests/glibc (RLIMIT_STACK)
+    // ERAISE(-ENOTSUP);
 done:
     return ret;
 }


### PR DESCRIPTION
Originally, `setrlimit` was only silent for `NOFILE` to allow memacached solution to pass. A failure in the glibc test case was discovered due to `ENOTSUP` from setting `STACK`. Added `STACK` to silent and changed error to `EINVAL` (allowed by specs). 