### PR TITLE
EXPERIMENTAL: FIFOs (named pipes)

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -5722,10 +5722,6 @@ int ext2_mkfifo(myst_fs_t* fs, const char* path, mode_t mode)
     if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
-    /* reject all S_IFMT bits except for O_DIRECT */
-    if ((mode & S_IFMT) && !(mode & O_DIRECT))
-        ERAISE(-EINVAL);
-
     /* Split the path */
     ECHECK(_split_path(path, locals->dirname, locals->basename));
 

--- a/hostfs/hostfs.c
+++ b/hostfs/hostfs.c
@@ -1236,6 +1236,34 @@ done:
     return ret;
 }
 
+static int _fs_mkfifo(myst_fs_t* fs, const char* pathname, mode_t mode)
+{
+    int ret = 0;
+    hostfs_t* hostfs = (hostfs_t*)fs;
+    long tret;
+    char path[PATH_MAX];
+    uid_t host_uid;
+    gid_t host_gid;
+
+    if (!_hostfs_valid(hostfs) || !pathname)
+        ERAISE(-EINVAL);
+
+    ECHECK(_to_host_path(hostfs, path, sizeof(path), pathname));
+
+    ECHECK(_get_host_uid_gid(&host_uid, &host_gid));
+
+    long params[6] = {(long)path, (long)mode, (long)host_uid, (long)host_gid};
+    ECHECK((tret = myst_tcall(MYST_TCALL_MKFIFO, params)));
+
+    if (tret != 0)
+        ERAISE(-EINVAL);
+
+    ret = tret;
+
+done:
+    return ret;
+}
+
 int myst_init_hostfs(myst_fs_t** fs_out)
 {
     int ret = 0;
@@ -1299,6 +1327,7 @@ int myst_init_hostfs(myst_fs_t** fs_out)
         .fs_fdatasync = _fs_fdatasync,
         .fs_fsync = _fs_fsync,
         .fs_release_tree = _fs_release_tree,
+        .fs_mkfifo = _fs_mkfifo,
     };
     // clang-format on
 

--- a/include/myst/fs.h
+++ b/include/myst/fs.h
@@ -182,6 +182,8 @@ struct myst_fs
 
     /* Recursively remove directory tree pointed at by pathname */
     int (*fs_release_tree)(myst_fs_t* fs, const char* pathname);
+
+    int (*fs_mkfifo)(myst_fs_t* fs, const char* pathname, mode_t mode);
 };
 
 int myst_add_fd_link(myst_fs_t* fs, myst_file_t* file, int fd);

--- a/include/myst/id.h
+++ b/include/myst/id.h
@@ -4,7 +4,44 @@
 #ifndef _MYST_ID_H
 #define _MYST_ID_H
 
+#include <unistd.h>
+
 #define MYST_DEFAULT_UID (uid_t)0
 #define MYST_DEFAULT_GID (gid_t)0
+
+#define MYST_RESUID_INITIALIZER \
+    {                           \
+        -1, -1, -1              \
+    }
+#define MYST_RESGID_INITIALIZER \
+    {                           \
+        -1, -1, -1              \
+    }
+
+typedef struct myst_resuid
+{
+    uid_t ruid; /* real user-id */
+    uid_t euid; /* effective user-id */
+    uid_t suid; /* saved set-user-id */
+} myst_resuid_t;
+
+typedef struct myst_resgid
+{
+    gid_t rgid; /* real group-id */
+    gid_t egid; /* effective group-id */
+    gid_t sgid; /* saved set-group-id */
+} myst_resgid_t;
+
+/* set the effective user-id and group-id and get the old identity */
+long myst_change_identity(
+    uid_t euid,
+    gid_t egid,
+    myst_resuid_t* resuid,
+    myst_resgid_t* resgid);
+
+/* restore the identity to resuid and resgid */
+long myst_restore_identity(
+    const myst_resuid_t* resuid,
+    const myst_resgid_t* resgid);
 
 #endif /* _MYST_ID_H */

--- a/include/myst/tcall.h
+++ b/include/myst/tcall.h
@@ -55,6 +55,7 @@ typedef enum myst_tcall_number
     MYST_TCALL_LOAD_FSSIG,
     MYST_TCALL_CLOCK_GETRES,
     MYST_TCALL_GCOV,
+    MYST_TCALL_MKFIFO,
 } myst_tcall_number_t;
 
 long myst_tcall(long n, long params[6]);
@@ -173,5 +174,11 @@ long myst_tcall_write(int fd, const void* buf, size_t count);
 long myst_tcall_poll(struct pollfd* fds, nfds_t nfds, int timeout);
 
 long myst_tcall_pipe2(int pipefd[2], int flags);
