### PR TITLE
Make sure that on SGX we always use config

### DIFF
--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -6,15 +6,17 @@
 
 #include <limits.h>
 
+#include <myst/args.h>
 #include <myst/kernel.h>
 #include <myst/types.h>
 
+// common options between sgx and linux target
 typedef struct myst_options
 {
-    bool trace_errors;
-    bool trace_syscalls;
     bool have_syscall_instruction;
     bool have_fsgsbase_instructions;
+    bool trace_errors;
+    bool trace_syscalls;
     bool shell_mode;
     bool debug_symbols;
     bool memcheck;
@@ -26,9 +28,17 @@ typedef struct myst_options
     size_t max_affinity_cpus;
     char rootfs[PATH_MAX];
     myst_fork_mode_t fork_mode;
-
     myst_host_enc_uid_gid_mappings host_enc_uid_gid_mappings;
 } myst_options_t;
+
+typedef struct myst_final_options
+{
+    myst_options_t base;
+    const char* cwd;
+    const char* hostname;
+    myst_args_t args;
+    myst_args_t env;
+} myst_final_options_t;
 
 extern myst_options_t __options;
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,8 +55,12 @@ DIRS += pipesz
 DIRS += futex
 DIRS += round
 DIRS += signal
+
+ifneq ($(TARGET),linux)
 DIRS += tlscert
 DIRS += tlscert2
+endif
+
 DIRS += wake_and_kill
 DIRS += cross_fs_symlinks
 DIRS += arch_prctl

--- a/tests/hello_world/java/Makefile
+++ b/tests/hello_world/java/Makefile
@@ -3,8 +3,10 @@ include $(TOP)/defs.mak
 
 APPBUILDER=$(TOP)/scripts/appbuilder
 
+OPTS = --app-config-path config.json
+
 ifdef STRACE
-	OPTS = --strace
+	OPTS += --strace
 endif
 
 all: appdir rootfs
@@ -16,7 +18,7 @@ rootfs: appdir
 	$(MYST) mkext2 --force appdir ext2rootfs
 
 tests:
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) ext2rootfs /opt/openjdk-13/bin/java -ea Helloworld red green blue --app-config-path config.json --max-affinity-cpus=1
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) ext2rootfs /opt/openjdk-13/bin/java -ea Helloworld red green blue 
 
 clean:
 	rm -rf ext2rootfs appdir

--- a/tests/hello_world/java/config.json
+++ b/tests/hello_world/java/config.json
@@ -5,5 +5,7 @@
     "UserMemSize": "2048m",
     "CurrentWorkingDirectory": "/app",
     "ApplicationPath": "/opt/openjdk-13/bin/java",
-    "ApplicationParameters": ["-ea", "Helloworld", "red", "green", "blue"]
+    "ApplicationParameters": ["-ea", "Helloworld", "red", "green", "blue"],
+
+    "MaxAffinityCPUs": 1
 }

--- a/tests/ltp/README.md
+++ b/tests/ltp/README.md
@@ -1113,7 +1113,7 @@ FAILING
 | /ltp/testcases/kernel/syscalls/setpriority/setpriority02 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/setregid/setregid01 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/setregid/setregid01_16 | 0 | 0 | 0 |
-| /ltp/testcases/kernel/syscalls/setregid/setregid02 | 1 | 1 | 1 |
+| /ltp/testcases/kernel/syscalls/setregid/setregid02 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/setregid/setregid02_16 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/setregid/setregid03 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/setregid/setregid03_16 | 0 | 0 | 0 |

--- a/tests/ltp/ext2fs_tests_passed.txt
+++ b/tests/ltp/ext2fs_tests_passed.txt
@@ -235,7 +235,6 @@
 /ltp/testcases/kernel/syscalls/setpgrp/setpgrp01
 /ltp/testcases/kernel/syscalls/setpgrp/setpgrp02
 /ltp/testcases/kernel/syscalls/setregid/setregid01
-/ltp/testcases/kernel/syscalls/setregid/setregid02
 /ltp/testcases/kernel/syscalls/setregid/setregid03
 /ltp/testcases/kernel/syscalls/setregid/setregid04
 /ltp/testcases/kernel/syscalls/setresgid/setresgid01

