### PR TITLE
Removing broken sub-module (third_party/ltp/ltp)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all:
 	$(MAKE) dirs
 
 .git/hooks/pre-commit:
-	cp scripts/pre-commit .git/hooks/pre-commit
+	cp scripts/pre-commit $(shell git rev-parse --show-superproject-working-tree)/.git/hooks/pre-commit
 
 ##==============================================================================
 ##

--- a/prereqs/Makefile
+++ b/prereqs/Makefile
@@ -4,7 +4,7 @@ DRIVER_URL=https://download.01.org/intel-sgx/sgx-dcap/1.7/linux/distro/ubuntu18.
 
 all:
 	test -e package-installed || $(MAKE) packages
-	test -e /dev/sgx || $(MAKE) install_sgx_driver
+	test -e /dev/sgx || test -e /dev/isgx || $(MAKE) install_sgx_driver
 
 package_repo:
 	echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list


### PR DESCRIPTION
Removing broken sub-module (third_party/ltp/ltp) and Adding /dev/isgx in sgx driver installation check

Signed-off-by: Ragavan Dasarathan <mrragava@gmail.com>