+
+long myst_tcall_mkfifo(
+    const char* pathname,
+    mode_t mode,
+    uid_t host_euid,
+    gid_t host_egid);
 
 #endif /* _MYST_TCALL_H */

--- a/kernel/lockfs.c
+++ b/kernel/lockfs.c
@@ -785,6 +785,21 @@ done:
     return ret;
 }
 
+static int _fs_mkfifo(myst_fs_t* fs, const char* pathname, mode_t mode)
+{
+    int ret = 0;
+    lockfs_t* lockfs = (lockfs_t*)fs;
+
+    if (!_lockfs_valid(lockfs))
+        ERAISE(-EINVAL);
+
+    myst_mutex_lock(&lockfs->lock);
+    ret = (*lockfs->fs->fs_mkfifo)(lockfs->fs, pathname, mode);
+    myst_mutex_unlock(&lockfs->lock);
+
+done:
+    return ret;
+}
 int myst_lockfs_init(myst_fs_t* fs, myst_fs_t** lockfs_out)
 {
     int ret = 0;
@@ -846,6 +861,7 @@ int myst_lockfs_init(myst_fs_t* fs, myst_fs_t** lockfs_out)
         .fs_fdatasync = _fs_fdatasync,
         .fs_fsync = _fs_fsync,
         .fs_release_tree = _fs_release_tree,
+        .fs_mkfifo = _fs_mkfifo,
     };
 
     if (lockfs_out)

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -144,7 +144,7 @@ static int _split_path(
 static int _inode_add_dirent(
     inode_t* dir,
     inode_t* inode,
-    uint8_t type, /* DT_REG or DT_DIR */
+    uint8_t type, /* DT_REG, DT_DIR, DT_LNK, or DT_FIFO */
     const char* name)
 {
     int ret = 0;
@@ -160,7 +160,7 @@ static int _inode_add_dirent(
     if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
-    if (type != DT_REG && type != DT_DIR && type != DT_LNK)
+    if (type != DT_REG && type != DT_DIR && type != DT_LNK && type != DT_FIFO)
         ERAISE(-EINVAL);
 
     /* Append the new directory entry */
@@ -273,6 +273,8 @@ static int _inode_new(
             type = DT_REG;
         else if (S_ISLNK(mode))
             type = DT_LNK;
+        else if (S_ISFIFO(mode))
+            type = DT_FIFO;
         else
         {
             ERAISE(-EINVAL);
@@ -2704,6 +2706,8 @@ static int _fs_release_tree(myst_fs_t* fs, const char* pathname)
             type = DT_REG;
         else if (S_ISLNK(mode))
             type = DT_LNK;
+        else if (S_ISFIFO(mode))
+            type = DT_FIFO;
         else
         {
             ERAISE(-EINVAL);

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -505,6 +505,19 @@ long myst_tcall(long n, long params[6])
             return myst_gcov(func, gcov_params);
         }
 #endif
+        case MYST_TCALL_MKFIFO:
+        {
+            const char* pathname = (const char*)x1;
+            mode_t mode = (mode_t)x2;
+            MYST_UNUSED uid_t host_euid = (uid_t)x3; /* ATTN: ignored */
+            MYST_UNUSED uid_t host_egid = (uid_t)x4; /* ATTN: ignored */
+            int ret;
+
+            if ((ret = mkfifo(pathname, mode)) < 0)
+                ret = -errno;
+
+            return ret;
+        }
         case SYS_ioctl:
         {
             int fd = (int)x1;

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -571,6 +571,14 @@ long myst_tcall(long n, long params[6])
             return myst_gcov(func, gcov_params);
         }
 #endif
+        case MYST_TCALL_MKFIFO:
+        {
+            const char* pathname = (const char*)x1;
+            mode_t mode = (mode_t)x2;
+            uid_t host_euid = (uid_t)x3;
+            uid_t host_egid = (uid_t)x4;
+            return myst_tcall_mkfifo(pathname, mode, host_euid, host_egid);
+        }
         case SYS_read:
         case SYS_write:
         case SYS_close:

--- a/tests/fs/fs.c
+++ b/tests/fs/fs.c
@@ -1032,6 +1032,19 @@ static void test_sync()
     _passed(__FUNCTION__);
 }
 
+static void test_mkfifo(void)
+{
+    const char path[] = "/tmp/myfifo";
+    struct stat statbuf;
+
+    assert(mkfifo(path, 0666) == 0);
+    assert(stat(path, &statbuf) == 0);
+    assert(S_ISFIFO(statbuf.st_mode));
+    assert(unlink(path) == 0);
+
+    _passed(__FUNCTION__);
+}
+
 int main(int argc, const char* argv[])
 {
     if (argc != 2)
@@ -1086,6 +1099,7 @@ int main(int argc, const char* argv[])
     test_o_excl();
     test_o_tmpfile_not_supp(argv[1]);
     test_sync();
+    test_mkfifo();
 
     printf("=== passed all tests (%s)\n", argv[0]);
 

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -946,6 +946,23 @@ int myst_load_fssig(const char* path, myst_fssig_t* fssig)
     return retval;
 }
 
+long myst_tcall_mkfifo(
+    const char* pathname,
+    mode_t mode,
+    uid_t host_euid,
+    gid_t host_egid)
+{
+    long retval = 0;
+
+    if (myst_mkfifo_ocall(&retval, pathname, mode, host_euid, host_egid) !=
+        OE_OK)
+    {
+        return -ENOSYS;
+    }
+
+    return retval;
+}
+
 OE_SET_ENCLAVE_SGX2(
     ENCLAVE_PRODUCT_ID,
     ENCLAVE_SECURITY_VERSION,

--- a/tools/myst/host/id.c
+++ b/tools/myst/host/id.c
@@ -1,0 +1,80 @@
+#include <syscall.h>
+
+#include <myst/eraise.h>
+#include <myst/id.h>
+
+long myst_change_identity(
+    uid_t euid,
+    gid_t egid,
+    myst_resuid_t* resuid,
+    myst_resgid_t* resgid)
+{
+    long ret = 0;
+
+    if (resuid)
+        *resuid = (myst_resuid_t)MYST_RESUID_INITIALIZER;
+
+    if (resgid)
+        *resgid = (myst_resgid_t)MYST_RESGID_INITIALIZER;
+
+    if (euid < 0 || egid < 0 || !resuid || !resgid)
+        ERAISE(-EINVAL);
+
+    if (syscall(SYS_getresuid, &resuid->ruid, &resuid->euid, &resuid->suid) !=
+        0)
+    {
+        ERAISE(-errno);
+    }
+
+    if (syscall(SYS_getresgid, &resgid->rgid, &resgid->egid, &resgid->sgid) !=
+        0)
+    {
+        ERAISE(-errno);
+    }
+
+    if (syscall(SYS_setresgid, -1, egid, -1) != 0)
+        ERAISE(-errno);
+
+    if (syscall(SYS_setresuid, -1, euid, -1) != 0)
+        ERAISE(-errno);
+
+done:
+
+    if (ret < 0)
+    {
+        myst_restore_identity(resuid, resgid);
+
+        if (resuid)
+            *resuid = (myst_resuid_t)MYST_RESUID_INITIALIZER;
+
+        if (resgid)
+            *resgid = (myst_resgid_t)MYST_RESGID_INITIALIZER;
+    }
+
+    return ret;
+}
+
+long myst_restore_identity(
+    const myst_resuid_t* resuid,
+    const myst_resgid_t* resgid)
+{
+    long ret = 0;
+
+    if (!resuid || !resgid)
+        ERAISE(-EINVAL);
+
+    if (resgid->rgid >= 0 && resgid->egid >= 0 && resgid->sgid >= 0 &&
+        syscall(SYS_setresgid, resgid->rgid, resgid->egid, resgid->sgid) != 0)
+    {
+        ERAISE(-errno);
+    }
+
+    if (resuid->ruid >= 0 && resuid->euid >= 0 && resuid->suid >= 0 &&
+        syscall(SYS_setresuid, resuid->ruid, resuid->euid, resuid->suid) != 0)
+    {
+        ERAISE(-errno);
+    }
+
+done:
+    return ret;
+}

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -1,8 +1,11 @@
 #define _GNU_SOURCE
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <myst/assume.h>
 #include <myst/defs.h>
+#include <myst/eraise.h>
+#include <myst/id.h>
 #include <sched.h>
 #include <stdint.h>
 #include <sys/epoll.h>

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -446,6 +446,12 @@ enclave
 
         long myst_fcntl_setlkw_ocall(int fd, [in] const struct flock* arg);
 
+        long myst_mkfifo_ocall(
+            [in, string] const char *pathname,
+            mode_t mode,
+            uid_t host_euid,
+            gid_t host_egid);
+
         // ATTN: If debugging support is excluded in certain build mode,
         // consider excluding relevant OCALL proxy code too.
 


### PR DESCRIPTION
Start implementation of FIFOs (named pipes). So far, this PR only implements ``mkfifo()`` for all three file system types: ``ramfs``, ``ext2fs``, and ``hostfs``.