### PR TITLE
Fix select() so read and write events are processed. Handle SIGPIPE from sendmsg/sendto.

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -3822,12 +3822,14 @@ static long _syscall(void* args_)
 
             _strace(
                 n,
-                "nfds=%d rfds=%p wfds=%p xfds=%p timeout=%p",
+                "nfds=%d rfds=%p wfds=%p xfds=%p timeout=%p(sec=%ld, usec=%ld)",
                 nfds,
                 rfds,
                 wfds,
                 efds,
-                timeout);
+                timeout,
+                timeout ? timeout->tv_sec : 0,
+                timeout ? timeout->tv_usec : 0);
 
             ret = myst_syscall_select(nfds, rfds, wfds, efds, timeout);
             BREAK(_return(n, ret));
@@ -3962,7 +3964,13 @@ static long _syscall(void* args_)
             const struct timespec* req = (const struct timespec*)x1;
             struct timespec* rem = (struct timespec*)x2;
 
-            _strace(n, "req=%p rem=%p", req, rem);
+            _strace(
+                n,
+                "req=%p(sec=%ld, nsec=%ld) rem=%p",
+                req,
+                req ? req->tv_sec : 0,
+                req ? req->tv_nsec : 0,
+                rem);
 
             BREAK(_return(n, myst_syscall_nanosleep(req, rem)));
         }
@@ -4998,15 +5006,32 @@ static long _syscall(void* args_)
             long arg = (long)x4;
             int* uaddr2 = (int*)x5;
             int val3 = (int)x6;
-
-            _strace(
-                n,
-                "uaddr=0x%lx(%d) futex_op=%u(%s) val=%d",
-                (long)uaddr,
-                (uaddr ? *uaddr : -1),
-                futex_op,
-                _futex_op_str(futex_op),
-                val);
+            int futex_op2 = futex_op & ~FUTEX_PRIVATE;
+            if (futex_op2 == FUTEX_WAIT || futex_op2 == FUTEX_WAIT_BITSET)
+            {
+                const struct timespec* timeout = (const struct timespec*)x4;
+                _strace(
+                    n,
+                    "uaddr=0x%lx(%d) futex_op=%u(%s) val=%d, "
+                    "timeout=%p(sec=%ld, nsec=%ld)",
+                    (long)uaddr,
+                    (uaddr ? *uaddr : -1),
+                    futex_op,
+                    _futex_op_str(futex_op),
+                    val,
+                    timeout,
+                    timeout ? timeout->tv_sec : 0,
+                    timeout ? timeout->tv_nsec : 0);
+            }
+            else
+                _strace(
+                    n,
+                    "uaddr=0x%lx(%d) futex_op=%u(%s) val=%d",
+                    (long)uaddr,
+                    (uaddr ? *uaddr : -1),
+                    futex_op,
+                    _futex_op_str(futex_op),
+                    val);
 
             BREAK(_return(
                 n,
@@ -5375,8 +5400,14 @@ static long _syscall(void* args_)
             const char* pathname = (const char*)x2;
             const struct timeval* times = (const struct timeval*)x3;
             long ret;
-
-            _strace(n, "dirfd=%d pathname=%s times=%p", dirfd, pathname, times);
+            _strace(
+                n,
+                "dirfd=%d pathname=%s times=%p(sec=%ld, usec=%ld)",
+                dirfd,
+                pathname,
+                times,
+                times ? times->tv_sec : 0,
+                times ? times->tv_usec : 0);
 
             ret = myst_syscall_futimesat(dirfd, pathname, times);
             BREAK(_return(n, ret));
@@ -5726,12 +5757,15 @@ static long _syscall(void* args_)
 
             _strace(
                 n,
-                "sockfd=%d msgvec=%p vlen=%u flags=%d timeout=%p",
+                "sockfd=%d msgvec=%p vlen=%u flags=%d timeout=%p(sec=%ld, "
+                "nsec=%ld)",
                 sockfd,
                 msgvec,
                 vlen,
                 flags,
-                timeout);
+                timeout,
+                timeout ? timeout->tv_sec : 0,
+                timeout ? timeout->tv_nsec : 0);
 
             ret = myst_syscall_recvmmsg(sockfd, msgvec, vlen, flags, timeout);
             BREAK(_return(n, ret));
@@ -5782,7 +5816,15 @@ static long _syscall(void* args_)
                 vlen,
                 flags);
 
-            ret = myst_syscall_sendmmsg(sockfd, msgvec, vlen, flags);
+            /* Note: We send in MSG_NOSIGNAL so it does not generate a SIGPIPE
+             * in the host. We get an EPIPE error back if the socket got closed,
+             * and then we will generate the signal ourselves if needed. */
+            ret = myst_syscall_sendmmsg(
+                sockfd, msgvec, vlen, flags | MSG_NOSIGNAL);
+            if (ret == -EPIPE && !(flags & MSG_NOSIGNAL))
+            {
+                myst_signal_deliver(thread, SIGPIPE, NULL);
+            }
             BREAK(_return(n, ret));
         }
         case SYS_setns:
@@ -6039,8 +6081,15 @@ static long _syscall(void* args_)
                     addrlen);
             }
 
+            /* Note: We send in MSG_NOSIGNAL so it does not generate a SIGPIPE
+             * in the host. We get an EPIPE error back if the socket got closed,
+             * and then we will generate the signal ourselves if needed. */
             ret = myst_syscall_sendto(
-                sockfd, buf, len, flags, dest_addr, addrlen);
+                sockfd, buf, len, flags | MSG_NOSIGNAL, dest_addr, addrlen);
+            if (ret == -EPIPE && !(flags & MSG_NOSIGNAL))
+            {
+                myst_signal_deliver(thread, SIGPIPE, NULL);
+            }
 
             BREAK(_return(n, ret));
         }
@@ -6089,7 +6138,11 @@ static long _syscall(void* args_)
 
             _strace(n, "sockfd=%d msg=%p flags=%d", sockfd, msg, flags);
 
-            ret = myst_syscall_sendmsg(sockfd, msg, flags);
+            ret = myst_syscall_sendmsg(sockfd, msg, flags | MSG_NOSIGNAL);
+            if (ret == -EPIPE && !(flags & MSG_NOSIGNAL))
+            {
+                myst_signal_deliver(thread, SIGPIPE, NULL);
+            }
             BREAK(_return(n, ret));
         }
         case SYS_recvmsg:
@@ -6262,7 +6315,6 @@ static long _syscall(void* args_)
 
             long ret = myst_syscall_sendfile(out_fd, in_fd, offset, count);
             BREAK(_return(n, ret));
-            break;
         }
         /* forward Open Enclave extensions to the target */
         case SYS_myst_oe_get_report_v2:

--- a/tests/cpython-tests/Makefile
+++ b/tests/cpython-tests/Makefile
@@ -4,14 +4,22 @@ include $(TOP)/defs.mak
 APPBUILDER=$(TOP)/scripts/appbuilder
 
 OPTS = --app-config-path config.json
-ifdef STRACE
-OPTS += --strace
+ifdef TRACE
+	OPTS += --strace --etrace
+else
+	ifdef STRACE
+		OPTS += --strace
+	endif
+	ifdef ETRACE
+		OPTS += --etrace
+	endif
 endif
 
 MPDB=$(TOP)/scripts/mpdb.py
 TESTFILE=tests.passed
 TEST = test_bz2
-TESTCASE = test_capi.CAPITest.test_negative_refcount
+TESTCASE = test_asynchat.TestAsynchat
+#TESTCASE = test_asynchat.TestAsynchat.test_close_when_done
 VER=3.9
 FS=ext2fs$(VER)
 
@@ -26,12 +34,12 @@ mpdb.py:$(MPDB)
 ext2fs3.8:mpdb.py
 	rm -fr appdir3.8
 	$(APPBUILDER) -o appdir3.8 -e "--build-arg CPYTHON_VERSION=v3.8.11" Dockerfile
-	$(MYST) mkext2 appdir3.8 ext2fs3.8
+	$(MYST) mkext2 -f appdir3.8 ext2fs3.8
 
 ext2fs3.9:mpdb.py
 	rm -fr appdir3.9
 	$(APPBUILDER) -o appdir3.9 -e "--build-arg CPYTHON_VERSION=v3.9.7" Dockerfile
-	$(MYST) mkext2 appdir3.9 ext2fs3.9
+	$(MYST) mkext2 -f appdir3.9 ext2fs3.9
 
 clean:
 	rm -fr appdir* ext2fs* @test_101* hostfs

--- a/tests/cpython-tests/test_config_v3.8.11/tests.failed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.failed
@@ -1,6 +1,5 @@
 test__locale
 test_asyncgen
-test_asynchat
 test_asyncio
 test_asyncore
 test_base64

--- a/tests/cpython-tests/test_config_v3.8.11/tests.passed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.passed
@@ -10,6 +10,7 @@ test_argparse
 test_array
 test_asdl_parser
 test_ast
+test_asynchat
 test_atexit
 test_audioop
 test_audit

--- a/tests/cpython-tests/test_config_v3.9.7/tests.failed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.failed
@@ -1,6 +1,5 @@
 test__locale
 test_asyncgen
-test_asynchat
 test_asyncio
 test_asyncore
 test_base64

--- a/tests/cpython-tests/test_config_v3.9.7/tests.passed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.passed
@@ -10,6 +10,7 @@ test_argparse
 test_array
 test_asdl_parser
 test_ast
+test_asynchat
 test_atexit
 test_audioop
 test_audit


### PR DESCRIPTION
* Enable cpython-tests asynchat tests.
* Fix select() so read and write events are processed as well as exceptions.
* Handle the SIGPIPE from sendto() and sendmsg() in the kernel and disable the signal in the host.

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>