--- a/tests/ltp/hostfs_tests_passed.txt
+++ b/tests/ltp/hostfs_tests_passed.txt
@@ -252,7 +252,6 @@
 /ltp/testcases/kernel/syscalls/setpgrp/setpgrp01
 /ltp/testcases/kernel/syscalls/setpgrp/setpgrp02
 /ltp/testcases/kernel/syscalls/setregid/setregid01
-/ltp/testcases/kernel/syscalls/setregid/setregid02
 /ltp/testcases/kernel/syscalls/setregid/setregid03
 /ltp/testcases/kernel/syscalls/setregid/setregid04
 /ltp/testcases/kernel/syscalls/setresgid/setresgid01

--- a/tests/ltp/ramfs_tests_passed.txt
+++ b/tests/ltp/ramfs_tests_passed.txt
@@ -223,7 +223,6 @@
 /ltp/testcases/kernel/syscalls/setpgrp/setpgrp01
 /ltp/testcases/kernel/syscalls/setpgrp/setpgrp02
 /ltp/testcases/kernel/syscalls/setregid/setregid01
-/ltp/testcases/kernel/syscalls/setregid/setregid02
 /ltp/testcases/kernel/syscalls/setregid/setregid03
 /ltp/testcases/kernel/syscalls/setregid/setregid04
 /ltp/testcases/kernel/syscalls/setresgid/setresgid01

--- a/tests/myst/exec-package-ext2/Makefile
+++ b/tests/myst/exec-package-ext2/Makefile
@@ -7,6 +7,18 @@ ROOTFS=$(TMPDIR)/rootfs
 PRIVKEY=$(TMPDIR)/private.pem
 PUBKEY=$(TMPDIR)/public.pem
 
+ifdef STRACE
+OPTS += --strace
+endif
+
+ifdef ETRACE
+OPTS += --etrace
+endif
+
+ifdef TRACE
+OPTS += --etrace --strace
+endif
+
 USER=$(shell id --user)
 GROUP=$(shell id --group)
 
@@ -28,8 +40,8 @@ $(TMPDIR):
 #export MYST_ROOTFS_PATH=$(ROOTFS)
 
 tests: all
-	$(RUNTEST) $(MYST) exec-sgx --pubkey=$(PUBKEY) $(ROOTFS) /bin/hello
-	$(RUNTEST) ./myst/bin/hello --rootfs=$(ROOTFS)
+	$(RUNTEST) $(MYST) exec-sgx $(OPTS) --pubkey=$(PUBKEY) $(ROOTFS) /bin/hello
+	$(RUNTEST) ./myst/bin/hello $(OPTS) --rootfs=$(ROOTFS)
 
 dump:
 	echo MYST_ROOTFS_PATH=$(MYST_ROOTFS_PATH)

--- a/tools/myst/enc/Makefile
+++ b/tools/myst/enc/Makefile
@@ -20,6 +20,7 @@ SOURCES += syscall.c
 SOURCES += ../config.c
 SOURCES += ../common.c
 SOURCES += ../kargs.c
+SOURCES += ../options.c
 
 ifdef MYST_ENABLE_GCOV
 SOURCES += gcov.c

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -44,7 +44,8 @@
 
 static myst_kernel_args_t _kargs;
 static mcontext_t _mcontext;
-static bool _trace_syscalls = false;
+
+struct myst_final_options final_options = {0};
 
 extern const void* __oe_get_heap_base(void);
 
