### PR TITLE
Add support for futex bitset and realtime clock

### DIFF
--- a/include/myst/cond.h
+++ b/include/myst/cond.h
@@ -26,14 +26,15 @@ int myst_cond_wait(myst_cond_t* c, myst_mutex_t* mutex);
 int myst_cond_timedwait(
     myst_cond_t* c,
     myst_mutex_t* mutex,
-    const struct timespec* timeout);
+    const struct timespec* timeout,
+    uint32_t bitset);
 
-int myst_cond_signal(myst_cond_t* c);
+int myst_cond_signal(myst_cond_t* c, uint32_t bitset);
 
 int myst_cond_signal_thread(myst_cond_t* c, myst_thread_t* thread);
 
 /* Wake up n waiters */
-int myst_cond_broadcast(myst_cond_t* c, size_t n);
+int myst_cond_broadcast(myst_cond_t* c, size_t n, uint32_t bitset);
 
 int myst_cond_requeue(
     myst_cond_t* c1,

--- a/include/myst/futex.h
+++ b/include/myst/futex.h
@@ -18,12 +18,18 @@
 #define FUTEX_UNLOCK_PI      7
 #define FUTEX_TRYLOCK_PI     8
 #define FUTEX_WAIT_BITSET    9
+#define FUTEX_WAKE_BITSET    10
 #define FUTEX_PRIVATE        128
 #define FUTEX_CLOCK_REALTIME 256
+#define FUTEX_BITSET_MATCH_ANY 0xffffffff
 // clang-format on
 
-int myst_futex_wait(int* uaddr, int val, const struct timespec* to);
+int myst_futex_wait(
+    int* uaddr,
+    int val,
+    const struct timespec* to,
+    uint32_t bitset);
 
-int myst_futex_wake(int* uaddr, int val);
+int myst_futex_wake(int* uaddr, int val, uint32_t bitset);
 
 #endif /* _MYST_FUTEX_H */

--- a/kernel/itimer.c
+++ b/kernel/itimer.c
@@ -97,7 +97,8 @@ long myst_syscall_run_itimer(void)
             }
 
             uint64_t start = _get_current_time();
-            int r = myst_cond_timedwait(&_it.cond, &_it.mutex, to);
+            int r = myst_cond_timedwait(
+                &_it.cond, &_it.mutex, to, FUTEX_BITSET_MATCH_ANY);
             uint64_t end = _get_current_time();
 
             assert(start != 0);
