### PR TITLE
Fix myst_cond_timedwait() recursion bug

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -77,51 +77,10 @@ typedef struct myst_mutex_thread_sig_handler
 
 } myst_mutex_thread_sig_handler_t;
 
-/* Our default handler just needs to remove itself from the queue and call the
- * next in line */
-static void myst_mutex_sig_handler(
-    MYST_UNUSED unsigned signum,
-    void* _sig_handler)
-{
-    myst_mutex_thread_sig_handler_t* sig_handler =
-        (myst_mutex_thread_sig_handler_t*)_sig_handler;
-    myst_thread_t* thread = myst_thread_self();
-
-    myst_spin_lock(&sig_handler->mutex->lock);
-
-    myst_thread_queue_remove_thread(&sig_handler->mutex->queue, thread);
-
-    thread->signal.waiting_on_event = false;
-
-    if (sig_handler->mutex->queue.front != NULL)
-        myst_tcall_wake(sig_handler->mutex->queue.front->event);
-
-    myst_spin_unlock(&sig_handler->mutex->lock);
-}
-
-static void myst_mutex_sig_handler_install(
-    myst_mutex_thread_sig_handler_t* sig_handler,
-    myst_mutex_t* mutex)
-{
-    memset(sig_handler, 0, sizeof(*sig_handler));
-
-    sig_handler->mutex = mutex;
-
-    myst_thread_sig_handler_install(
-        &sig_handler->sig_handler, myst_mutex_sig_handler, sig_handler);
-}
-
-static void myst_mutex_sig_handler_uninstall(
-    myst_mutex_thread_sig_handler_t* sig_handler)
-{
-    myst_thread_sig_handler_uninstall(&sig_handler->sig_handler);
-}
-
-int myst_mutex_lock(myst_mutex_t* mutex)
+static int _mutex_lock(myst_mutex_t* mutex)
 {
     myst_mutex_t* m = (myst_mutex_t*)mutex;
     myst_thread_t* self = myst_thread_self();
-    myst_mutex_thread_sig_handler_t sig_handler;
 
     if (!m)
         return -EINVAL;
@@ -146,6 +105,14 @@ int myst_mutex_lock(myst_mutex_t* mutex)
                 /* Insert thread at back of waiters queue */
                 myst_thread_queue_push_back(&m->queue, self);
             }
+
+            /* check whether any signals were raised on this thread */
+            if (myst_signal_has_active_signals(self))
+            {
+                myst_thread_queue_remove_thread(&m->queue, self);
+                myst_spin_unlock(&m->lock);
+                return -EINTR;
+            }
         }
         myst_spin_unlock(&m->lock);
 
@@ -154,11 +121,6 @@ int myst_mutex_lock(myst_mutex_t* mutex)
         if ((r = myst_tcall_wait(self->event, NULL)) != 0)
             myst_panic("myst_tcall_wait(): %ld: %d", r, *(int*)self->event);
         self->signal.waiting_on_event = false;
-
-        // Handle any signals
-        myst_mutex_sig_handler_install(&sig_handler, m);
-        myst_signal_process(self);
-        myst_mutex_sig_handler_uninstall(&sig_handler);
     }
 
     /* Unreachable! */
@@ -273,4 +235,19 @@ myst_thread_t* myst_mutex_owner(myst_mutex_t* m)
     myst_spin_unlock(&m->lock);
 
     return owner;
+}
+
+int myst_mutex_lock(myst_mutex_t* mutex)
+{
+    int ret;
+    myst_thread_t* self = myst_thread_self();
+
+    /* repeat as long as there is an -EINTR error */
+    while ((ret = _mutex_lock(mutex)) == -EINTR)
+    {
+        /* check for signals */
+        myst_signal_process(self);
+    }
+
+    return ret;
 }


### PR DESCRIPTION
Paul and I found that ``myst_cond_timedwait()`` can be entered twice by the same thread under the following scenario.
- The app calls ``futex()`` which enters ``myst_cond_timedwait()`` the first time.
- The ``myst_cond_timedwait()`` function discovers and dispatches a signal.
- The signal is dispatched to the app.
- The app calls ``futex()`` which enters ``myst_cond_timedwait()`` the second time.

Paul suggested calling ``myst_signal_has_active_signals()`` within ``myst_cond_timedwait()`` and ``myst_mutex_lock()``. This function returns true if there are signals on the given thread. We then take the return path and dispatch signals after we have reached a safe state. This patch renames the mutex and cond functions and makes them static and then defines new functions with the original names that dispatch the signals.