@@ -244,7 +245,7 @@ __attribute__((format(printf, 2, 3))) static void _exception_handler_strace(
     const char* fmt,
     ...)
 {
-    if (_trace_syscalls)
+    if (final_options.base.trace_syscalls)
     {
         char null_char = '\0';
         char* buf = &null_char;
@@ -407,22 +408,6 @@ static uint64_t _vectored_handler(oe_exception_record_t* er)
     return _forward_exception_as_signal_to_kernel(er);
 }
 
-static bool _is_allowed_env_variable(
-    const config_parsed_data_t* config,
-    const char* env)
-{
-    for (size_t i = 0; i < config->host_environment_variables_count; i++)
-    {
-        const char* allowed = config->host_environment_variables[i];
-        size_t len = strlen(allowed);
-
-        if (strncmp(env, allowed, len) == 0 && env[len] == '=')
-            return true;
-    }
-
-    return false;
-}
-
 const void* __oe_get_enclave_start_address(void);
 size_t __oe_get_enclave_size(void);
 
@@ -477,7 +462,7 @@ static long _enter(void* arg_)
 {
     long ret = -1;
     struct enter_arg* arg = (struct enter_arg*)arg_;
-    struct myst_options* options = arg->options;
+    struct myst_options* host_options = arg->options;
     struct myst_shm* shared_memory = arg->shared_memory;
     const void* argv_data = arg->argv_data;
     size_t argv_size = arg->argv_size;
@@ -485,39 +470,22 @@ static long _enter(void* arg_)
     size_t envp_size = arg->envp_size;
     uint64_t event = arg->event;
     pid_t target_tid = arg->target_tid;
-    bool trace_errors = false;
-    bool shell_mode = false;
-    bool debug_symbols = false;
-    bool memcheck = false;
-    bool nobrk = false;
-    bool perf = false;
-    bool report_native_tids = false;
-    size_t max_affinity_cpus = options ? options->max_affinity_cpus : 0;
-    size_t main_stack_size = options ? options->main_stack_size : 0;
-    const char* rootfs = NULL;
     config_parsed_data_t parsed_config;
     bool have_config = false;
-    myst_args_t args;
-    myst_args_t env;
-    const char* cwd = "/";       // default to root dir
-    const char* hostname = NULL; // kernel has a default
     const uint8_t* enclave_image_base;
     size_t enclave_image_size;
     const Elf64_Ehdr* ehdr;
     const char target[] = "MYST_TARGET=sgx";
     const bool tee_debug_mode = (_test_oe_debug_mode() == 0);
-    myst_fork_mode_t fork_mode = options ? options->fork_mode : myst_fork_none;
-    bool unhandled_syscall_enosys =
-        options ? options->unhandled_syscall_enosys
-                : false; // default terminate with myst_panic
+    myst_args_t mount_mappings;
+    myst_args_t args;
+    myst_args_t env;
 
     memset(&parsed_config, 0, sizeof(parsed_config));
+    memset(&mount_mappings, 0, sizeof(mount_mappings));
 
     if (!argv_data || !argv_size || !envp_data || !envp_size)
         goto done;
-
-    memset(&args, 0, sizeof(args));
-    memset(&env, 0, sizeof(env));
 
     /* Get the enclave base address */
     if (!(enclave_image_base = __oe_get_enclave_start_address()))
@@ -545,181 +513,34 @@ static long _enter(void* arg_)
         }
     }
 
