### PR TITLE
stop sigpipe being thrown with socket write

### DIFF
--- a/tests/cpython-tests/test_config_v3.8.11/tests.failed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.failed
@@ -15,7 +15,6 @@ test_faulthandler
 test_fcntl
 test_fileio
 test_fork1
-test_ftplib
 test_gc
 test_gdb
 test_glob
@@ -31,7 +30,6 @@ test_os
 test_pathlib
 test_pdb
 test_pkgutil
-test_poplib
 test_posix
 test_pty
 test_py_compile

--- a/tests/cpython-tests/test_config_v3.8.11/tests.passed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.passed
@@ -123,6 +123,7 @@ test_fractions
 test_frame
 test_frozen
 test_fstring
+test_ftplib
 test_funcattrs
 test_functools
 test_future
@@ -220,6 +221,7 @@ test_platform
 test_plistlib
 test_poll
 test_popen
+test_poplib
 test_positional_only_arg
 test_posixpath
 test_pow

--- a/tests/cpython-tests/test_config_v3.9.7/tests.failed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.failed
@@ -15,7 +15,6 @@ test_faulthandler
 test_fcntl
 test_fileio
 test_fork1
-test_ftplib
 test_gc
 test_gdb
 test_glob
@@ -32,7 +31,6 @@ test_pathlib
 test_pdb
 test_peg_generator
 test_pkgutil
-test_poplib
 test_posix
 test_pty
 test_py_compile

--- a/tests/cpython-tests/test_config_v3.9.7/tests.passed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.passed
@@ -123,6 +123,7 @@ test_fractions
 test_frame
 test_frozen
 test_fstring
+test_ftplib
 test_funcattrs
 test_functools
 test_future
@@ -222,6 +223,7 @@ test_platform
 test_plistlib
 test_poll
 test_popen
+test_poplib
 test_positional_only_arg
 test_posixpath
 test_pow

--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -245,6 +245,7 @@ static long _sendto(
 {
     long ret = 0;
     long retval;
+    oe_result_t oeret;
 
     if (sockfd < 0 || (!buf && len) || len > SSIZE_MAX)
     {
@@ -252,10 +253,13 @@ static long _sendto(
         goto done;
     }
 
-    if (myst_sendto_ocall(
-            &retval, sockfd, buf, len, flags, dest_addr, addrlen) != OE_OK)
+    if ((oeret = myst_sendto_ocall(
+             &retval, sockfd, buf, len, flags, dest_addr, addrlen)) != OE_OK)
     {
-        ret = -EINVAL;
+        if (oeret == OE_OUT_OF_MEMORY)
+            ret = -ENOMEM;
+        else
+            ret = -EINVAL;
         goto done;
     }
 
@@ -334,6 +338,7 @@ static long _sendmsg(int sockfd, const struct msghdr* msg, int flags)
 {
     long ret = 0;
     long retval;
+    oe_result_t oeret;
 
     if (sockfd < 0 || !msg)
     {
@@ -348,19 +353,22 @@ static long _sendmsg(int sockfd, const struct msghdr* msg, int flags)
         goto done;
     }
 
-    if (myst_sendmsg_ocall(
-            &retval,
-            sockfd,
-            msg->msg_name,
-            msg->msg_namelen,
-            msg->msg_iov[0].iov_base,
-            msg->msg_iov[0].iov_len,
-            msg->msg_control,
-            msg->msg_controllen,
-            msg->msg_flags,
-            flags) != OE_OK)
+    if ((oeret = myst_sendmsg_ocall(
+             &retval,
+             sockfd,
+             msg->msg_name,
+             msg->msg_namelen,
+             msg->msg_iov[0].iov_base,
+             msg->msg_iov[0].iov_len,
+             msg->msg_control,
+             msg->msg_controllen,
+             msg->msg_flags,
+             flags)) != OE_OK)
     {
-        ret = -EINVAL;
+        if (oeret == OE_OUT_OF_MEMORY)
+            ret = -ENOMEM;
+        else
+            ret = -EINVAL;
         goto done;
     }
 


### PR DESCRIPTION
For sockets, write now go through sendto and disable sigpipe, then throws when returning back to the kernel

This enables 2 cpython tests.
* test_poplib
* test_ftplib


Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>