### PR TITLE
Add syscall SYS_setsid(), enable tests/cpython:test_regrtest

### DIFF
--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -301,6 +301,8 @@ long myst_syscall_setuid(uid_t uid);
 long myst_syscall_getgid();
 long myst_syscall_setgid(gid_t gid);
 
+long myst_syscall_setsid();
+
 uid_t myst_syscall_geteuid();
 gid_t myst_syscall_getegid();
 

--- a/tests/cpython-tests/test_config_v3.8.11/tests.failed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.failed
@@ -30,7 +30,6 @@ test_pydoc
 test_random
 test_re
 test_readline
-test_regrtest
 test_resource
 test_runpy
 test_selectors

--- a/tests/cpython-tests/test_config_v3.8.11/tests.passed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.passed
@@ -245,6 +245,7 @@ test_queue
 test_quopri
 test_raise
 test_range
+test_regrtest
 test_repl
 test_reprlib
 test_richcmp

--- a/tests/cpython-tests/test_config_v3.9.7/tests.failed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.failed
@@ -32,7 +32,6 @@ test_pydoc
 test_random
 test_re
 test_readline
-test_regrtest
 test_resource
 test_runpy
 test_selectors

--- a/tests/cpython-tests/test_config_v3.9.7/tests.passed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.passed
@@ -246,6 +246,7 @@ test_queue
 test_quopri
 test_raise
 test_range
+test_regrtest
 test_repl
 test_reprlib
 test_richcmp


### PR DESCRIPTION
Implements setsid (man 2).
Enabled tests/cpython-tests:test_regrtest, which was initially failing due to missing syscall setsid.