-    if (have_config && !parsed_config.allow_host_parameters)
+    if (myst_args_unpack(&args, argv_data, argv_size) != 0)
+        goto done;
+    if (myst_args_unpack(&env, envp_data, envp_size) != 0)
+        goto done;
+    if (myst_args_unpack(
+            &mount_mappings,
+            arg->mount_mappings_data,
+            arg->mount_mappings_size) != 0)
+        goto done;
+
+    if (determine_final_options(
+            host_options,
+            &final_options,
+            &args,
+            &env,
+            &parsed_config,
+            have_config,
+            tee_debug_mode,
+            target,
+            &mount_mappings) != 0)
     {
-        if (myst_args_init(&args) != 0)
-            goto done;
-
-        if (myst_args_append1(&args, parsed_config.application_path) != 0)
-            goto done;
-
-        if (myst_args_append(
-                &args,
-                (const char**)parsed_config.application_parameters,
-                parsed_config.application_parameters_count) != 0)
-        {
-            goto done;
-        }
-    }
-    else
-    {
-        if (myst_args_unpack(&args, argv_data, argv_size) != 0)
-            goto done;
-    }
-
-    // Need to handle config to environment
-    // in the mean time we will just pull from the host
-    if (have_config)
-    {
-        myst_args_init(&env);
-
-        // append all enclave-side environment variables first
-        if (myst_args_append(
-                &env,
-                (const char**)parsed_config.enclave_environment_variables,
-                parsed_config.enclave_environment_variables_count) != 0)
-        {
-            goto done;
-        }
-
-        // now include host-side environment variables that are allowed
-        if (parsed_config.host_environment_variables &&
-            parsed_config.host_environment_variables_count)
-        {
-            myst_args_t tmp;
-
-            if (myst_args_unpack(&tmp, envp_data, envp_size) != 0)
-                goto done;
-
-            for (size_t i = 0; i < tmp.size; i++)
-            {
-                if (_is_allowed_env_variable(&parsed_config, tmp.data[i]))
-                {
-                    if (myst_args_append1(&env, tmp.data[i]) != 0)
-                    {
-                        free(tmp.data);
-                        goto done;
-                    }
-                }
-            }
-
-            free(tmp.data);
-        }
-    }
-    else
-    {
-        if (myst_args_unpack(&env, envp_data, envp_size) != 0)
-            goto done;
+        fprintf(stderr, "Failed to determine final options\n");
+        assert(0);
     }
 
-    // Override current working directory if present in config
-    if (have_config && parsed_config.cwd)
-    {
-        cwd = parsed_config.cwd;
-    }
-
-    // Override current working directory if present in config
-    if (have_config && parsed_config.hostname)
-    {
-        hostname = parsed_config.hostname;
-    }
-
-    // Override max affinity if present in config
-    if (have_config && parsed_config.max_affinity_cpus)
-    {
-        max_affinity_cpus = parsed_config.max_affinity_cpus;
-    }
-
-    // Override main stack size if present in config
-    if (have_config && parsed_config.main_stack_size)
-    {
-        main_stack_size = parsed_config.main_stack_size;
-    }
-
-    // record the configuration for which fork mode
-    if (have_config && parsed_config.fork_mode)
-    {
-        fork_mode = parsed_config.fork_mode;
-    }
-
-    if (have_config && parsed_config.no_brk)
-    {
-        nobrk = options->nobrk = true;
-    }
-
-    // record the configuration for which termination mode
-    if (have_config)
-    {
-        unhandled_syscall_enosys = parsed_config.unhandled_syscall_enosys;
-    }
-
-    /* Inject the MYST_TARGET environment variable */
-    {
-        const char val[] = "MYST_TARGET=";
-
-        for (size_t i = 0; i < env.size; i++)
-        {
-            if (strncmp(env.data[i], val, sizeof(val) - 1) == 0)
-            {
-                fprintf(stderr, "environment already contains %s", val);
-                goto done;
-            }
-        }
-
-        myst_args_append1(&env, "MYST_TARGET=sgx");
-    }
-
-    /* Add mount source paths to config read mount points */
-    {
-        myst_args_t tmp = {0};
-
-        if (myst_args_unpack(
-                &tmp, arg->mount_mappings_data, arg->mount_mappings_size) != 0)
-        {
-            fprintf(stderr, "Failed to unpack mapping parameters\n");
-            goto done;
-        }
-
-        if (have_config && (!myst_merge_mount_mapping_and_config(
-                                &parsed_config.mounts, &tmp) ||
-                            !myst_validate_mount_config(&parsed_config.mounts)))
-        {
-            fprintf(
-                stderr,
-                "Failed to merge mounting configuration with command line "
-                "mount parameters\n");
-            goto done;
-        }
-    }
-
-    if (options)
-    {
-        // _trace_syscalls is used by vectored exception handler tracing,
-        // disable it if tee_debug_mode is false
-        _trace_syscalls = tee_debug_mode ? options->trace_syscalls : false;
-        // if tee_debug_mode is false, these options are disabled by the
-        // kernel upon entry.
-        trace_errors = tee_debug_mode ? options->trace_errors : false;
-        shell_mode = tee_debug_mode ? options->shell_mode : false;
-        debug_symbols = tee_debug_mode ? options->debug_symbols : false;
-        memcheck = tee_debug_mode ? options->memcheck : false;
-        nobrk = options->nobrk;
-        perf = tee_debug_mode ? options->perf : false;
-
-        report_native_tids =
-            tee_debug_mode ? options->report_native_tids : false;
-
-        /* rootfs buffer content set by the host side. Max length of the string
-         * is PATH_MAX-1. Enforce NULL terminator at the end of the buffer.
-         */
-        if (strnlen(options->rootfs, PATH_MAX) == PATH_MAX)
-        {
-            fprintf(stderr, "rootfs path too long (> %u)\n", PATH_MAX);
-            goto done;
-        }
-
-        rootfs = options->rootfs;
-    }
+    myst_args_release(&args);
+    myst_args_release(&env);
+    myst_args_release(&mount_mappings);
 
     /* Setup the vectored exception handler */
     if (oe_add_vectored_exception_handler(true, _vectored_handler) != OE_OK)
