### PR TITLE
Mystikos Python Debugger (mpdb)

### DIFF
--- a/scripts/mpdb.py
+++ b/scripts/mpdb.py
@@ -1,0 +1,71 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+import os
+import runpy
+import socket
+import sys
+
+from pdb import Pdb
+
+# Based on cpython/Lib/pdb.py
+def main():
+    port_var = 'MYSTIKOS_PDB_PORT'
+
+    port = os.environ.get(port_var)
+    if not port:
+        print('MYSTIKOS_PDB_PORT environment variable not set. Defaulting to port 5678')
+        port = 5678
+    else:
+        port = int(port)
+
+    print('Mystikos pdb waiting for connections at port %d' % port)
+    sys.stdout.flush()
+
+    host = '127.0.0.1'
+    client_socket = socket.create_server((host, port),
+                                         family=socket.AF_INET,
+                                         reuse_port=True)
+
+    client_socket.listen(1)
+    connection, address = client_socket.accept()
+    fd = connection.makefile('rw')
+    
+    args = sys.argv[1:]
+    mainpyfile = args[0]
+    run_as_module = False
+
+    if args[0] == '-m':
+        run_as_module = True
+        mainpyfile = args[1]
+        args = args[1:]
+
+    # Update args
+    sys.argv[:] = args
+        
+    if not run_as_module:
+        mainpyfile = os.path.realpath(mainpyfile)
+        # Replace pdb's dir with script's dir in front of module search path.
+        sys.path[0] = os.path.dirname(mainpyfile)
+    else:
+        runpy._get_module_details(mainpyfile)
+
+    pdb = Pdb(completekey='tab', stdin=fd, stdout=fd)
+    # Alias n, c, s commands to show source listing.
+    pdb.rcLines.extend(['alias n n;; l .',
+                        'alias c c;; l .',
+                        'alias s s;; l .'])
+    try:
+        if run_as_module:
+            pdb._runmodule(mainpyfile)
+        else:
+            pdb._runscript(mainpyfile)
+    except:
+        pass
+
+    connection.close()
+    client_socket.close()
+
+if __name__ == '__main__':
+    import mpdb
+    mpdb.main()

--- a/tests/cpython-tests/.dockerignore
+++ b/tests/cpython-tests/.dockerignore
@@ -1,0 +1,2 @@
+appdir*
+ext2fs*

--- a/tests/cpython-tests/Dockerfile
+++ b/tests/cpython-tests/Dockerfile
@@ -18,3 +18,6 @@ COPY ./test_config_$CPYTHON_VERSION /tests.* /
 RUN ln -sf /bin/bash /bin/sh
 
 RUN cp /usr/bin/lsb_release /bin/
+
+# Copy Mystikos pdb
+COPY ./mpdb.py /cpython/mpdb.py

--- a/tests/cpython-tests/Makefile
+++ b/tests/cpython-tests/Makefile
@@ -8,21 +8,25 @@ ifdef STRACE
 OPTS += --strace
 endif
 
+MPDB=$(TOP)/scripts/mpdb.py
 TESTFILE=tests.passed
-TEST = test_trace
+TEST = test_bz2
 FS=ext2fs3.9
 
 # Set timeout to 25 mins (to run both the python3.8 test suite and the python3.9 test suite)
 export TIMEOUT=1500
 
-all: ext2fs3.8 ext2fs3.9 
+all: ext2fs3.8 ext2fs3.9
 
-ext2fs3.8:
+mpdb.py:$(MPDB)
+	cp -f $(TOP)/scripts/mpdb.py mpdb.py
+
+ext2fs3.8:mpdb.py
 	rm -fr appdir3.8
-	$(APPBUILDER) -o appdir3.8 -e "--build-arg CPYTHON_VERSION=v3.8.11" Dockerfile 
+	$(APPBUILDER) -o appdir3.8 -e "--build-arg CPYTHON_VERSION=v3.8.11" Dockerfile
 	$(MYST) mkext2 appdir3.8 ext2fs3.8
 
-ext2fs3.9:
+ext2fs3.9:mpdb.py
 	rm -fr appdir3.9
 	$(APPBUILDER) -o appdir3.9 -e "--build-arg CPYTHON_VERSION=v3.9.7" Dockerfile
 	$(MYST) mkext2 appdir3.9 ext2fs3.9
@@ -39,3 +43,9 @@ run-list: ext2fs3.8 ext2fs3.9
 
 one: $(FS)
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m test $(TEST) -v
+
+one-mpdb: $(FS)
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m mpdb -m test $(TEST) -v &
+	sleep 10 && rlwrap telnet 127.0.0.1 5678
+	# Once debugger prompt is available, do
+        # (Pdb) b /cpython/Lib/test/<test file>.py:line


### PR DESCRIPTION
This PR checks in mpdb.py and enables its use in tests/cpython_tests.
Running `make one-mpdb` will launch mpdb for a single testpoint.
See Makefile for further details.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>