### PR TITLE
Fallback to use pathname from fdmappings entry for msync

### DIFF
--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -15,7 +15,8 @@
 typedef struct myst_fdmapping
 {
     uint32_t used;           /* whether entry is used */
-    int32_t fd;              /* fd that page is mapped to */
+    int32_t fd;              /* fd that page is mapped to. Invalidated by
+                                myst_mman_close_notify. */
     uint64_t offset;         /* offset of page within file */
     myst_refstr_t* pathname; /* full pathname associated with fd */
 } myst_fdmapping_t;
@@ -52,6 +53,8 @@ int myst_get_free_ram(size_t* size);
 int myst_release_process_mappings(pid_t pid);
 
 int myst_msync(void* addr, size_t length, int flags);
+
+void myst_mman_close_notify(int fd);
 
 typedef struct myst_mman_stats
 {

--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -53,8 +53,6 @@ int myst_release_process_mappings(pid_t pid);
 
 int myst_msync(void* addr, size_t length, int flags);
 
-void myst_mman_close_notify(int fd);
-
 typedef struct myst_mman_stats
 {
     size_t brk_size;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1090,7 +1090,6 @@ long myst_syscall_close(int fd)
         myst_remove_fd_link(fd);
     }
 
-    myst_mman_close_notify(fd);
     ECHECK(myst_fdtable_remove(fdtable, fd));
     ECHECK((*fdops->fd_close)(device, object));
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1090,6 +1090,7 @@ long myst_syscall_close(int fd)
         myst_remove_fd_link(fd);
     }
 
+    myst_mman_close_notify(fd);
     ECHECK(myst_fdtable_remove(fdtable, fd));
     ECHECK((*fdops->fd_close)(device, object));
 

--- a/solutions/coreclr/pr0-256m
+++ b/solutions/coreclr/pr0-256m
@@ -2364,6 +2364,7 @@ baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r/BasicTest_QuickJitOn_R2r
 baseservices/typeequivalence/simple/Simple/Simple.dll
 baseservices/threading/coverage/OSThreadId/osthreadid/osthreadid.dll
 baseservices/compilerservices/RuntimeWrappedException/RuntimeWrappedException/RuntimeWrappedException.dll
+readytorun/crossgen2/crossgen2smoke/crossgen2smoke.dll
 readytorun/DynamicMethodGCStress/DynamicMethodGCStress/DynamicMethodGCStress.dll
 baseservices/varargs/varargsupport/varargsupport.dll
 baseservices/varargs/varargsupport_r/varargsupport_r.dll

--- a/solutions/coreclr/pr0-FAILED
+++ b/solutions/coreclr/pr0-FAILED
@@ -6,7 +6,6 @@ JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314/b425314.dll, potential-han
 JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654/b426654.dll, potential-hang, 1g
 JIT/Regression/JitBlue/Runtime_40444/Runtime_40444/Runtime_40444.dll, Error-255, 1g
 Loader/binding/tracing/BinderTracingTest.ResolutionFlow/BinderTracingTest.ResolutionFlow.dll, SIGSEGV, 3g
-readytorun/crossgen2/crossgen2smoke/crossgen2smoke.dll, System.UnauthorizedAccessException, 256m
 tracing/eventpipe/buffersize/buffersize/buffersize.dll
 tracing/eventpipe/diagnosticport/diagnosticport/diagnosticport.dll
 tracing/eventpipe/eventsourceerror/eventsourceerror/eventsourceerror.dll

--- a/tests/msync/msync.c
+++ b/tests/msync/msync.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -16,6 +17,11 @@
 #ifndef PAGE_SIZE
 #define PAGE_SIZE 4096
 #endif
+
+static void _passed(const char* name)
+{
+    printf("=== passed test (%s)\n", name);
+}
 
 static int _writen(int fd, const void* data, size_t size)
 {
@@ -78,7 +84,7 @@ static bool _check_page(uint8_t page[PAGE_SIZE], uint8_t byte)
     return true;
 }
 
-int main(int argc, const char* argv[])
+static void test_msync()
 {
     const size_t num_pages = 8;
     uint8_t page[PAGE_SIZE];
@@ -176,7 +182,56 @@ int main(int argc, const char* argv[])
         assert(close(fd) == 0);
     }
 
-    printf("=== passed test (%s)\n", argv[0]);
+    _passed(__FUNCTION__);
+}
 
+static void test_msync_closed_read_fd()
+{
+    int fd = creat("/tmp/datafile", 0666);
+    write(fd, "abcdefghijklmnopqrstuvwxyz", 27);
+    close(fd);
+
+    fd = open("/tmp/datafile", O_CLOEXEC);
+    void* p = mmap(NULL, PAGE_SIZE, PROT_READ, MAP_SHARED, fd, 0);
+    assert(p != MAP_FAILED);
+    close(fd);
+    int ret = msync(p, PAGE_SIZE, MS_SYNC | MS_INVALIDATE);
+    assert(ret == 0 && errno == 0);
+    assert(unlink("/tmp/datafile") == 0);
+    munmap(p, PAGE_SIZE);
+    _passed(__FUNCTION__);
+}
+
+static void test_msync_closed_rw_fd()
+{
+    int fd = creat("/tmp/datafile", 0666);
+    write(fd, "abcdefghijklmnopqrstuvwxyz", 27);
+    close(fd);
+
+    fd = open("/tmp/datafile", O_RDWR | O_CLOEXEC);
+    void* p = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    assert(p != MAP_FAILED);
+    close(fd);
+
+    char* cp = p;
+    memcpy(cp, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", 27);
+    int ret = msync(p, PAGE_SIZE, MS_SYNC | MS_INVALIDATE);
+    assert(ret == 0 && errno == 0);
+
+    char buf[27];
+    fd = open("/tmp/datafile", O_RDONLY);
+    read(fd, buf, 27);
+    assert(strcmp(buf, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") == 0);
+    assert(unlink("/tmp/datafile") == 0);
+    munmap(p, PAGE_SIZE);
+    _passed(__FUNCTION__);
+}
+
+int main(int argc, const char* argv[])
+{
+    test_msync();
+    test_msync_closed_read_fd();
+    test_msync_closed_rw_fd();
+    _passed(argv[0]);
     return 0;
 }


### PR DESCRIPTION
### Summary
- fdmappings are not cleaned up when fd is closed. This enables msync operations after file close.
- on `close(fd)`, the fd field in the corresponding file mapping entries is invalidated. Any later msync uses `fdmapping.pathname` to open the file. 

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>