@@ -156,7 +157,7 @@ long myst_syscall_setitimer(
         _it.real_value = value;
 
         /* signal the itimer thread */
-        if (myst_cond_signal(&_it.cond) != 0)
+        if (myst_cond_signal(&_it.cond, FUTEX_BITSET_MATCH_ANY) != 0)
         {
             myst_mutex_unlock(&_it.mutex);
             ERAISE(-ENOSYS);

--- a/kernel/pipedev.c
+++ b/kernel/pipedev.c
@@ -297,7 +297,7 @@ static ssize_t _pd_read(
                 }
 
                 /* signal that pipe is now write enabled */
-                myst_cond_signal(&shared->cond);
+                myst_cond_signal(&shared->cond, FUTEX_BITSET_MATCH_ANY);
             }
             else /* the buffer is empty */
             {
@@ -439,7 +439,7 @@ static ssize_t _pd_write(
                 }
 
                 /* signal that pipe is now read enabled */
-                myst_cond_signal(&shared->cond);
+                myst_cond_signal(&shared->cond, FUTEX_BITSET_MATCH_ANY);
             }
             else /* the buffer is full */
             {
@@ -666,7 +666,7 @@ static int _pd_interrupt(myst_pipedev_t* pipedev, myst_pipe_t* pipe)
     T(printf("_pd_interrupt(): fd=%d pid=%d\n", pipe->fd, myst_getpid());)
 
     /* signal any threads blocked on read or write */
-    myst_cond_signal(&pipe->shared->cond);
+    myst_cond_signal(&pipe->shared->cond, FUTEX_BITSET_MATCH_ANY);
 
 done:
     T(printf("_pd_interrupt(): done\n");)
@@ -705,7 +705,7 @@ static int _pd_close(myst_pipedev_t* pipedev, myst_pipe_t* pipe)
     else
     {
         /* signal that this end of the pipe has been closed */
-        myst_cond_signal(&pipe->shared->cond);
+        myst_cond_signal(&pipe->shared->cond, FUTEX_BITSET_MATCH_ANY);
         _unlock(&pipe->shared->lock, &locked);
     }
 

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -569,7 +569,7 @@ long myst_signal_deliver(
 
     if (!__sync_val_compare_and_swap(&thread->pause_futex, 0, 1))
     {
-        ret = myst_futex_wake(&thread->pause_futex, 1);
+        ret = myst_futex_wake(&thread->pause_futex, 1, FUTEX_BITSET_MATCH_ANY);
         // Expect ret == 1, otherwise, return error
         if (ret == 1)
             ret = 0;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -4049,7 +4049,8 @@ static long _syscall(void* args_)
         {
             int ret = 0;
             _strace(n, NULL);
-            myst_futex_wait(&thread->fork_exec_futex_wait, 0, NULL);
+            myst_futex_wait(
+                &thread->fork_exec_futex_wait, 0, NULL, FUTEX_BITSET_MATCH_ANY);
             BREAK(_return(n, ret));
         }
         case SYS_myst_kill_wait_child_forks:
@@ -4979,12 +4980,16 @@ static long _syscall(void* args_)
 
             _strace(
                 n,
-                "uaddr=0x%lx(%d) futex_op=%u(%s) val=%d",
+                "uaddr=0x%lx(%d) futex_op=%u(%s) val=%d arg=%li "
+                "uaddr2=0x%lx val3=%d",
                 (long)uaddr,
                 (uaddr ? *uaddr : -1),
                 futex_op,
                 _futex_op_str(futex_op),
-                val);
+                val,
+                arg,
+                (long)uaddr2,
+                val3);
 
             BREAK(_return(
                 n,
@@ -6557,7 +6562,8 @@ long myst_syscall_pause(void)
         }
 
         // Futex is not available, wait.
-        ret = myst_futex_wait(&thread->pause_futex, 0, NULL);
+        ret = myst_futex_wait(
+            &thread->pause_futex, 0, NULL, FUTEX_BITSET_MATCH_ANY);
         if (ret != 0 && ret != -EAGAIN)
             ERAISE(ret);
     }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -774,7 +774,10 @@ void myst_fork_exec_futex_wake(myst_process_t* process)
         {
             __sync_val_compare_and_swap(
                 &waiter_thread->fork_exec_futex_wait, 0, 1);
-            myst_futex_wake(&waiter_thread->fork_exec_futex_wait, 1);
+            myst_futex_wake(
+                &waiter_thread->fork_exec_futex_wait,
+                1,
+                FUTEX_BITSET_MATCH_ANY);
         }
 
         myst_spin_unlock(&waiter_process->thread_group_lock);

--- a/tests/futex/Makefile
+++ b/tests/futex/Makefile
@@ -24,19 +24,24 @@ ifdef ETRACE
 OPTS += --etrace
 endif
 
+OPTS += --user-mem-size=16m
+
 tests: all
 	$(MAKE) test1
 	$(MAKE) test2
 
 test1:
 	gcc -Wall -o futex futex.c -lpthread
-	$(RUNTEST) ./futex
+	$(RUNTEST) ./futex $(COUNT)
 
 test2:
-	$(RUNTEST) $(MYST_EXEC) rootfs /bin/futex $(OPTS)
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/futex $(OPTS) $(COUNT)
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst
 
 clean:
-	rm -rf $(APPDIR) rootfs export ramfs
+	rm -rf $(APPDIR) rootfs export ramfs futex
+
+stress:
+	$(MAKE) COUNT=100 test2

--- a/tests/futex/futex.c
+++ b/tests/futex/futex.c
@@ -6,6 +6,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/time.h>
 #include <syscall.h>
 #include <time.h>
@@ -14,6 +15,10 @@
 
 #define FUTEX_WAIT 0
 #define FUTEX_WAKE 1
+#define FUTEX_WAIT_BITSET 9
+#define FUTEX_WAKE_BITSET 10
+#define FUTEX_CLOCK_REALTIME 256
+#define FUTEX_BITSET_MATCH_ANY 0xffffffff
 
 /* get the timestamp in nanoseconds */
 uint64_t timestamp_nsec(void)
@@ -25,23 +30,25 @@ uint64_t timestamp_nsec(void)
 
 void test_double_wait(void)
 {
-    const uint64_t nsec = 1000000000;
-    const uint64_t timeout = nsec / 10;
-    const uint64_t slop = 5000000;
+    static uint64_t nanos = 1000000000; /* nanos in one second */
+    const uint64_t timeout = nanos;     /* timeout in nanoseconds */
+    const uint64_t slop = timeout / 4;  /* 25% tolerance */
     const uint64_t lo = timeout - slop;
     const uint64_t hi = timeout + slop;
     uint64_t delta;
-    struct timespec tp = {.tv_sec = 0, timeout};
+    struct timespec tp = {.tv_sec = timeout / nanos, timeout % nanos};
     int futex_word = 0;
+
+    printf("=== start test (%s)\n", __FUNCTION__);
 
     const uint64_t t0 = timestamp_nsec();
     syscall(SYS_futex, &futex_word, FUTEX_WAIT, futex_word, &tp, NULL, 0);
 
     const uint64_t t1 = timestamp_nsec();
     delta = t1 - t0;
-    assert(delta >= lo && delta <= hi);
 
     printf("delta=%zu lo=%zu hi=%zu tenth=%zu\n", delta, lo, hi, timeout);
+    assert(delta >= lo && delta <= hi);
 
     const uint64_t t3 = timestamp_nsec();
 
@@ -60,7 +67,14 @@ static int _uaddr = 0;
 
 static void* _wait_thread(void* arg)
 {
-    long r = syscall(SYS_futex, &_uaddr, FUTEX_WAIT, 1, NULL, NULL, 0);
+    long r = syscall(SYS_futex, &_uaddr, FUTEX_WAIT, 1, NULL, NULL, 1);
+    assert(r == 0);
+    return NULL;
+}
+
+static void* _wait_thread_bitset(void* arg)
+{
+    long r = syscall(SYS_futex, &_uaddr, FUTEX_WAIT_BITSET, 1, NULL, NULL, 1);
     assert(r == 0);
     return NULL;
 }
@@ -68,6 +82,8 @@ static void* _wait_thread(void* arg)
 static void test_wait_and_wake(void)
 {
     pthread_t t1;
+
+    printf("=== start test (%s)\n", __FUNCTION__);
 
     _uaddr = 1;
     assert(pthread_create(&t1, NULL, _wait_thread, NULL) == 0);
@@ -79,6 +95,8 @@ static void test_wait_and_wake(void)
     long r = syscall(SYS_futex, &_uaddr, FUTEX_WAKE, INT_MAX, NULL, NULL, 0);
     assert(r == 1);
     assert(pthread_join(t1, NULL) == 0);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
 }
 
 static void test_wait_and_wake_n(void)
@@ -87,24 +105,154 @@ static void test_wait_and_wake_n(void)
     pthread_t t[nthreads];
     _uaddr = 1;
 
+    printf("=== start test (%s)\n", __FUNCTION__);
+
     for (size_t i = 0; i < nthreads; i++)
         assert(pthread_create(&t[i], NULL, _wait_thread, NULL) == 0);
 
-    /* wait until thread is asleep */
-    sleep_msec(50);
+    /* wait until all threads are asleep */
+    sleep_msec(1000);
 
     long r = syscall(SYS_futex, &_uaddr, FUTEX_WAKE, INT_MAX, NULL, NULL, 0);
+    assert(r == nthreads);
+
+    for (size_t i = 0; i < nthreads; i++)
+        assert(pthread_join(t[i], NULL) == 0);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_wait_realtime(void)
+{
+    static uint64_t nanos = 1000000000; /* nanos in one second */
+    const uint64_t timeout = nanos;     /* timeout in nanoseconds */
+    const uint64_t slop = timeout / 4;  /* 25% tolerance */
+    const uint64_t lo = timeout - slop;
+    const uint64_t hi = timeout + slop;
+    uint64_t delta;
+    struct timespec tp;
+    int futex_word = 0;
+
+    printf("=== start test (%s)\n", __FUNCTION__);
+
+    const uint64_t now = timestamp_nsec();
+    const uint64_t then = (now + timeout);
+    tp.tv_sec = then / nanos;
+    tp.tv_nsec = then % nanos;
+
+#if 0
+    struct timespec timenow;
+    clock_gettime(CLOCK_REALTIME, &timenow);
+    tp.tv_sec = timenow.tv_sec;
+    tp.tv_nsec = timenow.tv_nsec + timeout;
+#else
+#endif
+
+    const uint64_t t0 = timestamp_nsec();
+    syscall(
+        SYS_futex,
+        &futex_word,
+        FUTEX_WAIT_BITSET | FUTEX_CLOCK_REALTIME,
+        futex_word,
+        &tp,
+        NULL,
+        1);
+
+    const uint64_t t1 = timestamp_nsec();
+    delta = t1 - t0;
+    assert(delta >= lo && delta <= hi);
+
+    printf("delta=%zu lo=%zu hi=%zu tenth=%zu\n", delta, lo, hi, timeout);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+static void test_wait_and_wake_bitset(void)
+{
+    pthread_t t1;
+
+    printf("=== start test (%s)\n", __FUNCTION__);
+
+    _uaddr = 1;
+    assert(pthread_create(&t1, NULL, _wait_thread_bitset, NULL) == 0);
+
+    /* wait until thread is asleep */
+    sleep_msec(100);
+
+    _uaddr = 0;
+
+    /* wait should fail as 1 & 2 == 0 */
+    long r =
+        syscall(SYS_futex, &_uaddr, FUTEX_WAKE_BITSET, INT_MAX, NULL, NULL, 2);
+    assert(r == 0);
+
+    /* wait should pass as 1 & 1 == 1 */
+    r = syscall(SYS_futex, &_uaddr, FUTEX_WAKE_BITSET, INT_MAX, NULL, NULL, 1);
+    assert(r == 1);
+
+    assert(pthread_join(t1, NULL) == 0);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+static void test_wait_and_wake_n_bitset(void)
+{
+    static const size_t nthreads = 16;
+    pthread_t t[nthreads];
+    _uaddr = 1;
+
+    printf("=== start test (%s)\n", __FUNCTION__);
+
+    for (size_t i = 0; i < nthreads; i++)
+        assert(pthread_create(&t[i], NULL, _wait_thread_bitset, NULL) == 0);
+
+    /* wait until thread is asleep */
+    sleep_msec(1000);
+
+    long r =
+        syscall(SYS_futex, &_uaddr, FUTEX_WAKE_BITSET, INT_MAX, NULL, NULL, 1);
     assert(r == 16);
 
     for (size_t i = 0; i < nthreads; i++)
         assert(pthread_join(t[i], NULL) == 0);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
 }
 
 int main(int argc, const char* argv[])
 {
-    test_double_wait();
-    test_wait_and_wake();
-    test_wait_and_wake_n();
+    unsigned long count = 1;
+
+    /* check command-line arguments */
+    if (argc != 1 && argc != 2)
+    {
+        fprintf(stderr, "Usage: %s <count>\n", argv[0]);
+        exit(1);
+    }
+
+    /* get the count argument if any */
+    if (argc == 2)
+    {
+        char* end = NULL;
+        count = strtoul(argv[1], &end, 10);
+
+        if (!end || *end || count == 0)
+        {
+            fprintf(stderr, "%s: bad count argument: %s\n", argv[0], argv[1]);
+            exit(1);
+        }
+    }
+
+    /* run the tests 1 or more times */
+    for (size_t i = 0; i < count; i++)
+    {
+        test_double_wait();
+        test_wait_and_wake();
+        test_wait_and_wake_n();
+        test_wait_realtime();
+        test_wait_and_wake_bitset();
+        test_wait_and_wake_n_bitset();
+    }
 
     printf("=== passed test (%s)\n", argv[0]);
 

--- a/tests/thread_queue/Makefile
+++ b/tests/thread_queue/Makefile
@@ -1,0 +1,24 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+PROGRAM = thread_queue
+
+SOURCES = $(wildcard *.c)
+
+INCLUDES = -I$(INCDIR)
+
+CFLAGS = $(OEHOST_CFLAGS)
+ifdef MYST_ENABLE_GCOV
+CFLAGS += $(GCOV_CFLAGS)
+endif
+
+LDFLAGS = $(OEHOST_LDFLAGS)
+
+LIBS = $(LIBDIR)/libmysthost.a
+
+REDEFINE_TESTS=1
+
+include $(TOP)/rules.mak
+
+tests:
+	$(RUNTEST) $(SUBBINDIR)/thread_queue

--- a/tests/thread_queue/thread_queue.c
+++ b/tests/thread_queue/thread_queue.c
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include <myst/thread.h>
+
+void test_myst_thread_queue_push_and_pop_bitset(void)
+{
+    int n = 5;
+    myst_thread_t thread[n];
+    myst_thread_queue_t tq = {NULL, NULL};
+
+    for (int i = 0; i < n; i++)
+    {
+        myst_thread_queue_push_back_bitset(&tq, &(thread[i]), i + 1);
+    }
+
+    uint32_t bitset;
+
+    for (int i = 0; i < n; i++)
+    {
+        myst_thread_t* cur_t = myst_thread_queue_pop_front_bitset(&tq, &bitset);
+        assert(cur_t == &(thread[i]));
+        assert(bitset == i + 1);
+    }
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_queue_push_and_pop(void)
+{
+    int n = 5;
+    myst_thread_t thread[n];
+    myst_thread_queue_t tq = {NULL, NULL};
+
+    for (int i = 0; i < n; i++)
+    {
+        myst_thread_queue_push_back(&tq, &(thread[i]));
+    }
+
+    for (int i = 0; i < n; i++)
+    {
+        myst_thread_t* cur_t = myst_thread_queue_pop_front(&tq);
+        assert(cur_t == &(thread[i]));
+    }
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_queue_empty(void)
+{
+    myst_thread_t thread1;
+    myst_thread_t thread2;
+    myst_thread_t thread3;
+    myst_thread_queue_t tq = {NULL, NULL};
+
+    assert(myst_thread_queue_empty(&tq));
+    myst_thread_queue_push_back(&tq, &thread1);
+    assert(!myst_thread_queue_empty(&tq));
+    myst_thread_queue_push_back(&tq, &thread2);
+    assert(!myst_thread_queue_empty(&tq));
+    myst_thread_queue_push_back(&tq, &thread3);
+    assert(!myst_thread_queue_empty(&tq));
+    myst_thread_queue_pop_front(&tq);
+    assert(!myst_thread_queue_empty(&tq));
+    myst_thread_queue_pop_front(&tq);
+    assert(!myst_thread_queue_empty(&tq));
+    myst_thread_queue_pop_front(&tq);
+    assert(myst_thread_queue_empty(&tq));
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_queue_size(void)
+{
+    myst_thread_t thread1;
+    myst_thread_t thread2;
+    myst_thread_t thread3;
+    myst_thread_queue_t tq = {NULL, NULL};
+
+    assert(myst_thread_queue_size(&tq) == 0);
+    myst_thread_queue_push_back(&tq, &thread1);
+    assert(myst_thread_queue_size(&tq) == 1);
+    myst_thread_queue_push_back(&tq, &thread2);
+    assert(myst_thread_queue_size(&tq) == 2);
+    myst_thread_queue_push_back(&tq, &thread3);
+    assert(myst_thread_queue_size(&tq) == 3);
+    myst_thread_queue_pop_front(&tq);
+    assert(myst_thread_queue_size(&tq) == 2);
+    myst_thread_queue_pop_front(&tq);
+    assert(myst_thread_queue_size(&tq) == 1);
+    myst_thread_queue_pop_front(&tq);
+    assert(myst_thread_queue_size(&tq) == 0);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_queue_search_remove_bitset_remove_all(void)
+{
+    int n = 5;
+    myst_thread_t thread[n];
+    myst_thread_queue_t tq = {NULL, NULL};
+
+    for (int i = 0; i < n; i++)
+    {
+        myst_thread_queue_push_back_bitset(&tq, &(thread[i]), 1);
+    }
+
+    myst_thread_queue_t waiters = {NULL, NULL};
+    long int ret = myst_thread_queue_search_remove_bitset(&tq, &waiters, n, 1);
+    assert(ret == n);
+    assert(myst_thread_queue_empty(&tq));
+
+    uint32_t bitset = 0;
+    ;
+    for (int i = 0; i < n; i++)
+    {
+        myst_thread_t* cur_t =
+            myst_thread_queue_pop_front_bitset(&waiters, &bitset);
+        assert(cur_t == &(thread[i]));
+        assert(bitset == 1);
+        bitset = 0;
+    }
+    assert(myst_thread_queue_empty(&waiters));
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_queue_search_remove_bitset_remove_some(void)
+{
+    int n = 5;
+    int n_remove = 3; // less than n
+    myst_thread_t thread[n];
+    myst_thread_queue_t tq = {NULL, NULL};
+
+    for (int i = 0; i < n; i++)
+    {
+        myst_thread_queue_push_back_bitset(&tq, &(thread[i]), 1);
+    }
+
+    myst_thread_queue_t waiters = {NULL, NULL};
+    long int ret =
+        myst_thread_queue_search_remove_bitset(&tq, &waiters, n_remove, 1);
+    assert(ret == n_remove);
+    assert(myst_thread_queue_size(&tq) == n - n_remove);
+    assert(myst_thread_queue_size(&waiters) == n_remove);
+
+    uint32_t bitset = 0;
+    for (int i = 0; i < n_remove; i++)
+    {
+        assert(myst_thread_queue_pop_front_bitset(&waiters, &bitset));
+        assert(bitset == 1);
+        bitset = 0;
+    }
+    assert(myst_thread_queue_empty(&waiters));
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_queue_search_remove_bitset_remove_none(void)
+{
+    int n = 5;
+    myst_thread_t thread[n];
+    myst_thread_queue_t tq = {NULL, NULL};
+
+    for (int i = 0; i < n; i++)
+    {
+        myst_thread_queue_push_back_bitset(&tq, &(thread[i]), 1);
+    }
+
+    myst_thread_queue_t waiters = {NULL, NULL};
+    long int ret = myst_thread_queue_search_remove_bitset(&tq, &waiters, n, 2);
+    assert(ret == 0);
+    assert(myst_thread_queue_empty(&waiters));
+    assert(myst_thread_queue_size(&tq) == n);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_queue_search_remove_bitset_some_match(void)
+{
+    int n = 6;
+    myst_thread_t thread[n];
+    myst_thread_queue_t tq = {NULL, NULL};
+
+    int num_odd = 0;
+
+    for (int i = 0; i < n; i++)
+    {
+        uint32_t bitset = (i % 2) + 1; // 2 if odd, 1 if even
+        num_odd += i % 2;
+        myst_thread_queue_push_back_bitset(&tq, &(thread[i]), bitset);
+    }
+
+    myst_thread_queue_t waiters = {NULL, NULL};
+    long int ret = myst_thread_queue_search_remove_bitset(&tq, &waiters, n, 2);
+    assert(ret == num_odd);
+    assert(myst_thread_queue_size(&tq) == n - num_odd);
+    assert(myst_thread_queue_size(&waiters) == num_odd);
+
+    uint32_t bitset = 0;
+    for (int i = 0; i < num_odd; i++)
+    {
+        assert(myst_thread_queue_pop_front_bitset(&waiters, &bitset));
+        assert(bitset == 2);
+        bitset = 0;
+    }
+    assert(myst_thread_queue_empty(&waiters));
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_remove_single(void)
+{
+    myst_thread_queue_t tq = {NULL, NULL};
+    myst_thread_t thread;
+    myst_thread_queue_push_back(&tq, &thread);
+    assert(myst_thread_queue_remove_thread(&tq, &thread) == 0);
+    assert(myst_thread_queue_empty(&tq));
+    assert(myst_thread_queue_remove_thread(&tq, &thread) == -1);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_remove_front(void)
+{
+    myst_thread_queue_t tq = {NULL, NULL};
+    myst_thread_t thread1;
+    myst_thread_t thread2;
+    myst_thread_queue_push_back(&tq, &thread1);
+    myst_thread_queue_push_back(&tq, &thread2);
+    assert(myst_thread_queue_remove_thread(&tq, &thread1) == 0);
+    assert(!myst_thread_queue_empty(&tq));
+    assert(myst_thread_queue_remove_thread(&tq, &thread2) == 0);
+    assert(myst_thread_queue_empty(&tq));
+    assert(myst_thread_queue_remove_thread(&tq, &thread1) == -1);
+    assert(myst_thread_queue_remove_thread(&tq, &thread2) == -1);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_myst_thread_remove_back(void)
+{
+    myst_thread_queue_t tq = {NULL, NULL};
+    myst_thread_t thread1;
+    myst_thread_t thread2;
+    myst_thread_queue_push_back(&tq, &thread1);
+    myst_thread_queue_push_back(&tq, &thread2);
+    assert(myst_thread_queue_remove_thread(&tq, &thread2) == 1);
+    assert(!myst_thread_queue_empty(&tq));
+    assert(myst_thread_queue_remove_thread(&tq, &thread1) == 0);
+    assert(myst_thread_queue_empty(&tq));
+    assert(myst_thread_queue_remove_thread(&tq, &thread1) == -1);
+    assert(myst_thread_queue_remove_thread(&tq, &thread2) == -1);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+int main(int argc, const char* argv[])
+{
+    test_myst_thread_queue_push_and_pop_bitset();
+    test_myst_thread_queue_push_and_pop();
+    test_myst_thread_queue_size();
+    test_myst_thread_queue_empty();
+    test_myst_thread_queue_search_remove_bitset_remove_all();
+    test_myst_thread_queue_search_remove_bitset_remove_none();
+    test_myst_thread_queue_search_remove_bitset_remove_some();
+    test_myst_thread_queue_search_remove_bitset_some_match();
+    test_myst_thread_remove_single();
+    test_myst_thread_remove_front();
+    test_myst_thread_remove_back();
+    return 0;
+}


### PR DESCRIPTION
Futex syscall now supports `FUTEX_CLOCK_REALTIME` and `FUTEX_{WAKE,WAIT}_BITSET`.

Real time clock
This is implemented by converting the timeout parameter into a relative timeout.

Bitset support
Most of the change is in `cond.c`. See [futex manpage](https://man7.org/linux/man-pages/man2/futex.2.html) for expected functionality. 

**Testing**:
Added test cases for wait/wake with bitset in `test\futex`.
Added test case for realtime clock in `test\futex`.
Added new test file in `test\thread_queue`