### PR TITLE
Comply with spec for O_PATH

### DIFF
--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -414,8 +414,12 @@ long myst_mmap(
         if ((flags = myst_syscall_fcntl(fd, F_GETFL, 0)) < 0)
             ERAISE(-EBADF);
 
+        /* operation not allowed on fd opened with O_PATH*/
+        if (flags & O_PATH)
+            ERAISE(-EBADF);
+
         /* if file is not open for read */
-        if ((flags & O_WRONLY))
+        if (flags & O_WRONLY)
             ERAISE(-EACCES);
 
         /* MAP_SHARED & PROT_WRITE set, but fd is not open for read-write */

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -470,11 +470,22 @@ long myst_syscall_open(const char* pathname, int flags, mode_t mode)
     struct locals
     {
         char suffix[PATH_MAX];
+        struct stat statbuf;
     };
     struct locals* locals = NULL;
 
     if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
+
+    if (flags & O_NOFOLLOW)
+    {
+        /* check if path is a link, if so O_PATH should be passed */
+        if (ret = myst_syscall_lstat(pathname, &locals->statbuf) < 0)
+            ERAISE(ret);
+
+        if (S_ISLNK(locals->statbuf.st_mode) && !(flags & O_PATH))
+            ERAISE(-ELOOP);
+    }
 
     ECHECK(myst_mount_resolve(pathname, locals->suffix, &fs));
     ECHECK((*fs->fs_open)(fs, locals->suffix, flags, mode, &fs_out, &file));
@@ -1091,14 +1102,17 @@ long myst_syscall_fstatat(
     };
     struct locals* locals = NULL;
 
-    if (!pathname || !statbuf)
+    if ((!pathname || *pathname == '\0') && !(flags & AT_EMPTY_PATH))
+        ERAISE(-ENOENT);
+
+    if (!statbuf)
         ERAISE(-EINVAL);
 
     if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     /* If pathname is absolute, then ignore dirfd */
-    if (*pathname == '/' || dirfd == AT_FDCWD)
+    if ((pathname && *pathname == '/') || dirfd == AT_FDCWD)
     {
         if (flags & AT_SYMLINK_NOFOLLOW)
         {
@@ -1111,7 +1125,7 @@ long myst_syscall_fstatat(
             goto done;
         }
     }
-    else if (*pathname == '\0')
+    else if (!pathname || *pathname == '\0')
     {
         if (!(flags & AT_EMPTY_PATH))
             ERAISE(-EINVAL);
@@ -1139,21 +1153,31 @@ long myst_syscall_fstatat(
         myst_fdtable_t* fdtable = myst_fdtable_current();
         myst_fs_t* fs;
         myst_file_t* file;
+        const char* finalpath;
 
         ECHECK(myst_fdtable_get_file(fdtable, dirfd, &fs, &file));
         ECHECK((*fs->fs_realpath)(
             fs, file, locals->dirpath, sizeof(locals->dirpath)));
-        ECHECK(myst_make_path(
-            locals->path, sizeof(locals->path), locals->dirpath, pathname));
+
+        if (pathname && (flags & AT_EMPTY_PATH))
+        {
+            finalpath = locals->dirpath;
+        }
+        else
+        {
+            ECHECK(myst_make_path(
+                locals->path, sizeof(locals->path), locals->dirpath, pathname));
+            finalpath = locals->path;
+        }
 
         if (flags & AT_SYMLINK_NOFOLLOW)
         {
-            ECHECK(myst_syscall_lstat(locals->path, statbuf));
+            ECHECK(myst_syscall_lstat(finalpath, statbuf));
             goto done;
         }
         else
         {
-            ECHECK(myst_syscall_stat(locals->path, statbuf));
+            ECHECK(myst_syscall_stat(finalpath, statbuf));
             goto done;
         }
     }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -128,6 +128,7 @@ DIRS += unhandled_syscall_enosys
 DIRS += stack_overflow
 DIRS += sendfile
 DIRS += strtonum
+DIRS += fsflags
 
 ifdef MYST_NIGHTLY_TEST
 DIRS += glibc

--- a/tests/fsflags/Makefile
+++ b/tests/fsflags/Makefile
@@ -1,0 +1,32 @@
+.NOTPARALLEL:
+
+TOP = $(abspath ../..)
+include $(TOP)/defs.mak
+
+all:
+	make -C appdir
+	$(MYST) mkcpio appdir rootfs
+	$(MYST) mkext2 --force appdir ext2fs
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+ifdef MYST_ENABLE_GCOV
+OPTS += --export-ramfs
+endif
+
+tests_ext2fs:
+	$(MYST_EXEC) $(OPTS) ext2fs /opath
+	$(MYST_EXEC) $(OPTS) ext2fs /atemptypath
+
+tests_ramfs:
+	$(MYST_EXEC) $(OPTS) rootfs /opath
+	$(MYST_EXEC) $(OPTS) rootfs /atemptypath
+
+tests: all tests_ext2fs tests_ramfs
+
+
+clean:
+	rm -rf rootfs ramfs
+	make -C appdir clean

--- a/tests/fsflags/appdir/AT_EMPTY_PATH.c
+++ b/tests/fsflags/appdir/AT_EMPTY_PATH.c
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <syscall.h>
+
+#define AT_EMPTY_PATH 0x1000
+const char* test_dir = "testdir";
+
+int open_setup(int flags)
+{
+    remove(test_dir);
+    int ret = mkdir(test_dir, 0700);
+    assert(ret == 0);
+    int fd = open(test_dir, flags);
+    printf("fd is %i\n", fd);
+    assert(fd > 0);
+    return fd;
+}
+
+void test_expect_error(int ret, int expected)
+{
+    printf("ret is %i, errno is %i\n", ret, errno);
+    assert(ret < 0);
+    assert(errno == expected);
+}
+
+void test_fstatat_nullpath_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = open_setup(O_RDONLY);
+    struct stat buf;
+    test_expect_error(fstatat(fd, "", &buf, 0), ENOENT);
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_fstatat_atemptypath()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = open_setup(O_RDONLY);
+    struct stat buf;
+    int ret = fstatat(fd, "", &buf, AT_EMPTY_PATH);
+    assert(ret == 0);
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+int main(int argc, const char* argv[])
+{
+    printf("== starting testsuite (%s)\n", argv[0]);
+
+    test_fstatat_nullpath_expect_error();
+    test_fstatat_atemptypath();
+
+    printf("== passed testsuite (%s)\n", argv[0]);
+
+    remove(test_dir);
+
+    return 0;
+}

--- a/tests/fsflags/appdir/Makefile
+++ b/tests/fsflags/appdir/Makefile
@@ -1,0 +1,7 @@
+all:
+	gcc -Wall -o opath O_PATH.c
+	gcc -Wall -o atemptypath AT_EMPTY_PATH.c
+
+clean:
+	rm -rf opath
+	rm -rf atemptypath

--- a/tests/fsflags/appdir/O_PATH.c
+++ b/tests/fsflags/appdir/O_PATH.c
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <syscall.h>
+#include <unistd.h>
+
+#define O_PATH 010000000
+
+struct linux_dirent
+{
+    unsigned long d_ino;     /* Inode number */
+    unsigned long d_off;     /* Offset to next linux_dirent */
+    unsigned short d_reclen; /* Length of this linux_dirent */
+    char d_name[];           /* Filename (null-terminated) */
+                             /* length is actually (d_reclen - 2 -
+                                offsetof(struct linux_dirent, d_name) */
+    /*
+    char           pad;       // Zero padding byte
+    char           d_type;    // File type (only since Linux 2.6.4;
+                              // offset is (d_reclen - 1))
+    */
+};
+
+const char* test_file = "test.txt";
+const char* test_sym = "test_sym";
+
+int opath_open_setup()
+{
+    remove(test_file);
+    int fd = open(test_file, O_CREAT);
+    assert(fd > 0);
+    fd = open(test_file, O_PATH);
+    printf("fd is %i\n", fd);
+    assert(fd > 0);
+    return fd;
+}
+
+void test_expect_error(int ret)
+{
+    printf("ret is %i, errno is %i\n", ret, errno);
+    assert(ret < 0);
+    assert(errno == EBADF);
+}
+
+void test_read_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    char buffer[5];
+    test_expect_error(read(fd, buffer, 3));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_write_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    char buffer[5];
+    test_expect_error(write(fd, buffer, 3));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_fchmod_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    // Using syscall: fchmod/fchown wrapper does not
+    // error in Mystikos due musl behavior difference
+    test_expect_error(syscall(SYS_fchmod, fd, S_IRUSR));
+    remove(test_file);
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_fchown_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    // Using syscall: see fchmod
+    test_expect_error(syscall(SYS_fchown, fd, -1, -1));
+    remove(test_file);
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_ioctl_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    test_expect_error(ioctl(fd, 1));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_ftruncate_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    test_expect_error(ftruncate(fd, 1));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_getdents_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    struct linux_dirent dirp;
+    test_expect_error(syscall(SYS_getdents64, fd, &dirp, 0));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_fdatasync_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    test_expect_error(fdatasync(fd));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_fsync_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    test_expect_error(fsync(fd));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_lseek_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    test_expect_error(lseek(fd, 1, SEEK_SET));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+void test_mmap_expect_error()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    test_expect_error(
+        (int)(uintptr_t)mmap(NULL, 1, PROT_NONE, MAP_SHARED, fd, 0));
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+// If O_PATH is specified other access flags ignored
+void test_fcntl_get_access_flag()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    int fd = opath_open_setup();
+    int ret = fcntl(fd, F_GETFL);
+    assert(ret == O_PATH);
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+// Return ELOOP on open if pathname was a symbolic link,
+// and flags specified O_NOFOLLOW but not O_PATH
+void test_fstatat_eloop()
+{
+    printf("=== starting test (%s)\n", __FUNCTION__);
+    opath_open_setup();
+    remove(test_sym);
+    int ret_sym = symlink(test_file, test_sym);
+    assert(ret_sym == 0);
+    int ret = open(test_sym, O_NOFOLLOW);
+    assert(ret < 0);
+    assert(errno == ELOOP);
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+int main(int argc, const char* argv[])
+{
+    printf("== starting testsuite (%s)\n", argv[0]);
+
+    test_read_expect_error();
+    test_write_expect_error();
+    test_fchmod_expect_error();
+    test_fchown_expect_error();
+    test_ioctl_expect_error();
+    test_ftruncate_expect_error();
+    test_getdents_expect_error();
+    test_fdatasync_expect_error();
+    test_fsync_expect_error();
+    test_lseek_expect_error();
+    test_mmap_expect_error();
+
+    test_fcntl_get_access_flag();
+    test_fstatat_eloop();
+
+    printf("== passed testsuite (%s)\n", argv[0]);
+
+    remove(test_sym);
+    remove(test_file);
+
+    return 0;
+}


### PR DESCRIPTION
Closes #489

 Modified file system to match specified behavior for O_PATH as follows:
1. Return `ELOOP` on open if "pathname was a symbolic link, and flags specified O_NOFOLLOW but not O_PATH".
2. Fail on operations "read(2), write(2), fchmod(2), fchown(2), fgetxattr(2), ioctl(2), mmap(2))"  if file was opened with O_PATH.
3. "When O_PATH is specified in flags, flag bits other than O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW are ignored."

Modified fstatat to allow empty path if AT_EMPTY_PATH flag is passed in. 

Above quotes from [open(2) manpage](https://man7.org/linux/man-pages/man2/open.2.html)