### PR TITLE
Adding pandas tests

### DIFF
--- a/solutions/Makefile
+++ b/solutions/Makefile
@@ -28,6 +28,7 @@ ifndef MYST_SKIP_PR_TEST
 # Disable this as it fails pipeline, will re-enable after investigation
 #DIRS += pytorch_inference
 DIRS += tensorflow_lite
+DIRS += pandas_tests
 endif
 DIRS += nodejs
 DIRS += numpy_core_tests

--- a/solutions/pandas_tests/Dockerfile
+++ b/solutions/pandas_tests/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-slim
+
+RUN pip3 install pytest pandas hypothesis &&\
+    ln -sf /bin/bash /bin/sh
+
+WORKDIR /app
+COPY ./app.py .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["/usr/local/bin/python3", "/app/app.py"]

--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -1,0 +1,64 @@
+# Some tests in files listed in tests.partially_passed fail/ error out on execution.
+# These failures and error are caused by one of below:
+# 1. pypaper linux specific errors, documented
+# here - https://pyperclip.readthedocs.io/en/latest/#not-implemented-error
+# 2. s3fs error (which is currently an optional file handling mechanism in pandas)
+# https://bleepcoder.com/evalml/557744402/unit-test-fails-after-upgrading-to-pandas-1-0-0
+
+TOP = $(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER=$(TOP)/scripts/appbuilder
+PYTHON3 = /usr/local/bin/python3
+PYTEST_CMD = $(PYTHON3) -m pytest
+PYTEST_INI_FILE = pytest.ini
+PYTEST_OPTS = -s -q --no-header --skip-slow --skip-db --skip-network
+TEST_ROOT = /usr/local/lib/python3.9/site-packages/
+TEST = pandas/tests/arrays/string_/test_string.py
+
+OPTS = --max-affinity-cpus=4 --app-config-path config.json
+ifdef STRACE
+OPTS += --strace
+endif
+
+all: rootfs
+
+appdir:
+	$(APPBUILDER) Dockerfile
+	cp $(PYTEST_INI_FILE) appdir/
+
+rootfs: appdir
+	$(MYST) mkext2 appdir rootfs
+
+rootfs-passed: appdir
+	# remove test files that are known to fail partially. These are tested in target 'run'
+	# for expected failures/ errors.
+	cat tests.partially_passed | while read line; do rm -f appdir/"$$line"; done
+	$(MYST) mkext2 appdir rootfs-passed
+
+run-passed: rootfs-passed
+	$(MYST_EXEC) rootfs-passed $(OPTS) $(PYTHON3) /app/app.py
+
+run: rootfs
+	(cat tests.partially_passed | xargs -P 8 $(MYST_EXEC) rootfs $(OPTS) \
+		$(PYTEST_CMD) $(PYTEST_OPTS) 2>&1 > result; \
+		test "$$?" -eq "123")
+	sed -i '$$d' result
+	tail -n 27 result > test_summary
+	diff test_summary expected-test-summary
+	$(MAKE) clean_intermediate
+	$(MAKE) run-passed
+
+run-one: rootfs
+	# NOTE: This target is provided for debugging purposes only. It could fail
+	# unexpectedly for few test files.
+	# (e.g., pandas/tests/extension/arrow/arrays.py fails with
+	# ModuleNotFoundError).
+	$(MYST_EXEC) rootfs $(OPTS) $(PYTEST_CMD) $(PYTEST_OPTS) $(TEST_ROOT)/$(TEST)
+
+clean_intermediate:
+	rm -rf rootfs .pytest_cache result test_summary
+
+clean:
+	$(MAKE) clean_intermediate
+	rm -rf myst rootfs rootfs-passed appdir

--- a/solutions/pandas_tests/app.py
+++ b/solutions/pandas_tests/app.py
@@ -1,0 +1,4 @@
+import pandas as pd
+import pytest
+
+result = pd.test()

--- a/solutions/pandas_tests/config.json
+++ b/solutions/pandas_tests/config.json
@@ -1,0 +1,18 @@
+{
+    // OpenEnclave specific values
+
+    // Whether we are running myst+OE+app in debug mode
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+
+    // The heap size of the user application. Increase this setting if your app experienced OOM.
+    "MemorySize": "3g",
+    "NoBrk": true,
+    "HostApplicationParameters": true,
+    "ForkMode":"pseudo_wait_for_exit_exec",
+    "CurrentWorkingDirectory":"/app",
+    "EnvironmentVariables":["PYTHONUNBUFFERED=1"]
+}

--- a/solutions/pandas_tests/expected-test-summary
+++ b/solutions/pandas_tests/expected-test-summary
@@ -1,0 +1,27 @@
+=========================== short test summary info ============================
+FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[\U0001f44d...]
+FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[\u03a9\u0153\u2211\xb4...]
+FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[abcd...]
+FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/xml/test_xml.py::test_empty_string_etree[0]
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetPyArrow::test_s3_roundtrip_explicit_fs
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetPyArrow::test_s3_roundtrip
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetFastParquet::test_s3_roundtrip
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_compression.py::test_with_s3_url[None]
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_compression.py::test_with_s3_url[gzip]
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_compression.py::test_with_s3_url[bz2]
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_compression.py::test_with_s3_url[zip]
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_compression.py::test_with_s3_url[xz]
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_pandas.py::TestPandasContainer::test_read_s3_jsonl
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_pandas.py::TestPandasContainer::test_to_s3
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_parse_public_s3n_bucket
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_parse_public_s3a_bucket
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_parse_public_s3_bucket_nrows
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_parse_public_s3_bucket_chunked
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_parse_public_s3_bucket_chunked_python
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_parse_public_s3_bucket_python
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_infer_s3_compression
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_parse_public_s3_bucket_nrows_python
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_read_s3_fails
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_read_csv_handles_boto_s3_object
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_read_csv_chunked_download
+ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py::TestS3::test_read_s3_with_hash_in_key

--- a/solutions/pandas_tests/pytest.ini
+++ b/solutions/pandas_tests/pytest.ini
@@ -1,0 +1,16 @@
+# pytest.ini
+
+# pandas/tests uses the following custom pytest markers, which are not
+# automatically registered by the pytest commandline. Registering them here
+# enables tests that fail with PytestUnknownMarkWarning error to run smoothly.
+
+[pytest]
+markers =
+    slow
+    arm_slow
+    high_memory
+    arraymanager
+    single
+    network
+    db
+    clipboard

--- a/solutions/pandas_tests/tests.partially_passed
+++ b/solutions/pandas_tests/tests.partially_passed
@@ -1,0 +1,6 @@
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_compression.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/json/test_pandas.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_network.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/xml/test_xml.py


### PR DESCRIPTION
The file selective_tests holds a list of files that contains tests that fail/ error out. The target 'run-all' runs the tests in these files and compares the test summary to the expect-test-summary. These failures and error are caused by one of below:

1. pypaper copy/paste linux specific errors, documented here - https://pyperclip.readthedocs.io/en/latest/#not-implemented-error

2. s3fs functioning incorrectly (which is currently an optional file handling mechanism in pandas) https://bleepcoder.com/evalml/557744402/unit-test-fails-after-upgrading-to-pandas-1-0-0

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>