### PR TITLE
Fix sched_getaffinity bug which causes get_nprocs to return incorrect…

### DIFF
--- a/tests/pthread/Makefile
+++ b/tests/pthread/Makefile
@@ -28,22 +28,23 @@ endif
 export TIMEOUT=360
 
 MAX_CPUS=--max-cpus=1024
+NPROCS=$(shell nproc)
 
 tests:
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_musl $(COUNT)
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_gcc $(COUNT)
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_musl $(NPROCS) $(COUNT) 
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_gcc $(NPROCS) $(COUNT)
 
 t:
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(MAX_CPUS) rootfs /bin/pthread_gcc $(COUNT)
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(MAX_CPUS) rootfs /bin/pthread_gcc $(NPROCS) $(COUNT)
 
 tn:
 	$(foreach i, $(shell seq 1 10), \
-            $(RUNTEST) $(MYST_EXEC) $(OPTS) $(MAX_CPUS) rootfs /bin/pthread_gcc $(COUNT) \
+            $(RUNTEST) $(MYST_EXEC) $(OPTS) $(MAX_CPUS) rootfs /bin/pthread_gcc $(NRPOC) $(COUNT)\
             $(NL))
 
 tests-n:
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_musl 1000
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_gcc 1000
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_musl $(NPROCS) 1000
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_gcc $(NPROCS) 1000
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/pthread/pthread.c
+++ b/tests/pthread/pthread.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/syscall.h>
+#include <sys/sysinfo.h>
 #include <sys/times.h>
 #include <unistd.h>
 
@@ -30,6 +31,8 @@
 #else
 #define T(EXPR)
 #endif
+
+static int _host_nprocs = -1;
 
 __attribute__((format(printf, 3, 4))) static int _err(
     const char* file,
@@ -852,21 +855,44 @@ int main(int argc, const char* argv[])
 
     printf("=== start test (%s)\n", argv[0]);
 
-    if (argc > 2)
+    if (argc > 3)
     {
-        fprintf(stderr, "Usage: %s [<count>]\n", argv[0]);
+        fprintf(stderr, "Usage: %s [<nprocs> [<count>]]\n", argv[0]);
         exit(1);
     }
 
-    if (argc == 2)
+    if (argc == 3)
     {
         char* end = NULL;
-        n = strtoul(argv[1], &end, 0);
+        n = strtoul(argv[2], &end, 0);
 
         if (!end || *end)
         {
             fprintf(stderr, "%s: bad count argument: %s\n", argv[0], argv[1]);
             exit(1);
+        }
+    }
+
+    if (argc >= 2)
+    {
+        char* end = NULL;
+        _host_nprocs = strtoul(argv[1], &end, 0);
+
+        if (!end || *end)
+        {
+            fprintf(stderr, "%s: bad count argument: %s\n", argv[0], argv[1]);
+            exit(1);
+        }
+    }
+
+    int nprocs = get_nprocs();
+    printf("Number of processors is %d\n", nprocs);
+
+    if (_host_nprocs != -1)
+    {
+        if (_host_nprocs != nprocs)
+        {
+            PUTERR("nprocs mismatch %d != %d\n", _host_nprocs, nprocs);
         }
     }
 

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -504,7 +504,7 @@ enclave
         long myst_sched_getaffinity_ocall(
             pid_t pid,
             size_t cpusetsize,
-            [out, size=cpusetsize] uint8_t* mask);
+            [in, out, size=cpusetsize] uint8_t* mask);
 
         void myst_cpuid_ocall(
             uint32_t leaf,


### PR DESCRIPTION
… val.

The cpuset_t* mask parameter is an in/out parameter.
The kernel will set/unset only those bits that correspond to
a processor; the other bits are untouched and retain their original value.

Therefore, make the mask parameter an in/out parameter in EDL.
If it is made only an out parameter, then it is not initialized on the host
side and has junk values. These junk values are not cleared by the syscall
and propagate all the way to the enclave. This causes the enclave to report
that it has a large number of processors (e.g 208).

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>