### PR TITLE
Add impl. for __pthread_get_minstack glibc function`

### DIFF
--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -1118,6 +1118,19 @@ index b5845dd0..016dcfdd 100644
 -}
 +}
 \ No newline at end of file
+diff --git a/src/thread/pthread_attr_setstack.c b/src/thread/pthread_attr_setstack.c
+index 1eddcbd6..d3ec0363 100644
+--- a/src/thread/pthread_attr_setstack.c
++++ b/src/thread/pthread_attr_setstack.c
+@@ -7,3 +7,8 @@ int pthread_attr_setstack(pthread_attr_t *a, void *addr, size_t size)
+ 	a->_a_stacksize = size;
+ 	return 0;
+ }
++
++size_t __pthread_get_minstack(const pthread_attr_t *attr)
++{
++	return DEFAULT_STACK_SIZE;
++}
 diff --git a/src/thread/pthread_cancel.c b/src/thread/pthread_cancel.c
 index 2f9d5e97..e4d3d000 100644
 --- a/src/thread/pthread_cancel.c


### PR DESCRIPTION
### Summary
Adds support for pthread_get_minstack glibc function to get minimum stack size. Returns 128 KiB.
Used by ubuntu aspnetcore.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>