### PR TITLE
Interruptible syscalls part 2

### DIFF
--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -357,4 +357,12 @@ long myst_syscall_pause(void);
 
 long myst_syscall_interrupt_thread(int tid);
 
+/* interruptible by myst_syscall_interrupt_thread() */
+long myst_interruptible_syscall(
+    long n,       /* syscall number */
+    int fd,       /* file descriptor to be interrupted */
+    short events, /* events passed to ppoll() (POLLIN, POLLOUT) */
+    bool retry,   /* whether to retry the operation on EAGAIN/EINPROGRESS */
+    ...);
+
 #endif /* _MYST_SYSCALL_H */

--- a/target/shared/interrupt.c
+++ b/target/shared/interrupt.c
@@ -1,5 +1,13 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdarg.h>
 #include <sys/syscall.h>
+#include <unistd.h>
 
+#include <myst/eraise.h>
+#include <myst/syscall.h>
 #include <myst/tcall.h>
 #include <myst/thread.h>
 
@@ -9,6 +17,82 @@ long myst_tcall_interrupt_thread(pid_t tid)
 
     if (ret < 0)
         ret = -errno;
+
+    return ret;
+}
+
+long myst_interruptible_syscall(long n, int fd, short events, bool retry, ...)
+{
+    long ret = 0;
+    va_list ap;
+    int flags;
+
+    if (fd < 0)
+        ERAISE(-EINVAL);
+
+    va_start(ap, retry);
+    long a = va_arg(ap, long);
+    long b = va_arg(ap, long);
+    long c = va_arg(ap, long);
+    long d = va_arg(ap, long);
+    long e = va_arg(ap, long);
+    long f = va_arg(ap, long);
+    va_end(ap);
+
+    /* get the file status flags */
+    if ((flags = fcntl(fd, F_GETFL)) < 0)
+        ERAISE(-errno);
+
+    /* if fd is non-blocking, then perform syscall up front */
+    if ((flags & O_NONBLOCK))
+    {
+        if ((ret = syscall(n, a, b, c, d, e, f)) < 0)
+            ret = -errno;
+        goto done;
+    }
+
+    /* handle blocking fd */
+    for (;;)
+    {
+        /* atomically unblock signals during ppoll() call below */
+        sigset_t sigmask;
+        sigemptyset(&sigmask);
+
+        /* wait indefinitely for event or EINTR */
+        int poll_ret;
+        struct pollfd fds[1];
+        fds[0].fd = fd;
+        fds[0].events = events;
+        fds[0].revents = 0;
+
+        poll_ret = ppoll(fds, 1, NULL, &sigmask);
+
+        if (poll_ret < 0)
+            ERAISE(-errno);
+
+        /* if event occurred, then perform operation */
+        if (poll_ret == 1 && (fds[0].revents & events))
+        {
+            if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0)
+                ERAISE(-errno);
+
+            long syscall_ret = syscall(n, a, b, c, d, e, f);
+
+            if (fcntl(fd, F_SETFL, flags) < 0)
+                ERAISE(-errno);
+
+            if (syscall_ret >= 0)
+            {
+                ret = syscall_ret;
+                goto done;
+            }
+
+            if (!(retry && (errno == EAGAIN || errno == EINPROGRESS)))
+                ERAISE(-errno);
+        }
+    }
+
+done:
 
     return ret;
 }

--- a/tests/cpython-tests/Makefile
+++ b/tests/cpython-tests/Makefile
@@ -18,8 +18,7 @@ endif
 MPDB=$(TOP)/scripts/mpdb.py
 TESTFILE=tests.passed
 TEST = test_bz2
-TESTCASE = test_asynchat.TestAsynchat
-#TESTCASE = test_asynchat.TestAsynchat.test_close_when_done
+TESTCASE = test_socket.LinuxKernelCryptoAPI.test_aead_aes_gcm
 VER=3.9
 FS=ext2fs$(VER)
 

--- a/tests/eventfd/eventfd.c
+++ b/tests/eventfd/eventfd.c
@@ -29,7 +29,11 @@ static void* _read_thread(void* arg)
         if (slow)
             sleep_msec(3);
 
-        ssize_t n = read(fd, &val, sizeof(val));
+        ssize_t n;
+
+        while (((n = read(fd, &val, sizeof(val))) < 0) && errno == EINTR)
+            ;
+
         assert(n == sizeof(val));
     }
 
@@ -158,7 +162,12 @@ void test2(void)
     const uint64_t expect = ((N - 1) * ((N - 1) + 1)) / 2;
 
     uint64_t val = 0;
-    assert(read(fd, &val, sizeof(val)) == sizeof(uint64_t));
+    ssize_t n;
+
+    while ((n = read(fd, &val, sizeof(val))) < 0 && errno == EINTR)
+        ;
+
+    assert(n == sizeof(uint64_t));
     assert(val == expect);
 
     printf("=== passed test (%s)\n", __FUNCTION__);

--- a/tests/interrupt/interrupt.c
+++ b/tests/interrupt/interrupt.c
@@ -3,12 +3,14 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <netinet/in.h>
 #include <poll.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/epoll.h>
+#include <sys/socket.h>
 #include <syscall.h>
 #include <unistd.h>
 
