### PR TITLE
Fix broken error-tracing feature

### DIFF
--- a/kernel/hostfile.c
+++ b/kernel/hostfile.c
@@ -61,8 +61,6 @@ int myst_load_host_file(const char* path, void** data_out, size_t* size_out)
     };
     struct locals* locals = NULL;
 
-    myst_set_trace(true);
-
     if (data_out)
         *data_out = NULL;
 
@@ -114,8 +112,6 @@ done:
 
     if (locals)
         free(locals);
-
-    myst_set_trace(false);
 
     return ret;
 }

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -1065,8 +1065,6 @@ static long _handle_mman_pids_op(
     size_t index;
     size_t count;
 
-    // myst_set_trace(true);
-
     if (!addr || pid < 0)
         ERAISE(-EINVAL);
 
@@ -1137,7 +1135,6 @@ static long _handle_mman_pids_op(
 done:
     _runlock(&locked);
 
-    // myst_set_trace(false);
     return ret;
 }
 


### PR DESCRIPTION
The error-tracing feature (--etrace) was broken by the following line added during debugging and development.

```
myst_set_trace(false);
```