### PR TITLE
Suppress oesign() "Created..." output

### DIFF
--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -528,6 +528,9 @@ int _package(int argc, const char* argv[])
         goto done;
     }
 
+    /* Tell the console user that the packaged program has been created */
+    printf("Created %s\n\n", scratch_path);
+
     ret = 0;
 
 done:

--- a/tools/myst/host/sign.c
+++ b/tools/myst/host/sign.c
@@ -459,6 +459,11 @@ int _sign(int argc, const char* argv[])
         _err("File path to long: %s/lib/openenclave/mystenc.so", sign_dir);
     }
 
+    // Temporarily redirect standard output to /dev/null during the call to
+    // oesign(). This suppresses the "Created <tempfile>" message, which
+    // conveys nothing useful to the user.
+    freopen("/dev/null", "a+", stdout);
+
     if (oesign(
             scratch_path,
             temp_oeconfig_file,
@@ -472,6 +477,9 @@ int _sign(int argc, const char* argv[])
         unlink(temp_oeconfig_file);
         _err("Failed to sign \"%s\"", scratch_path);
     }
+
+    /* restore standard output */
+    freopen("/dev/tty", "w", stdout);
 
     // delete temporary oe config file
     if (unlink(temp_oeconfig_file) != 0)


### PR DESCRIPTION
Consider the following command.

```
$ myst package-sgx appdir private.pem config.json
Created /tmp/mystKA0Ggj/lib/openenclave/mystenc.so.signed
```

The "Created..." message is printed by the ``oesign()`` function and conveys no useful information to the user (it is a temporary file that is subsequently removed).

This PR suppresses this output and instead prints out the name of the created file as shown below.

```
$ myst package-sgx appdir private.pem config.json
Created appdir/bin/hello
```

Also added ``--outfile=<file>`` option.