### PR TITLE
Fix VM crash; Increase sleep

### DIFF
--- a/tests/cpython-tests/Makefile
+++ b/tests/cpython-tests/Makefile
@@ -46,8 +46,10 @@ one: $(FS)
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m test $(TEST) -v
 
 one-mpdb: $(FS)
+	killall myst 2> /dev/null || echo ""
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m mpdb -m test $(TEST) -v &
-	sleep 10 && rlwrap telnet 127.0.0.1 5678
+	sleep 15 # Increase this value in Makefile if connection fails
+	rlwrap telnet 127.0.0.1 5678
 	# Once debugger prompt is available, do
 	# (Pdb) b /cpython/Lib/test/<test file>.py:line
 


### PR DESCRIPTION
1) Sleep for 15 seconds before attempting to connect to mpdb.
   10 seconds isn't enough anymore.
2) Kill previous instances of myst. Otherwise, the system could
   run out of memory and when the oom handler kills processes,
   the VM goes down, likely due to a bug in SGX driver.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>