@@ -302,6 +304,116 @@ static void _test_poll(void)
 /*
 **==============================================================================
 **
+** _test_accept()
+**
+**==============================================================================
+*/
+
+static const uint16_t port = 14321;
+
+struct test_pipe_read_arg
+{
+    _Atomic(pid_t) tid;
+    size_t num_interruptions;
+    size_t max_interruptions;
+};
+
+static void* _test_accept_thread(void* arg_)
+{
+    struct test_pipe_read_arg* arg = (struct test_pipe_read_arg*)arg_;
+    static time_t sec = 1;
+    struct timespec req = {.tv_sec = sec, .tv_nsec = 0};
+    struct timespec ts0;
+    struct timespec ts1;
+    size_t n = 0;
+    int fds[2];
+    int lsock;
+
+    (void)arg;
+
+    assert(pipe(fds) == 0);
+
+    /* unblock the parent thread that is waiting on the tid */
+    arg->tid = syscall(SYS_gettid);
+
+    assert((lsock = socket(AF_INET, SOCK_STREAM, 0)) >= 0);
+
+    /* reuse the server address */
+    {
+        const int opt = 1;
+        const socklen_t len = sizeof(opt);
+        int r = setsockopt(lsock, SOL_SOCKET, SO_REUSEADDR, (void*)&opt, len);
+        assert(r == 0);
+    }
+
+    {
+        struct sockaddr_in addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = htons(port);
+        assert(bind(lsock, (struct sockaddr*)&addr, sizeof(addr)) == 0);
+    }
+
+    assert(listen(lsock, 10) == 0);
+
+    printf("=== thread sleeping...\n");
+
+    for (size_t i = 0; i < arg->max_interruptions; i++)
+    {
+        char buf[16];
+        struct sockaddr_in addr;
+        socklen_t addrlen = sizeof(addr);
+        assert(accept4(lsock, (struct sockaddr*)NULL, &addrlen, 0) == -1);
+
+        if (errno == EINTR)
+        {
+            arg->num_interruptions++;
+        }
+        else
+        {
+            assert(0);
+        }
+    }
+
+    return arg;
+}
+
+static void _test_accept(void)
+{
+    pthread_t th;
+    struct test_pipe_read_arg arg;
+    const size_t num_interruptions = 100;
+
+    memset(&arg, 0, sizeof(arg));
+    arg.max_interruptions = num_interruptions;
+
+    int ret = pthread_create(&th, NULL, _test_accept_thread, &arg);
+    assert(ret == 0);
+
+    /* wait until the tid has been set by the thread */
+    while (arg.tid == 0)
+        __asm__ __volatile__("pause" : : : "memory");
+
+    /* interrupt the thread multiple times */
+    for (size_t i = 0; i < num_interruptions; i++)
+    {
+        sleep_msec(10);
+        syscall(SYS_myst_interrupt_thread, arg.tid);
+    }
+
+    /* join the thread */
+    pthread_join(th, NULL);
+
+    assert(arg.num_interruptions > 0);
+    assert(arg.num_interruptions <= num_interruptions);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+/*
+**==============================================================================
+**
 ** main()
 **
 **==============================================================================
@@ -320,6 +432,8 @@ int main(int argc, const char* argv[])
 #if (MYST_INTERRUPT_POLL_WITH_SIGNAL == 1)
     _test_poll();
 #endif
+
+    _test_accept();
 
     printf("=== passed all tests (%s)\n", argv[0]);
 

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -179,8 +179,7 @@ enclave
             int flags,
             [out, size=src_addr_size] struct sockaddr* src_addr,
             [in, out] socklen_t* addrlen_out,
-            socklen_t src_addr_size)
-            transition_using_threads;
+            socklen_t src_addr_size);
 
         long myst_sendto_ocall(
             int sockfd,
@@ -188,8 +187,7 @@ enclave
             size_t len,
             int flags,
             [in, size=addrlen] const struct sockaddr* dest_addr,
-            socklen_t addrlen)
-            transition_using_threads;
+            socklen_t addrlen);
 
         long myst_socket_ocall(int domain, int type, int protocol);
 
@@ -211,8 +209,7 @@ enclave
             socklen_t msg_controllen,
             int msg_flags,
             /* -- end struct msghdr -- */
-            int flags)
-            transition_using_threads;
+            int flags);
 
         long myst_recvmsg_ocall(
             int sockfd,
@@ -227,8 +224,7 @@ enclave
             [out] socklen_t* msg_controllen_out,
             [out] int* msg_flags,
             /* -- end struct msghdr -- */
-            int flags)
-            transition_using_threads;
+            int flags);
 
         long myst_shutdown_ocall(int sockfd, int how);
 
@@ -304,14 +300,12 @@ enclave
         long myst_read_ocall(
             int fd,
             [out, size=count] void* buf,
-            size_t count)
-            transition_using_threads;
+            size_t count);
 
         long myst_write_ocall(
             int fd,
             [in, size=count] const void* buf,
-            size_t count)
-            transition_using_threads;
+            size_t count);
 
         long myst_close_ocall(int fd);
 


### PR DESCRIPTION
This PR permits the following operations to be interrupted when blocked on the host.
- read
- write
- sendto
- recvfrom
- sendmsg
- recvmsg
- accept
- connect