### PR TITLE
dotnet-sos sgx driver fix

### DIFF
--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -28,13 +28,12 @@ runner-image:
 clean:
 	sudo rm -fr appdir ext2fs rootfs stdouterr.txt
 
+DOCKER_SGX_DRIVER_OPTIONS = -v /dev/sgx:/dev/sgx
+DOCKER_SGX_DRIVER_OPTIONS += --device /dev/sgx/enclave:/dev/sgx/enclave
+DOCKER_SGX_DRIVER_OPTIONS += --device /dev/sgx/provision:/dev/sgx/provision
+
 tests:
-	$(RUNTEST) docker run --rm \
-	-e TARGET=$(TARGET) \
-	-v $(abspath .):/app/ -v $(TOP)/build:/build \
-	--device /dev/sgx:/dev/sgx \
-	$(TEST_RUNNER_IMG) \
-	/app/exec.sh $(MYST_LLDB_DOCKER) /build/bin/myst $(EXEC) $(OPTS)
+	$(RUNTEST) docker run --rm -e TARGET=$(TARGET) -v $(abspath .):/app/ -v $(TOP)/build:/build $(DOCKER_SGX_DRIVER_OPTIONS) $(TEST_RUNNER_IMG) /app/exec.sh $(MYST_LLDB_DOCKER) /build/bin/myst $(EXEC) $(OPTS)
 	@ echo "=== passed test (dotnet-sos)"
 
 tests-without-docker:


### PR DESCRIPTION
This PR fixes the build to work on all pipeline machines. It failed on some pipeline machines due to differences in the structure of the ``/dev/sgx`` directory. Depending on the version of SGX platform software, the directory may contain symbolic links rather than devices.