### PR TITLE
Use PR merge instead of head

### DIFF
--- a/.jenkins/nightly.Jenkinsfile
+++ b/.jenkins/nightly.Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
                                     extensions: [],
                                     userRemoteConfigs: [[
                                         url: 'https://github.com/deislabs/mystikos',
-                                        refspec: "+refs/pull/${PULL_REQUEST_ID}/head:refs/remotes/origin/pr/${PULL_REQUEST_ID}"
+                                        refspec: "+refs/pull/${PULL_REQUEST_ID}/merge:refs/remotes/origin/pr/${PULL_REQUEST_ID}"
                                     ]]
                                 ])
                             } else {

--- a/.jenkins/tests.Jenkinsfile
+++ b/.jenkins/tests.Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                                     extensions: [],
                                     userRemoteConfigs: [[
                                         url: 'https://github.com/deislabs/mystikos',
-                                        refspec: "+refs/pull/${PULL_REQUEST_ID}/head:refs/remotes/origin/pr/${PULL_REQUEST_ID}"
+                                        refspec: "+refs/pull/${PULL_REQUEST_ID}/merge:refs/remotes/origin/pr/${PULL_REQUEST_ID}"
                                     ]]
                                 ])
                             } else {


### PR DESCRIPTION
This changes the _manual_ pull request jobs and nightly jobs to check out a PR merge instead of head.
The automated pull request builds does not need to change as it already has the desired behaviour.