### PR TITLE
Ignore self-loops when resolving symlinks.

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -1334,15 +1334,20 @@ static int _path_to_ino_recursive(
                     }
                 }
 
-                ECHECK(_path_to_ino_recursive(
-                    ext2,
-                    locals->target,
-                    current_ino,
-                    FOLLOW,
-                    &current_ino,
-                    &locals->ino,
-                    realpath,
-                    target_out));
+                // Ignore self-loops.
+                if (strcmp(path, locals->target) != 0)
+                {
+                    // Recursively resolve links.
+                    ECHECK(_path_to_ino_recursive(
+                        ext2,
+                        locals->target,
+                        current_ino,
+                        FOLLOW,
+                        &current_ino,
+                        &locals->ino,
+                        realpath,
+                        target_out));
+                }
 
                 free(data);
                 data = NULL;

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -590,15 +590,20 @@ static int _path_to_inode_recursive(
                     }
                 }
 
-                ECHECK(_path_to_inode_recursive(
-                    ramfs,
-                    target,
-                    parent,
-                    true,
-                    &parent,
-                    &p,
-                    realpath,
-                    target_out));
+                // Ignore self-loops.
+                if (strcmp(path, target) != 0)
+                {
+                    // Recursively resolve links.
+                    ECHECK(_path_to_inode_recursive(
+                        ramfs,
+                        target,
+                        parent,
+                        true,
+                        &parent,
+                        &p,
+                        realpath,
+                        target_out));
+                }
 
                 assert(target != NULL);
             }


### PR DESCRIPTION
This prevents infinite recursion.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>