### PR TITLE
Disable memory scrubbing in the memory manager by default.

### DIFF
--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -33,7 +33,10 @@
 MYST_PRINTF_FORMAT(2, 3)
 int asprintf(char** strp, const char* fmt, ...);
 
-#define SCRUB
+/* Scrubbing the unmapped memory (marking with a fixed pattern) has significant
+ * performance impact in SGX mode, if the EPC is small. Scrubbing should not be
+ * enabled unless the performance impact is not a concern */
+//#define SCRUB
 
 static myst_mman_t _mman;
 static void* _mman_start;

--- a/solutions/coreclr/config_1g.json
+++ b/solutions/coreclr/config_1g.json
@@ -9,7 +9,7 @@
     // Mystikos specific values
 
     // The heap size of the user application. Increase this setting if your app experienced OOM.
-    "MemorySize": "2g",
+    "MemorySize": "1g",
     // The path to the entry point application in rootfs
     "ApplicationPath": "/coreclr-tests-all/Tests/Core_Root/corerun",
     // The parameters to the entry point application

--- a/solutions/coreclr/stat.sh
+++ b/solutions/coreclr/stat.sh
@@ -35,7 +35,7 @@ if [[ -f FAILED-1 ]]; then
 	cat FAILED-1
 fi
 
-if [ "$(( pass_count*100/NUM_TESTS ))" -lt "95" ]; then
-	echo "Failed to pass at least 95% - Pass percentage: $(( $pass_count*100/$NUM_TESTS ))%"
+if [ "$(( pass_count*100/NUM_TESTS ))" -lt "99" ]; then
+	echo "Failed to pass at least 99% - Pass percentage: $(( $pass_count*100/$NUM_TESTS ))%"
 	exit 1
 fi


### PR DESCRIPTION
A recent change in mman.c enabled marking the unmapped memory with 0xEE, if SCRUB compiling switch in mmanutils.c  is set.
The operation has significant performance impact in SGX mode, if the EPC is small. As a result, many test cases in solutions/coreclr took much longer to complete and triggered the timeout. This PR set the SCRUB compiling switch as off by default. With this PR, the coreclr test suite can finish with the the original timeout settings.

Disable memory scrubbing in the memory manager by default.
 - Disable SCRUB compiling switch in mmanutils.c by default
  - When marking the unmmaped memory, use myst_tcall_mprotect() instead of
    _MMAN_MPROTECT_PAGES macro to set page table entry permission for write,
    avoiding the wasterful write to the prot. vector
  - Re-enable marking the unmapped memory in myst_mman_mremap(), if SCRUB compiling
    switch is on or MEMCHECK runtime config is set
Tighten .NET coreclr test pass criteria.
  - 99%(instead of 95%) of the test cases must pass to be considered successful

Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>