### PR TITLE
Disable nobrk for ltp tests

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -27,7 +27,7 @@ endif
 URL=https://github.com/paulcallen/ltp
 BRANCH=paulcallen/revert-fork
 
-OPTS += --app-config-path config.json --nobrk
+OPTS += --app-config-path config.json
 
 # *** end fork related settings ***
 

--- a/tests/ltp/config.json
+++ b/tests/ltp/config.json
@@ -10,5 +10,6 @@
     // Mystikos specific values
     "MemorySize": "200m",
     "HostApplicationParameters": true,
-    "ForkMode":"pseudo"
+    "ForkMode":"pseudo",
+    "NoBrk": false
 }


### PR DESCRIPTION
it is causing instability due to fork-mode=pseudo and the child is
unmapping pages that are part of the shared crt heap

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>