@@ -740,50 +561,56 @@ static long _enter(void* arg_)
         const void* regions_end = __oe_get_heap_base();
         char err[256];
 
-        init_kernel_args(
-            &_kargs,
-            target,
-            (int)args.size,
-            args.data,
-            (int)env.size,
-            env.data,
-            cwd,
-            &options->host_enc_uid_gid_mappings,
-            &parsed_config.mounts,
-            hostname,
-            regions_end,
-            enclave_image_base, /* image_data */
-            enclave_image_size, /* image_size */
-            _get_num_tcs(),     /* max threads */
-            trace_errors,
-            _trace_syscalls,
-            false, /* have_syscall_instruction */
-            tee_debug_mode,
-            event, /* thread_event */
-            target_tid,
-            max_affinity_cpus,
-            fork_mode,
-            myst_tcall,
-            rootfs,
-            err,
-            unhandled_syscall_enosys,
-            sizeof(err));
+        if (init_kernel_args(
+                &_kargs,
+                target,
+                (int)final_options.args.size,
+                final_options.args.data,
+                (int)final_options.env.size,
+                final_options.env.data,
+                final_options.cwd,
+                &final_options.base.host_enc_uid_gid_mappings,
+                &parsed_config.mounts,
+                final_options.hostname,
+                regions_end,
+                enclave_image_base, /* image_data */
+                enclave_image_size, /* image_size */
+                _get_num_tcs(),     /* max threads */
+                final_options.base.trace_errors,
+                final_options.base.trace_syscalls,
+                false, /* have_syscall_instruction */
+                tee_debug_mode,
+                event, /* thread_event */
+                target_tid,
+                final_options.base.max_affinity_cpus,
+                final_options.base.fork_mode,
+                myst_tcall,
+                final_options.base.rootfs,
+                err,
+                final_options.base.unhandled_syscall_enosys,
+                sizeof(err)) != 0)
+        {
+            fprintf(stderr, "init_kernel_args() failed\n");
+            assert(0);
+        }
 
-        _kargs.shell_mode = shell_mode;
-        _kargs.debug_symbols = debug_symbols;
-        _kargs.memcheck = memcheck;
-        _kargs.nobrk = nobrk;
-        _kargs.perf = perf;
+        _kargs.shell_mode = final_options.base.shell_mode;
+        _kargs.debug_symbols = final_options.base.debug_symbols;
+        _kargs.memcheck = final_options.base.memcheck;
+        _kargs.nobrk = final_options.base.nobrk;
+        _kargs.perf = final_options.base.perf;
         _kargs.start_time_sec = arg->start_time_sec;
         _kargs.start_time_nsec = arg->start_time_nsec;
-        _kargs.report_native_tids = report_native_tids;
+        _kargs.report_native_tids = final_options.base.report_native_tids;
         _kargs.enter_stack = arg->enter_stack;
         _kargs.enter_stack_size = arg->enter_stack_size;
-        _kargs.main_stack_size =
-            main_stack_size ? main_stack_size : MYST_PROCESS_INIT_STACK_SIZE;
+        _kargs.main_stack_size = final_options.base.main_stack_size
+                                     ? final_options.base.main_stack_size
+                                     : MYST_PROCESS_INIT_STACK_SIZE;
 
         /* whether user-space FSGSBASE instructions are supported */
