### PR TITLE
Report compatibility with glibc 2.27 via confstr(_CS_GNU_LIBC_VERSION)

### DIFF
--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -369,6 +369,19 @@ index afec985a..0ac9f0c4 100644
  	return p;
  }
  
+diff --git a/src/conf/confstr.c b/src/conf/confstr.c
+index 02cb1aa2..07e76f19 100644
+--- a/src/conf/confstr.c
++++ b/src/conf/confstr.c
+@@ -7,6 +7,8 @@ size_t confstr(int name, char *buf, size_t len)
+ 	const char *s = "";
+ 	if (!name) {
+ 		s = "/bin:/usr/bin";
++	} else if (name == _CS_GNU_LIBC_VERSION) {
++		s = "glibc 2.27";
+ 	} else if ((name&~4U)!=1 && name-_CS_POSIX_V6_ILP32_OFF32_CFLAGS>33U) {
+ 		errno = EINVAL;
+ 		return 0;
 diff --git a/src/exit/_Exit.c b/src/exit/_Exit.c
 index 7a6115c7..9f715d51 100644
 --- a/src/exit/_Exit.c


### PR DESCRIPTION
### Summary
One of the conditions [cpython checks for opting posix_spawn over fork is a glibc version > 2.24](https://github.com/python/cpython/blob/b1930bf75f276cd7ca08c4455298128d89adf7d1/Lib/subprocess.py#L679).

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>