### PR TITLE
Prevent fails due to file lock

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -105,9 +105,13 @@ group-file:
 	echo "grp1000:x:1000:" >> appdir/etc/group
 
 add_host_users_and_groups:
+	while sudo lsof /etc/group; do sleep 3; done
 	sudo groupadd -f -g 100701 grp701
+	while sudo lsof /etc/group; do sleep 3; done
 	sudo groupadd -f -g 100704 grp704
+	while sudo lsof /etc/group; do sleep 3; done
 	sudo groupadd -f -g 100705 grp705
+	while sudo lsof /etc/group; do sleep 3; done
 	sudo groupadd -f -g 101000 grp1000
 	id -u user700 >/dev/null 2>&1 || sudo useradd -g grp701 -u 100700 user700
 	id -u user702 >/dev/null 2>&1 || sudo useradd -g grp701 -u 100702 user702


### PR DESCRIPTION
This is a fix for an issue root caused to be due the groupadd commands failing due to the /etc/group file still being in use while the next groupadd command is ran. In reference to https://github.com/deislabs/mystikos/issues/813#issuecomment-939057711

Signed-off-by: Chris Yan <chrisyan@microsoft.com>