### PR TITLE
add lldb-10 install to code-coverage-nightly pipeline; add gcov in tests/myst/

### DIFF
--- a/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
@@ -32,6 +32,7 @@ jobs:
         sudo apt-get install build-essential lcov python3-setuptools python3-pip llvm-7 libmbedtls-dev docker-ce -y
         sudo chmod 666 /var/run/docker.sock
         sudo apt install python3-pip -y
+        sudo apt install lldb-10 -y
         docker system prune -a -f
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
         sudo pip3 install lcov_cobertura

--- a/tests/myst/dump-package/Makefile
+++ b/tests/myst/dump-package/Makefile
@@ -7,6 +7,10 @@ CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 LDFLAGS += -L$(LIBDIR) -lopenenclave
 
+ifdef MYST_ENABLE_GCOV
+CFLAGS += $(GCOV_CFLAGS)
+endif
+
 REDEFINE_TESTS=1
 
 include $(TOP)/rules.mak
@@ -19,7 +23,7 @@ dump-package:
 	openssl genrsa -out private.pem -3 3072
 	openssl rsa -in private.pem -pubout -out public.pem
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(VALGRIND) $(MYST) package $(APPDIR) private.pem config.json
 	$(PREFIX) $(VALGRIND) $(MYST) dump ./myst/bin/$(APPNAME)
 	sudo chown -R $(USER).$(USER) myst

--- a/tests/myst/exec-not-signed/Makefile
+++ b/tests/myst/exec-not-signed/Makefile
@@ -7,6 +7,10 @@ CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 LDFLAGS += -L$(LIBDIR) -lopenenclave
 
+ifdef MYST_ENABLE_GCOV
+CFLAGS += $(GCOV_CFLAGS)
+endif
+
 REDEFINE_TESTS=1
 
 CLEAN = appdir result rootfs
@@ -21,7 +25,7 @@ tests:
 test-a:
 	rm -rf $(APPDIR) result rootfs
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
 	$(MYST_EXEC) rootfs /bin/$(APPNAME) red green blue yellow > result
 	grep -E "argv\[0]=/bin/hello" result
@@ -35,7 +39,7 @@ test-a:
 test-mem-size:
 	rm -rf $(APPDIR) result rootfs
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
 	$(MYST_EXEC) rootfs --memory-size 1g /bin/$(APPNAME) red green blue yellow > result
 	grep -E "argv\[0]=/bin/hello" result
@@ -49,7 +53,7 @@ test-mem-size:
 test-config:
 	rm -rf $(APPDIR) result rootfs
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
 	$(MYST_EXEC) rootfs --app-config-path config.json /bin/$(APPNAME) red green blue yellow > result
 	grep -E "argv\[0]=/bin/hello" result
@@ -65,7 +69,7 @@ clean-exec-not-signed:
 
 build: clean-exec-not-signed
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 
 mkcpio: build
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs

--- a/tests/myst/exec-package/Makefile
+++ b/tests/myst/exec-package/Makefile
@@ -7,6 +7,10 @@ CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 LDFLAGS += -L$(LIBDIR) -lopenenclave
 
+ifdef MYST_ENABLE_GCOV
+CFLAGS += $(GCOV_CFLAGS)
+endif
+
 REDEFINE_TESTS=1
 
 include $(TOP)/rules.mak
@@ -23,7 +27,7 @@ package:
 	openssl genrsa -out private.pem -3 3072
 	openssl rsa -in private.pem -pubout -out public.pem
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(VALGRIND) $(MYST) package $(APPDIR) private.pem config.json
 	sudo chown -R $(USER).$(USER) myst
 
@@ -32,7 +36,7 @@ package-zerobase:
 	openssl genrsa -out private.pem -3 3072
 	openssl rsa -in private.pem -pubout -out public.pem
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(VALGRIND) $(MYST) package $(APPDIR) private.pem config_zerobase.json
 	sudo chown -R $(USER).$(USER) myst
 

--- a/tests/myst/exec-signed-1/Makefile
+++ b/tests/myst/exec-signed-1/Makefile
@@ -7,6 +7,10 @@ CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 LDFLAGS += -L$(LIBDIR) -lopenenclave
 
+ifdef MYST_ENABLE_GCOV
+CFLAGS += $(GCOV_CFLAGS)
+endif
+
 REDEFINE_TESTS=1
 
 include $(TOP)/rules.mak
@@ -19,7 +23,7 @@ exec-signed:
 	openssl genrsa -out private.pem -3 3072
 	openssl rsa -in private.pem -pubout -out public.pem
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
 	$(PREFIX) $(MYST) sign rootfs private.pem config.json
 	sudo chown -R $(USER).$(USER) hello.signed
@@ -37,7 +41,7 @@ pem:
 
 build: clean-exec-signed-1
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 
 mkcpio: build
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs

--- a/tests/myst/exec-signed-2/Makefile
+++ b/tests/myst/exec-signed-2/Makefile
@@ -7,6 +7,10 @@ CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 LDFLAGS += -L$(LIBDIR) -lopenenclave
 
+ifdef MYST_ENABLE_GCOV
+CFLAGS += $(GCOV_CFLAGS)
+endif
+
 REDEFINE_TESTS=1
 
 include $(TOP)/rules.mak
@@ -17,7 +21,7 @@ tests:
 exec-signed:
 	rm -rf $(APPDIR) result rootfs private.pem public.pem $(APPNAME).signed
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
 	openssl genrsa -out private.pem -3 3072
 	openssl rsa -in private.pem -pubout -out public.pem

--- a/tests/myst/mkcpio/Makefile
+++ b/tests/myst/mkcpio/Makefile
@@ -7,6 +7,10 @@ CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 LDFLAGS += -L$(LIBDIR) -lopenenclave
 
+ifdef MYST_ENABLE_GCOV
+CFLAGS += $(GCOV_CFLAGS)
+endif
+
 REDEFINE_TESTS=1
 
 include $(TOP)/rules.mak
@@ -17,7 +21,7 @@ tests:
 test-mkcpio:
 	rm -rf $(APPDIR) $(APPDIR)2 dir1 dir2 dir1.txt dir2.txt difference1.txt rootfs private.pem public.pem $(APPNAME).signed
 	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/$(APPNAME) ../hello.c $(LDFLAGS)
 	$(PREFIX) $(MYST) mkcpio $(APPDIR) rootfs
 	$(PREFIX) $(MYST) excpio rootfs $(APPDIR)2
 	sudo chown -R $(USER).$(USER) $(APPDIR) rootfs $(APPDIR)2


### PR DESCRIPTION
Fixed bug where myst/tests/ did not have gcov library linked; Added lldb-10 install step to code-coverage-nightly pipeline.