### PR TITLE
Use duplicated fd for file mappings

### DIFF
--- a/hostfs/hostfs.c
+++ b/hostfs/hostfs.c
@@ -910,7 +910,6 @@ static int _fs_dup(
     ECHECK((tret = myst_tcall(SYS_dup, params)));
 
     new_file->fd = tret;
-    ret = tret;
 
     *file_out = new_file;
     new_file = NULL;

--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -11,11 +11,15 @@
 
 #define MYST_FDMAPPING_USED 0x1ca0597f
 
-/* defines a file-page to memory-page mapping */
+/*
+defines a file-page to memory-page mapping
+The mapping entries in the fdmappings vector are populated at mmap, and cleaned
+up at munmap.
+*/
 typedef struct myst_fdmapping
 {
     uint32_t used;           /* whether entry is used */
-    int32_t fd;              /* fd that page is mapped to */
+    int32_t fd;              /* duplicated fd */
     uint64_t offset;         /* offset of page within file */
     myst_refstr_t* pathname; /* full pathname associated with fd */
 } myst_fdmapping_t;
@@ -52,8 +56,6 @@ int myst_get_free_ram(size_t* size);
 int myst_release_process_mappings(pid_t pid);
 
 int myst_msync(void* addr, size_t length, int flags);
-
-void myst_mman_close_notify(int fd);
 
 typedef struct myst_mman_stats
 {

--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -186,6 +186,8 @@ long myst_syscall_getcwd(char* buf, size_t size);
 
 long myst_syscall_fcntl(int fd, int cmd, long arg);
 
+long myst_syscall_dup(int fd);
+
 long myst_syscall_chmod(const char* pathname, mode_t mode);
 
 long myst_syscall_add_symbol_file(

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1090,7 +1090,6 @@ long myst_syscall_close(int fd)
         myst_remove_fd_link(fd);
     }
 
-    myst_mman_close_notify(fd);
     ECHECK(myst_fdtable_remove(fdtable, fd));
     ECHECK((*fdops->fd_close)(device, object));
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -932,11 +932,6 @@ static long _run_thread(void* arg_)
                     myst_sleep_msec(10);
                 }
             }
-            if (process->fdtable)
-            {
-                myst_fdtable_free(process->fdtable);
-                process->fdtable = NULL;
-            }
 
             myst_signal_free(process);
 
@@ -1008,6 +1003,14 @@ static long _run_thread(void* arg_)
                 }
                 i--;
             }
+        }
+
+        /* unmapping closes fd's associated with mappings, so free fdtable
+         * after all unmaps are done */
+        if (!is_child_thread && process->fdtable)
+        {
+            myst_fdtable_free(process->fdtable);
+            process->fdtable = NULL;
         }
 
         /* Only free child thread as parent is zombified so parent can wait on

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -970,6 +970,14 @@ static long _run_thread(void* arg_)
             /* unmap any mapping made by the process */
             myst_release_process_mappings(process->pid);
 
+            /* unmapping closes fd's associated with mappings, so free fdtable
+             * after all unmaps are done */
+            if (process->fdtable)
+            {
+                myst_fdtable_free(process->fdtable);
+                process->fdtable = NULL;
+            }
+
             /* Only need to zombify the process thread.
             ATTN: referencing "process" after zombification is not safe,
             parent might have cleaned it up */
@@ -1003,14 +1011,6 @@ static long _run_thread(void* arg_)
                 }
                 i--;
             }
