### PR TITLE
Clean up aspnet solution config.json and Makefile

### DIFF
--- a/solutions/aspnet/Makefile
+++ b/solutions/aspnet/Makefile
@@ -4,6 +4,8 @@ include $(TOP)/defs.mak
 APPBUILDER=$(TOP)/scripts/appbuilder
 APPNAME=webapp
 
+OPTS = --app-config-path config.json
+
 ifdef STRACE
 OPTS += --strace
 endif
@@ -12,17 +14,15 @@ ifdef PERF
 OPTS += --perf
 endif
 
-OPTS += --memory-size=1024m
-
 # ATTN: this setting causes curl to get empty responses after two attempts
 #OPTS += --max-affinity-cpus=1
 
 all: appdir private.pem
 
-TIMEOUT=300s
+TIMEOUT=30s
 
 export COMPlus_EnableDiagnostics=0
-export COMPlus_GCHeapHardLimit=0x8000000
+export COMPlus_GCHeapHardLimit=0x10000000
 
 run: rootfs private.pem
 	./kill.sh
@@ -34,7 +34,7 @@ run: rootfs private.pem
 
 # run the server in the foreground:
 server: rootfs
-	$(MYST_EXEC) rootfs /app/webapp $(OPTS)
+	$(MYST_EXEC) $(OPTS) rootfs /app/webapp 
 
 # run the client
 client:

--- a/solutions/aspnet/config.json
+++ b/solutions/aspnet/config.json
@@ -3,22 +3,21 @@
 
     // Whether we are running myst+OE+app in debug mode
     "Debug": 1,
-    // The stack size of each ethread
     "ProductID": 1,
     "SecurityVersion": 1,
-    // The stack size of each ethread
-    "StackMemSize": "800k",
 
     // Mystikos specific values
 
     // The heap size of the user application. Increase this setting if your app experienced OOM.
     "MemorySize": "1024m",
+    // CWD for the app
+    "CurrentWorkingDirectory": "/app",
     // The path to the entry point application in rootfs
     "ApplicationPath": "/app/webapp",
     // The parameters to the entry point application
     "ApplicationParameters": [],
-    // Whether we allow "ApplicationParameters" to be overridden by command line options of "myst exec"
-    "HostApplicationParameters": true,
+    // Whether we allow "ApplicationParameters" to be overridden by command line
+    "HostApplicationParameters": false,
     // The environment variables accessible inside the enclave.
-    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0", "COMPlus_GCHeapHardLimit=0x10000000"],
+    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0", "COMPlus_GCHeapHardLimit=0x10000000"]
 }


### PR DESCRIPTION
  - Add CWD entry in config.json, for .NET runtime to correctly locate
    appsettings.json of the app
  - Use config.json consistently across different make run targets
  - sync COMPlus_GCHeapHardLimit env. variable setting in Makefile and config.json
  - shorten timeout to a more resonable 30s

Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>