### PR TITLE
Add stubs for glibc itm functions

### DIFF
--- a/crt/glibc_stub.c
+++ b/crt/glibc_stub.c
@@ -208,3 +208,15 @@ int __libc_alloca_cutoff(size_t size)
     abort();
     return false;
 }
+
+void _ITM_deregisterTMCloneTable()
+{
+    assert(0);
+    abort();
+}
+
+void _ITM_registerTMCloneTable()
+{
+    assert(0);
+    abort();
+}


### PR DESCRIPTION
References to these functions are generated by GCC for pretty much
every shared library. But they are never called. These functions
are part of the imlementation of transactional memory support for C/C++
- a feature that was never accepted into the standard.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>