-        }
-
-        /* unmapping closes fd's associated with mappings, so free fdtable
-         * after all unmaps are done */
-        if (!is_child_thread && process->fdtable)
-        {
-            myst_fdtable_free(process->fdtable);
-            process->fdtable = NULL;
         }
 
         /* Only free child thread as parent is zombified so parent can wait on

--- a/solutions/coreclr/pr0-256m
+++ b/solutions/coreclr/pr0-256m
@@ -2364,6 +2364,7 @@ baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r/BasicTest_QuickJitOn_R2r
 baseservices/typeequivalence/simple/Simple/Simple.dll
 baseservices/threading/coverage/OSThreadId/osthreadid/osthreadid.dll
 baseservices/compilerservices/RuntimeWrappedException/RuntimeWrappedException/RuntimeWrappedException.dll
+readytorun/crossgen2/crossgen2smoke/crossgen2smoke.dll
 readytorun/DynamicMethodGCStress/DynamicMethodGCStress/DynamicMethodGCStress.dll
 baseservices/varargs/varargsupport/varargsupport.dll
 baseservices/varargs/varargsupport_r/varargsupport_r.dll

--- a/solutions/coreclr/pr0-FAILED
+++ b/solutions/coreclr/pr0-FAILED
@@ -6,7 +6,6 @@ JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314/b425314.dll, potential-han
 JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654/b426654.dll, potential-hang, 1g
 JIT/Regression/JitBlue/Runtime_40444/Runtime_40444/Runtime_40444.dll, Error-255, 1g
 Loader/binding/tracing/BinderTracingTest.ResolutionFlow/BinderTracingTest.ResolutionFlow.dll, SIGSEGV, 3g
-readytorun/crossgen2/crossgen2smoke/crossgen2smoke.dll, System.UnauthorizedAccessException, 256m
 tracing/eventpipe/buffersize/buffersize/buffersize.dll
 tracing/eventpipe/diagnosticport/diagnosticport/diagnosticport.dll
 tracing/eventpipe/eventsourceerror/eventsourceerror/eventsourceerror.dll

--- a/tests/ltp/hostfs_tests_other_errors.txt
+++ b/tests/ltp/hostfs_tests_other_errors.txt
@@ -222,6 +222,7 @@
 /ltp/testcases/kernel/syscalls/fork/fork05
 /ltp/testcases/kernel/syscalls/fork/fork06
 /ltp/testcases/kernel/syscalls/fork/fork07
+/ltp/testcases/kernel/syscalls/fork/fork08
 /ltp/testcases/kernel/syscalls/fork/fork09
 /ltp/testcases/kernel/syscalls/fork/fork10
 /ltp/testcases/kernel/syscalls/fork/fork12

--- a/tests/ltp/hostfs_tests_passed.txt
+++ b/tests/ltp/hostfs_tests_passed.txt
@@ -72,7 +72,6 @@
 /ltp/testcases/kernel/syscalls/fork/fork02
 /ltp/testcases/kernel/syscalls/fork/fork03
 /ltp/testcases/kernel/syscalls/fork/fork04
-/ltp/testcases/kernel/syscalls/fork/fork08
 /ltp/testcases/kernel/syscalls/fork/fork11
 /ltp/testcases/kernel/syscalls/fpathconf/fpathconf01
 /ltp/testcases/kernel/syscalls/fstat/fstat02

--- a/tests/msync/msync.c
+++ b/tests/msync/msync.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -16,6 +17,11 @@
 #ifndef PAGE_SIZE
 #define PAGE_SIZE 4096
 #endif
+
+static void _passed(const char* name)
+{
+    printf("=== passed test (%s)\n", name);
+}
 
 static int _writen(int fd, const void* data, size_t size)
 {
@@ -78,7 +84,7 @@ static bool _check_page(uint8_t page[PAGE_SIZE], uint8_t byte)
     return true;
 }
 
-int main(int argc, const char* argv[])
+static void test_msync()
 {
     const size_t num_pages = 8;
     uint8_t page[PAGE_SIZE];
@@ -176,7 +182,56 @@ int main(int argc, const char* argv[])
         assert(close(fd) == 0);
     }
 
-    printf("=== passed test (%s)\n", argv[0]);
+    _passed(__FUNCTION__);
+}
 
+static void test_msync_closed_read_fd()
+{
+    int fd = creat("/tmp/datafile", 0666);
+    write(fd, "abcdefghijklmnopqrstuvwxyz", 27);
+    close(fd);
+
+    fd = open("/tmp/datafile", O_CLOEXEC);
+    void* p = mmap(NULL, PAGE_SIZE, PROT_READ, MAP_SHARED, fd, 0);
+    assert(p != MAP_FAILED);
+    close(fd);
+    int ret = msync(p, PAGE_SIZE, MS_SYNC | MS_INVALIDATE);
+    assert(ret == 0 && errno == 0);
+    assert(unlink("/tmp/datafile") == 0);
+    munmap(p, PAGE_SIZE);
+    _passed(__FUNCTION__);
+}
+
+static void test_msync_closed_rw_fd()
+{
+    int fd = creat("/tmp/datafile", 0666);
+    write(fd, "abcdefghijklmnopqrstuvwxyz", 27);
+    close(fd);
+
+    fd = open("/tmp/datafile", O_RDWR | O_CLOEXEC);
+    void* p = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    assert(p != MAP_FAILED);
+    close(fd);
+
+    char* cp = p;
+    memcpy(cp, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", 27);
+    int ret = msync(p, PAGE_SIZE, MS_SYNC | MS_INVALIDATE);
+    assert(ret == 0 && errno == 0);
+
+    char buf[27];
+    fd = open("/tmp/datafile", O_RDONLY);
+    read(fd, buf, 27);
+    assert(strcmp(buf, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") == 0);
+    assert(unlink("/tmp/datafile") == 0);
+    munmap(p, PAGE_SIZE);
+    _passed(__FUNCTION__);
+}
+
+int main(int argc, const char* argv[])
+{
+    test_msync();
+    test_msync_closed_read_fd();
+    test_msync_closed_rw_fd();
+    _passed(argv[0]);
     return 0;
 }


### PR DESCRIPTION
### Summary
- For file mappings, mman duplicates the fd and uses that for msync operations.
- Mechanism for notifying mman of fd close - myst_mman_close_notify, is removed. As mman now has its own copy of the fd.
- munmap and myst_release_process_mappings now need to do additional cleanup of closing duplicated file handles. This is done in a 2 pass manner. In the first pass, the list of fd's to be closed is collected. And once outside the mman lock, the close operation on the fd list is performed. This is to avoid deadlock situation between the mman lock and the file system lock.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>