### PR TITLE
Remove test sets not in cpython3.8.11 test suite, add workaround for cpython3.9.7 test suite

### DIFF
--- a/tests/cpython-tests/Dockerfile
+++ b/tests/cpython-tests/Dockerfile
@@ -13,11 +13,16 @@ RUN ./configure --with-pydebug && make -j -s
 WORKDIR /
 
 #Copy test lists
-COPY ./test_config_$CPYTHON_VERSION /tests.* /
+COPY ./test_config_$CPYTHON_VERSION/tests.* /
 
+#workaround - Mystikos does not support Ubunut's default shell dash
 RUN ln -sf /bin/bash /bin/sh
 
-RUN cp /usr/bin/lsb_release /bin/
+#workaround - lsb-core package installation doe snot create /bin/lsb_release symbolic link
+RUN ln -sf /usr/bin/lsb_release /bin/lsb_release
+
+#workaround - lsb_release invokes /usr/bin/python3. Ubuntu's default python executable is not PIE, not supported in Mystikos
+RUN ln -sf /cpython/python /usr/bin/python3
 
 # Copy Mystikos pdb
 COPY ./mpdb.py /cpython/mpdb.py

--- a/tests/cpython-tests/Makefile
+++ b/tests/cpython-tests/Makefile
@@ -23,8 +23,8 @@ TESTCASE = test_asynchat.TestAsynchat
 VER=3.9
 FS=ext2fs$(VER)
 
-# Set timeout to 25 mins (to run both the python3.8 test suite and the python3.9 test suite)
-export TIMEOUT=1500
+# Set timeout to 50 mins (to run both the python3.8 test suite and the python3.9 test suite)
+export TIMEOUT=3000
 
 all: ext2fs3.8 ext2fs3.9
 

--- a/tests/cpython-tests/test_config_v3.8.11/tests.failed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.failed
@@ -5,6 +5,7 @@ test_asyncore
 test_c_locale_coercion
 test_cmd_line
 test_compileall
+test_concurrent_futures
 test_ctypes
 test_distutils
 test_eintr
@@ -17,9 +18,14 @@ test_gdb
 test_glob
 test_import
 test_importlib
+test_ioctl
 test_locale
 test_logging
 test_mailbox
+test_multiprocessing_fork
+test_multiprocessing_forkserver
+test_multiprocessing_main_handling
+test_multiprocessing_spawn
 test_openpty
 test_os
 test_pathlib
@@ -30,6 +36,7 @@ test_pydoc
 test_random
 test_re
 test_readline
+test_regrtest
 test_resource
 test_runpy
 test_selectors
@@ -53,5 +60,6 @@ test_uuid
 test_venv
 test_wait3
 test_wait4
+test_weakref
 test_wsgiref
 test_zipfile

--- a/tests/cpython-tests/test_config_v3.8.11/tests.passed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.passed
@@ -62,7 +62,6 @@ test_colorsys
 test_compare
 test_compile
 test_complex
-test_concurrent_futures
 test_configparser
 test_contains
 test_context
@@ -136,7 +135,6 @@ test_gc
 test_gzip
 test_generator_stop
 test_generators
-test_genericalias
 test_genericclass
 test_genericpath
 test_genexps
@@ -146,7 +144,6 @@ test_getpass
 test_gettext
 test_global
 test_grammar
-test_graphlib
 test_grp
 test_hash
 test_hashlib
@@ -167,7 +164,6 @@ test_inspect
 test_int
 test_int_literal
 test_io
-test_ioctl
 test_ipaddress
 test_isinstance
 test_iter
@@ -199,10 +195,6 @@ test_module
 test_modulefinder
 test_msilib
 test_multibytecodec
-test_multiprocessing_fork
-test_multiprocessing_forkserver
-test_multiprocessing_main_handling
-test_multiprocessing_spawn
 test_named_expressions
 test_netrc
 test_nis
@@ -245,7 +237,6 @@ test_queue
 test_quopri
 test_raise
 test_range
-test_regrtest
 test_repl
 test_reprlib
 test_richcmp
@@ -341,7 +332,6 @@ test_utf8source
 test_uu
 test_warnings
 test_wave
-test_weakref
 test_weakset
 test_webbrowser
 test_winconsoleio

