### PR TITLE
fix ttydev get_events() operation

### DIFF
--- a/kernel/ttydev.c
+++ b/kernel/ttydev.c
@@ -322,10 +322,19 @@ static int _td_get_events(myst_ttydev_t* ttydev, myst_tty_t* tty)
     if (!ttydev || !_valid_tty(tty))
         ERAISE(-EINVAL);
 
-    if (tty->fd == STDOUT_FILENO)
-        ret |= POLLOUT;
-    else
-        ret = -ENOTSUP;
+    switch (tty->fd)
+    {
+        case STDIN_FILENO:
+            ret |= POLLIN;
+            break;
+        case STDOUT_FILENO:
+        case STDERR_FILENO:
+            ret |= POLLOUT;
+            break;
+        default:
+            ret = -ENOTSUP;
+            break;
+    }
 
 done:
     return ret;


### PR DESCRIPTION
This PR fixes the events returned by the get_events() operation.