### PR TITLE
remove dotnet coreclr P0 and P1 test suites from ADO nightly

### DIFF
--- a/.azure_pipelines/ci-pipeline-makefile-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-makefile-nightly.yml
@@ -15,7 +15,7 @@ jobs:
   # 10m build
   # 15m basic/unit tests
   # 1-4h solution tests(based on which are enabled)
-  timeoutInMinutes: 540
+  timeoutInMinutes: 300
   pool: '1804DC4CCagentpool'
 
   steps:
@@ -78,23 +78,6 @@ jobs:
         SSR_PKEY: $(MHSM_SSR_PKEY)
         MYST_DO_CLEANUP: 1
         MYST_NIGHTLY_TEST: 1
-
-    # run dotnet P0 solution tests
-    - script: |
-        export PATH="$PATH:$(pwd)/mystikos/bin"
-        make tests -C $(Build.SourcesDirectory)/solutions/coreclr
-      displayName: 'run dotnet 5 P0 test suite'
-      continueOnError: true
-      enabled: true
-      workingDirectory: $(Build.SourcesDirectory)
-
-    # run dotnet 5 P1 test suite
-    - script: |
-        make tests -C $(Build.SourcesDirectory)/solutions/coreclr-p1
-      displayName: 'run dotnet 5 P1 test suite'
-      continueOnError: true
-      enabled: true
-      workingDirectory: $(Build.SourcesDirectory)
 
     # Mini-clean up before running azure tests.
     - script: |


### PR DESCRIPTION
The pipeline ci-pipeline-dotnet-test-suite.yml is scheduled to run nightly to test the same.

mystikos-dotnet-tests-pipeline - https://openenclave.visualstudio.com/ACC-Services/_build?definitionId=104&_a=summary

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>