--- a/tests/cpython-tests/test_config_v3.9.7/tests.failed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.failed
@@ -5,6 +5,7 @@ test_asyncore
 test_c_locale_coercion
 test_cmd_line
 test_compileall
+test_concurrent_futures
 test_ctypes
 test_distutils
 test_eintr
@@ -17,10 +18,14 @@ test_gdb
 test_glob
 test_import
 test_importlib
-test_json
+test_ioctl
 test_locale
 test_logging
 test_mailbox
+test_multiprocessing_fork
+test_multiprocessing_forkserver
+test_multiprocessing_main_handling
+test_multiprocessing_spawn
 test_openpty
 test_os
 test_pathlib
@@ -32,6 +37,7 @@ test_pydoc
 test_random
 test_re
 test_readline
+test_regrtest
 test_resource
 test_runpy
 test_selectors
@@ -55,5 +61,6 @@ test_uuid
 test_venv
 test_wait3
 test_wait4
+test_weakref
 test_wsgiref
 test_zipfile

--- a/tests/cpython-tests/test_config_v3.9.7/tests.passed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.passed
@@ -62,7 +62,6 @@ test_colorsys
 test_compare
 test_compile
 test_complex
-test_concurrent_futures
 test_configparser
 test_contains
 test_context
@@ -167,7 +166,6 @@ test_inspect
 test_int
 test_int_literal
 test_io
-test_ioctl
 test_ipaddress
 test_isinstance
 test_iter
@@ -199,10 +197,6 @@ test_module
 test_modulefinder
 test_msilib
 test_multibytecodec
-test_multiprocessing_fork
-test_multiprocessing_forkserver
-test_multiprocessing_main_handling
-test_multiprocessing_spawn
 test_named_expressions
 test_netrc
 test_nis
@@ -246,7 +240,6 @@ test_queue
 test_quopri
 test_raise
 test_range
-test_regrtest
 test_repl
 test_reprlib
 test_richcmp
@@ -343,7 +336,6 @@ test_utf8source
 test_uu
 test_warnings
 test_wave
-test_weakref
 test_weakset
 test_webbrowser
 test_winconsoleio

--- a/tests/cpython-tests/tests.skipped
+++ b/tests/cpython-tests/tests.skipped
@@ -1,0 +1,26 @@
+The following test sets are enabled, but skipped by the cpython test framework:
+
+test_curses, 'curses' resource not enabled, for terminal handling, https://docs.python.org/3/library/curses.html
+test_devpoll, Solaris only
+test_idle, No module named '_tkinter', for Tcl/TK GUI https://docs.python.org/3/library/tkinter.html
+test_kqueue, BSD only
+test_msilib, Windows only
+test_nis, No module named '_nis', for Sun's Network Information Service
+test_ossaudiodev, 'audio' resource not enabled
+test_smtpnet, 'network' resource not enabled
+test_socketserver, 'network' resource not enabled
+test_startfile, Windows only
+test_tcl, No module named '_tkinter'
+test_timeout, 'network' resource not enabled
+test_tix, No module named '_tkinter'
+test_tk, No module named '_tkinter'
+test_ttk_guionly, No module named '_tkinter'
+test_ttk_textonly, No module named '_tkinter'
+test_turtle, No module named '_tkinter'
+test_urllib2net, 'network' resource not enabled
+test_urllibnet, 'network' resource not enabled
+test_winconsoleio, Windows only
+test_winreg, Windows only
+test_winsound, Windows only
+test_xmlrpc_net, 'network' resource not enabled
+test_zipfile64, test requires loads of disk-space bytes and a long time to run


### PR DESCRIPTION
The previous successful run of tests/cpython_test locally or in pipeline did not run all enabled tests. Somehow the obsolete partial "tests.passed" file in tests/cpython_test directory override the configuration-specific (cpython3.8 and cpython3.9) files. As a result, only part of the enabled tests were run. After a recent PR removed the obsolete file, the full list of the enabled tests were used, and the pipeline run reported failure.

This PR includes:
  - Remove mistakenly included test sets that are not in cpython3.8.11 test suite
  - Temporarily disabled test_regrtest and test_weakre for cpython3.9.7.
    They seem to hang running in the test suites, but passed when run individually
  - Moved a set of tests to failed list. The tests were enabled but skipped due to lack
    of /dev/shm support
  - Added a skipped list, for test sets enabled but skipped by the python test framework.

Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>