### PR TITLE
Fix flaky clock tests

### DIFF
--- a/tests/clock/main.c
+++ b/tests/clock/main.c
@@ -23,7 +23,7 @@ static int is_sgx_target()
 static int test_clock_get_time(long reference)
 {
     struct timespec tp = {0};
-    long tolerance = NANO_IN_SECOND * 2; // 2s
+    long tolerance = NANO_IN_SECOND * 3L; // 3s
 
 #ifdef MYST_ENABLE_GCOV
     /* gcov slows down the app, so add another 1/2 second to the tolerance */


### PR DESCRIPTION
This PR fixes two problems with ``tests/clock``.
- The tolerance sometimes is too small when the system is heavily loaded (increased from 2 seconds to 3 seconds).
- The ``cpuclocks`` test was not waiting for the thread to start up, resulting in zero-valued TIDs that produced invalid clock ids.