-        _kargs.have_fsgsbase_instructions = options->have_fsgsbase_instructions;
+        _kargs.have_fsgsbase_instructions =
+            final_options.base.have_fsgsbase_instructions;
 
         /* set ehdr and verify that the kernel is an ELF image */
         {
@@ -814,11 +641,10 @@ static long _enter(void* arg_)
 
 done:
 
-    if (args.data)
-        free(args.data);
-
-    if (env.data)
-        free(env.data);
+    if (final_options.args.data)
+        free(final_options.args.data);
+    if (final_options.env.data)
+        free(final_options.env.data);
 
     free_config(&parsed_config);
     return ret;

--- a/tools/myst/options.c
+++ b/tools/myst/options.c
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <errno.h>
+#include <string.h>
+
+#include <myst/eraise.h>
+#include <myst/options.h>
+
+#include "config.h"
+#include "shared.h"
+
+static bool _is_allowed_env_variable(
+    const config_parsed_data_t* config,
+    const char* env)
+{
+    for (size_t i = 0; i < config->host_environment_variables_count; i++)
+    {
+        const char* allowed = config->host_environment_variables[i];
+        size_t len = strlen(allowed);
+
+        if (strncmp(env, allowed, len) == 0 && env[len] == '=')
+            return true;
+    }
+
+    return false;
+}
+
+long determine_final_options(
+    struct myst_options* cmdline_opts,
+    struct myst_final_options* final_opts,
+    const myst_args_t* args,
+    const myst_args_t* env,
+    config_parsed_data_t* parsed_config,
+    bool have_config,
+    bool tee_debug_mode,
+    const char* target_env_var,
+    myst_args_t* mount_mappings)
+{
+    long ret = -1;
+
+    /* make sure rootfs is null terminated. */
+    if (strnlen(cmdline_opts->rootfs, PATH_MAX) == PATH_MAX)
+    {
+        fprintf(
+            stderr,
+            "rootfs path too long or not null terminated (> %u)\n",
+            PATH_MAX);
+        goto done;
+    }
+    memcpy(
+        final_opts->base.rootfs,
+        cmdline_opts->rootfs,
+        sizeof(final_opts->base.rootfs));
+
+    final_opts->base.host_enc_uid_gid_mappings =
+        cmdline_opts->host_enc_uid_gid_mappings;
+    final_opts->base.have_fsgsbase_instructions =
+        cmdline_opts->have_fsgsbase_instructions;
+
+    // Config always wins, even if it is the default value from config
+    if (have_config)
+    {
+        final_opts->cwd = parsed_config->cwd;
+        final_opts->hostname = parsed_config->hostname;
+        final_opts->base.max_affinity_cpus = parsed_config->max_affinity_cpus;
+        final_opts->base.main_stack_size = parsed_config->main_stack_size;
+        final_opts->base.fork_mode = parsed_config->fork_mode;
+        final_opts->base.nobrk = parsed_config->no_brk;
+        final_opts->base.unhandled_syscall_enosys =
+            parsed_config->unhandled_syscall_enosys;
+
+        // Some options should not be enabled unless running in debug mode
+        if (tee_debug_mode)
+        {
+            final_opts->base.trace_syscalls = cmdline_opts->trace_syscalls;
+            final_opts->base.trace_errors = cmdline_opts->trace_errors;
+            final_opts->base.shell_mode = cmdline_opts->shell_mode;
+            final_opts->base.debug_symbols = cmdline_opts->debug_symbols;
+            final_opts->base.memcheck = cmdline_opts->memcheck;
+            final_opts->base.perf = cmdline_opts->perf;
+            final_opts->base.report_native_tids =
+                cmdline_opts->report_native_tids;
+        }
+        else
+        {
+            final_opts->base.trace_syscalls = false;
+            final_opts->base.trace_errors = false;
+            final_opts->base.shell_mode = false;
+            final_opts->base.debug_symbols = false;
+            final_opts->base.memcheck = false;
+            final_opts->base.perf = false;
+            final_opts->base.report_native_tids = false;
+        }
+    }
+    else
+    {
+        // No config is only possible when we are in debug mode for SGX or linux
+        // target
+        final_opts->base = *cmdline_opts;
+    }
+
+    if (final_opts->cwd == NULL)
+        final_opts->cwd = "/";
+
+    // Process command line
+    if (myst_args_init(&final_opts->args) != 0)
+        ERAISE(-EINVAL);
+
+    if (have_config && !parsed_config->allow_host_parameters)
+    {
+        if (myst_args_append1(
+                &final_opts->args, parsed_config->application_path) != 0)
+            ERAISE(-EINVAL);
+
+        if (myst_args_append(
+                &final_opts->args,
+                (const char**)parsed_config->application_parameters,
+                parsed_config->application_parameters_count) != 0)
+            ERAISE(-EINVAL);
+    }
+    else
+    {
+        if (myst_args_append(&final_opts->args, args->data, args->size) != 0)
+            ERAISE(-EINVAL);
+    }
+
+    // process environment
+    if (myst_args_init(&final_opts->env) != 0)
+        ERAISE(-EINVAL);
+    if (have_config)
+    {
+        // append all enclave-side environment variables first
+        if (myst_args_append(
+                &final_opts->env,
+                (const char**)parsed_config->enclave_environment_variables,
+                parsed_config->enclave_environment_variables_count) != 0)
+            ERAISE(-EINVAL);
+
+        // now include host-side environment variables that are allowed
+        if (parsed_config->host_environment_variables &&
+            parsed_config->host_environment_variables_count)
+        {
+            for (size_t i = 0; i < env->size; i++)
+            {
+                if (_is_allowed_env_variable(parsed_config, env->data[i]))
+                {
+                    if (myst_args_append1(&final_opts->env, env->data[i]) != 0)
+                    {
+                        ERAISE(-EINVAL);
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        if (myst_args_append(&final_opts->env, env->data, env->size) != 0)
+            ERAISE(-EINVAL);
+    }
+
+    /* Inject the MYST_TARGET environment variable */
+    {
+        const char val[] = "MYST_TARGET=";
+
+        for (size_t i = 0; i < final_opts->env.size; i++)
+        {
+            if (strncmp(final_opts->env.data[i], val, sizeof(val) - 1) == 0)
+            {
+                fprintf(stderr, "environment already contains %s", val);
+                ERAISE(-EINVAL);
+            }
+        }
+
+        myst_args_append1(&final_opts->env, target_env_var);
+    }
+
+    /* Add mount source paths to config read mount points */
+    if (!myst_merge_mount_mapping_and_config(
+            &parsed_config->mounts, mount_mappings) ||
+        !myst_validate_mount_config(&parsed_config->mounts))
+        ERAISE(-EINVAL);
+
+    ret = 0;
+
+done:
+    return ret;
+}

--- a/tools/myst/shared.h
+++ b/tools/myst/shared.h
@@ -8,11 +8,23 @@
 #include <myst/kernel.h>
 #include <myst/options.h>
 #include <myst/regions.h>
+#include "config.h"
 
 int myst_expand_size_string_to_ulong(const char* size_string, size_t* size);
 bool myst_merge_mount_mapping_and_config(
     myst_mounts_config_t* mounts,
     myst_args_t* mount_mapping);
 bool myst_validate_mount_config(myst_mounts_config_t* mounts);
+
+long determine_final_options(
+    struct myst_options* cmdline_opts,
+    struct myst_final_options* final_opts,
+    const myst_args_t* args,
+    const myst_args_t* env,
+    config_parsed_data_t* parsed_config,
+    bool have_config,
+    bool tee_debug_mode,
+    const char* target_env_var,
+    myst_args_t* mount_mappings);
 
 #endif /* _MYST_MYST_SHARED_H */


### PR DESCRIPTION
Command line is not allowed to override config.
Even items not specified in config will use the config defaults.
Allowing config from command line to override the config breaks the
attestation promise