### PR TITLE
Update glibC tests to disable tests that are failing due to missing f…

### DIFF
--- a/tests/glibc/tests.failed
+++ b/tests/glibc/tests.failed
@@ -1680,10 +1680,12 @@
 /glibc/build/nptl/tst-cancelx6
 /glibc/build/nptl/tst-cancelx7
 /glibc/build/nptl/tst-cancelx9
+/glibc/build/nptl/tst-cleanup0
 /glibc/build/nptl/tst-cleanup1
 /glibc/build/nptl/tst-cleanup2
 /glibc/build/nptl/tst-cleanup3
 /glibc/build/nptl/tst-cleanup4
+/glibc/build/nptl/tst-cleanupx0
 /glibc/build/nptl/tst-cleanupx1
 /glibc/build/nptl/tst-cleanupx2
 /glibc/build/nptl/tst-cleanupx3
@@ -1920,6 +1922,7 @@
 /glibc/build/posix/tst-glob_lstat_compat
 /glibc/build/posix/tst-gnuglob
 /glibc/build/posix/tst-gnuglob64
+/glibc/build/posix/tst-nanosleep
 /glibc/build/posix/tst-nice
 /glibc/build/posix/tst-pathconf
 /glibc/build/posix/tst-pcre
@@ -2028,6 +2031,7 @@
 /glibc/build/stdio-common/tstscanf
 /glibc/build/stdlib/test-a64l
 /glibc/build/stdlib/test-at_quick_exit-race
+/glibc/build/stdlib/tst-atexit
 /glibc/build/stdlib/test-atexit-race
 /glibc/build/stdlib/test-bz22786
 /glibc/build/stdlib/test-canon
@@ -2038,6 +2042,7 @@
 /glibc/build/stdlib/tst-at_quick_exit
 /glibc/build/stdlib/tst-bz20544
 /glibc/build/stdlib/tst-canon-bz26341
+/glibc/build/stdlib/tst-cxa_atexit
 /glibc/build/stdlib/tst-environ
 /glibc/build/stdlib/tst-fmtmsg
 /glibc/build/stdlib/tst-makecontext-align

--- a/tests/glibc/tests.passed
+++ b/tests/glibc/tests.passed
@@ -342,8 +342,6 @@
 /glibc/build/nptl/tst-cancelx15
 /glibc/build/nptl/tst-cancelx2
 /glibc/build/nptl/tst-cancelx3
-/glibc/build/nptl/tst-cleanup0
-/glibc/build/nptl/tst-cleanupx0
 /glibc/build/nptl/tst-clock1
 /glibc/build/nptl/tst-cnd-basic
 /glibc/build/nptl/tst-cnd-broadcast
@@ -451,13 +449,11 @@
 /glibc/build/posix/tst-glob_symlinks
 /glibc/build/posix/tst-mmap
 /glibc/build/posix/tst-mmap-offset
-/glibc/build/posix/tst-nanosleep
 /glibc/build/posix/tst-preadwrite
 /glibc/build/posix/tst-preadwrite64
 /glibc/build/posix/tst-vfork1
 /glibc/build/rt/tst-aio2
 /glibc/build/rt/tst-aio3
-/glibc/build/rt/tst-aio5
 /glibc/build/rt/tst-aio8
 /glibc/build/setjmp/test-as-const-jmp_buf-ssp
 /glibc/build/setjmp/tst-saved_mask-1
@@ -505,11 +501,9 @@
 /glibc/build/stdlib/testmb
 /glibc/build/stdlib/testmb2
 /glibc/build/stdlib/testrand
-/glibc/build/stdlib/tst-atexit
 /glibc/build/stdlib/tst-atof1
 /glibc/build/stdlib/tst-atof2
 /glibc/build/stdlib/tst-bsearch
-/glibc/build/stdlib/tst-cxa_atexit
 /glibc/build/stdlib/tst-limits
 /glibc/build/stdlib/tst-makecontext
 /glibc/build/stdlib/tst-putenv

--- a/tests/glibc/tests.remove
+++ b/tests/glibc/tests.remove
@@ -22,6 +22,7 @@
 /glibc/build/nptl/tst-tsd5
 /glibc/build/posix/wordexp-test
 /glibc/build/rt/tst-aio
+/glibc/build/rt/tst-aio5
 /glibc/build/rt/tst-aio64
 /glibc/build/rt/tst-aio7
 /glibc/build/stdlib/tst-getrandom


### PR DESCRIPTION
…eature support in the ability to call atexit or tests that have a fork inside a fork

After the waitpid stability enhancements in https://github.com/deislabs/mystikos/commit/4fbed213fab3855f7f345f70fa9cb570d96c3626, certain tests in glibC related to atexit are failing. These are because of atexit not being supported in vfork currently.  tst-aio5 is a fork within a fork which is also not a supported scenario. Disabling these for now.

Signed-off-by: Radhika Jandhyala <radhikaj@microsoft.com>