### PR TITLE
Test for python debugger

### DIFF
--- a/tests/python_pdb/Dockerfile
+++ b/tests/python_pdb/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-rc-slim
+WORKDIR /app
+COPY ./main.py .
+RUN pip install rpdb && \
+    pip install remote-pdb
+ENV PYTHONUNBUFFERED=1
+CMD ["/usr/local/bin/python3", "/app/main.py"]

--- a/tests/python_pdb/Makefile
+++ b/tests/python_pdb/Makefile
@@ -1,0 +1,33 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+PDB_LOG_FILE=pdb.log
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+all: rootfs
+
+appdir:
+	$(APPBUILDER) Dockerfile
+
+rootfs: appdir
+	$(MYST) mkext2 appdir rootfs
+
+APP_NAME=/usr/local/bin/python3
+APP_ARGS=/app/main.py
+
+tests: rootfs
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs $(APP_NAME) $(APP_ARGS) &
+	sleep 2 && nc 127.0.0.1 4444 < commands.pdb > ${PDB_LOG_FILE}
+	@cat ${PDB_LOG_FILE}
+	@cat ${PDB_LOG_FILE} | grep -E "\(Pdb) 16" > /dev/null
+	@cat ${PDB_LOG_FILE} | grep -E "=== passed test \(pdb)" > /dev/null
+
+gdb:
+	$(MAKE) tests GDB=1
+
+clean:
+	rm -fr appdir rootfs

--- a/tests/python_pdb/commands.pdb
+++ b/tests/python_pdb/commands.pdb
@@ -1,0 +1,20 @@
+n
+n
+s
+s
+s
+s
+s
+s
+s
+s
+s
+s
+s
+s
+s
+p n
+b main.py:14
+c
+c
+q

--- a/tests/python_pdb/main.py
+++ b/tests/python_pdb/main.py
@@ -1,0 +1,14 @@
+#!/usr/local/bin/python3
+import remote_pdb
+
+print ("Setting break")
+remote_pdb.set_trace('127.0.0.1', 4444)
+
+def fact(n):
+    if n == 0:
+        return 1
+    return n * fact(n-1)
+
+print ("Hello, World")
+print ("fact(20) = %s" % fact(20))
+print ("=== passed test (pdb)")


### PR DESCRIPTION
Since mystikos doesn't enable stdin, remote debugging is
preferred for python.

To enable remote debugging, a python program must to the following:

```
   import remote_pdb
   ...
   ...
   \# Set breakpoint
   remote_pdb.set_trace('127.0.0.1', 4444)
```

When the program is run, the remote debugger will wait for
connections at port 4444 in localhost.

To debug, telnet or nc can be used to connect to the port
```bash
   $ telnet 127.0.0.1 4444
    (Pdb) n
    ...
```

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>