### PR TITLE
Parallel Test Execution

### DIFF
--- a/.jenkins/pipelines/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/azure-sdk-tests.Jenkinsfile
@@ -1,0 +1,99 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC4'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        string(name: "BUILD_RESOURCES", description: "prebuilt resources stash from parent node")
+    }
+    environment {
+        MYST_SCRIPTS =    "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS = "${WORKSPACE}/.jenkins/scripts"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+        MYST_NIGHTLY_TEST = 1
+        MYST_ENABLE_GCOV = 1
+    }
+    stages {
+        stage("Cleanup files") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+            }
+        }
+        stage('Init Config') {
+            steps {
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Pull build resource') {
+            steps {
+                azureDownload(
+                    downloadType: 'container',
+                    containerName: 'mystikos-build-resources',
+                    includeFilesPattern: "${BUILD_RESOURCES}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+                sh "tar -xzf ${BUILD_RESOURCES}"
+            }
+        }
+        stage('Setup Solutions Access') {
+            steps {
+                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
+                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
+                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
+                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
+                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
+                    sh """
+                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
+                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
+                       """
+                }
+            }
+        }
+        stage('Run Azure SDK tests') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'servicePrincipalId'),
+                                     string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'tenantId'),
+                                     string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'servicePrincipalKey'),
+                                     string(credentialsId: 'mystikos-ci-keyvault-url', variable: 'AZURE_KEYVAULT_URL'),
+                                     string(credentialsId: 'mystikos-ci-keyvault-url', variable: 'AZURE_TEST_KEYVAULT_URL'),
+                                     string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                                     string(credentialsId: 'mystikos-storage-mystikosciacc-connectionstring', variable: 'STANDARD_STORAGE_CONNECTION_STRING')]) {
+                        sh """
+                           ${JENKINS_SCRIPTS}/global/run-azure-tests.sh \
+                             ${WORKSPACE}/tests/azure-sdk-for-cpp  \
+                             ${WORKSPACE}/solutions/dotnet_azure_sdk
+                           """
+                    }
+                }
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/dotnet-tests.Jenkinsfile
+++ b/.jenkins/pipelines/dotnet-tests.Jenkinsfile
@@ -1,0 +1,89 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC4'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        string(name: "BUILD_RESOURCES", description: "prebuilt resources stash from parent node")
+    }
+    environment {
+        MYST_SCRIPTS =    "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS = "${WORKSPACE}/.jenkins/scripts"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+        MYST_NIGHTLY_TEST = 1
+        MYST_ENABLE_GCOV = 1
+    }
+    stages {
+        stage("Cleanup files") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+            }
+        }
+        stage('Init Config') {
+            steps {
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Pull build resource') {
+            steps {
+                azureDownload(
+                    downloadType: 'container',
+                    containerName: 'mystikos-build-resources',
+                    includeFilesPattern: "${BUILD_RESOURCES}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+                sh "tar -xzf ${BUILD_RESOURCES}"
+            }
+        } 
+        stage('Setup Solutions Access') {
+            steps {
+                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
+                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
+                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
+                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
+                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
+                    sh """
+                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
+                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
+                       """
+                }
+            }
+        }
+        stage('Run DotNet 5 Test Suite') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    sh """
+                       make tests -C ${WORKSPACE}/solutions/coreclr
+                       """
+                }
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/pipeline-tests.Jenkinsfile
+++ b/.jenkins/pipelines/pipeline-tests.Jenkinsfile
@@ -1,0 +1,143 @@
+/* A Jenkins pipeline that will handle code coverage and nightly tests
+*  These are the original pipelines:
+*  https://github.com/deislabs/mystikos/blob/main/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
+*/
+
+pipeline {
+    agent {
+        label 'ACC-1804-DC8-build-machine'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        choice(name: "TEST_CONFIG", choices:['Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        choice(name: "REGION", choices:['useast', 'canadacentral'], description: "Azure region for SQL test")
+    }
+    environment {
+        MYST_SCRIPTS =      "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
+        MYST_NIGHTLY_TEST = 1
+        MYST_ENABLE_GCOV =  1
+        BUILD_RESOURCES =   "build-resources-${GIT_COMMIT[0..7]}"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+    }
+    stages {
+        stage("Initialize Workspace") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+                azureDownload(
+                    downloadType: 'container',
+                    containerName: 'mystikos-build-resources',
+                    includeFilesPattern: "${BUILD_RESOURCES}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+            }
+        }
+        stage('Init Config') {
+            when {
+                not { expression { return fileExists("${BUILD_RESOURCES}") }}
+            }
+            steps {
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Build repo source') {
+            when {
+                not { expression { return fileExists("${BUILD_RESOURCES}") }}
+            }
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/build-repo-source.sh
+                   tar -zcf ${BUILD_RESOURCES} build
+                   """
+            }
+        }
+        stage('Upload build resources') {
+            steps {
+                sh """
+                   echo "Uploading build resources: ${BUILD_RESOURCES}"
+                   """
+                // Lifecycle management > build-resources-retention
+                // Build resources are automatically deleted 2 days
+                // the last modification
+                azureUpload(
+                    containerName: 'mystikos-build-resources',
+                    storageType: 'container',
+                    uploadZips: true,
+                    filesPath: "${BUILD_RESOURCES}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+            }
+        }
+        stage('Run Tests') {
+            parallel {
+                stage("Run Unit Tests") {
+                    steps {
+                        build job: "Helper-Pipelines/Unit-Test-Pipeline",
+                        parameters: [
+                            string(name: "REPOSITORY", value: REPOSITORY),
+                            string(name: "BRANCH", value: BRANCH),
+                            string(name: "TEST_CONFIG", value: TEST_CONFIG),
+                            string(name: "BUILD_RESOURCES", value: BUILD_RESOURCES)
+                        ]
+                    }
+                }
+                stage("Run SQL Tests") {
+                    steps {
+                        build job: "Helper-Pipelines/SQL-Test-Pipeline",
+                        parameters: [
+                            string(name: "REPOSITORY", value: REPOSITORY),
+                            string(name: "BRANCH", value: BRANCH),
+                            string(name: "REGION", value: REGION),
+                            string(name: "BUILD_RESOURCES", value: BUILD_RESOURCES)
+                        ]
+                    }
+                }
+                stage("Run DotNet Tests") {
+                    steps {
+                        build job: "Helper-Pipelines/DotNet-Test-Pipeline",
+                        parameters: [
+                            string(name: "REPOSITORY", value: REPOSITORY),
+                            string(name: "BRANCH", value: BRANCH),
+                            string(name: "BUILD_RESOURCES", value: BUILD_RESOURCES)
+                        ]
+                    }
+                }
+                stage("Run Azure SDK Tests") {
+                    steps {
+                        build job: "Helper-Pipelines/Azure-SDK-Test-Pipeline",
+                        parameters: [
+                            string(name: "REPOSITORY", value: REPOSITORY),
+                            string(name: "BRANCH", value: BRANCH),
+                            string(name: "BUILD_RESOURCES", value: BUILD_RESOURCES)
+                        ]
+                    }
+                }
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/sql-tests.Jenkinsfile
+++ b/.jenkins/pipelines/sql-tests.Jenkinsfile
@@ -1,0 +1,102 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC4'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        choice(name: "REGION", choices:['useast', 'canadacentral'], description: "Azure region for SQL test")
+        string(name: "BUILD_RESOURCES", description: "prebuilt resources stash from parent node")
+    }
+    environment {
+        MYST_SCRIPTS =    "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS = "${WORKSPACE}/.jenkins/scripts"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+        MYST_NIGHTLY_TEST = 1
+        MYST_ENABLE_GCOV = 1
+    }
+    stages {
+        stage("Cleanup files") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+            }
+        }
+        stage('Init Config') {
+            steps {
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Pull build resource') {
+            steps {
+                azureDownload(
+                    downloadType: 'container',
+                    containerName: 'mystikos-build-resources',
+                    includeFilesPattern: "${BUILD_RESOURCES}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+                sh "tar -xzf ${BUILD_RESOURCES}"
+            }
+        }
+        stage('Setup Solutions Access') {
+            steps {
+                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
+                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
+                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
+                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
+                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
+                    sh """
+                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
+                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
+                       """
+                }
+            }
+        }
+        stage('Run SQL Solution') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    withCredentials([string(credentialsId: "mystikos-sql-db-name-${REGION}", variable: 'DB_NAME'),
+                                     string(credentialsId: "mystikos-sql-db-server-name-${REGION}", variable: 'DB_SERVER_NAME'),
+                                     string(credentialsId: "mystikos-maa-url-${REGION}", variable: 'MAA_URL'),
+                                     string(credentialsId: 'mystikos-managed-identity-objectid', variable: 'DB_USERID'),
+                                     string(credentialsId: 'mystikos-mhsm-client-secret', variable: 'CLIENT_SECRET'),
+                                     string(credentialsId: 'mystikos-mhsm-client-id', variable: 'CLIENT_ID'),
+                                     string(credentialsId: 'mystikos-mhsm-app-id', variable: 'APP_ID'),
+                                     string(credentialsId: 'mystikos-mhsm-aad-url', variable: 'MHSM_AAD_URL'),
+                                     string(credentialsId: 'mystikos-mhsm-ssr-pkey', variable: 'SSR_PKEY')
+                    ]) {
+                        sh """
+                           echo "Running in ${REGION}"
+                           make tests -C ${WORKSPACE}/solutions
+                           """
+                    }
+                }
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/unit-tests.Jenkinsfile
+++ b/.jenkins/pipelines/unit-tests.Jenkinsfile
@@ -1,0 +1,115 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC8'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY")
+        string(name: "BRANCH", description: "Branch to build")
+        string(name: "TEST_CONFIG", description: "Test configuration to execute")
+        string(name: "BUILD_RESOURCES", description: "prebuilt resources stash from parent node")
+    }
+    environment {
+        MYST_SCRIPTS =    "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS = "${WORKSPACE}/.jenkins/scripts"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+        MYST_NIGHTLY_TEST = 1
+        MYST_ENABLE_GCOV = 1
+    }
+    stages {
+        stage("Cleanup files") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+            }
+        }
+        stage('Init Config') {
+            steps {
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Init Code Coverage Config') {
+            when {
+                expression { params.TEST_CONFIG == 'Code Coverage' }
+            }
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/code-coverage/init-install.sh
+                   """
+            }
+        }
+        stage('Pull build resource') {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/make-repo-source.sh
+                   """
+            }
+        }
+        stage('Run all tests') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    sh """
+                       ${JENKINS_SCRIPTS}/global/make-tests.sh
+                       """
+                }
+            }
+        }
+        stage('Measure Code Coverage') {
+            when {
+                expression { params.TEST_CONFIG == 'Code Coverage' }
+            }
+            steps {
+                sh """
+                   ${MYST_SCRIPTS}/myst_cc
+                   """
+            }
+        }
+        stage('Report Code Coverage') {
+            when {
+                expression { params.TEST_CONFIG == 'Code Coverage' }
+            }
+            steps {
+                script {
+                    LCOV_DIR="mystikos-cc-${env.GIT_COMMIT}"
+                }
+
+                sh """
+                   mkdir ${LCOV_DIR}
+                   mv lcov* ${LCOV_DIR}
+                   tar -zcvf ${LCOV_DIR}.tar.gz ${LCOV_DIR}
+                   """
+
+                azureUpload(
+                    containerName: 'mystikos-code-coverage',
+                    storageType: 'container',
+                    uploadZips: true,
+                    filesPath: "${LCOV_DIR}.tar.gz",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/scripts/global/build-repo-source.sh
+++ b/.jenkins/scripts/global/build-repo-source.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+make distclean
+make -j build
+
+rm build/bin/myst-lldb build/bin/myst-gdb
+cp build/openenclave/bin/oelldb build/bin/myst-lldb
+cp build/openenclave/bin/oegdb build/bin/myst-gdb


### PR DESCRIPTION
Parallel test execution workflow:

1. Run `make build` on DC8 node to improve build time from ~30 minutes to under 15 minutes. The resulting build folder will be used for the solutions tests.
2a. The solutions tests (SQL, Azure SDK, and DotNet) will download the prebuilt `build` folder, and run the respective tests. These tests are built on DC4 nodes, as test runs on DC8 nodes did not show much improvements.
2b. Due to some build bits using absolute paths, the build folder will need to rebuilt in the node running the unit tests. Tests will be built and ran on a DC8 node as the build time is reduced by ~20 minutes, and the test runtime is further reduced by another ~20 minutes. Code coverage analysis will run if enabled.

Running the equivalent of the nightly/code coverage build in the manner described above reduces build/run time from ~5 hours, to ~2 hours. Though the total compute runtime is the same, (Unit tests: ~1 hour 40 minutes, Azure SDK: ~25 minutes, DotNet: ~1 hour 30 minutes, SQL:  ~1 hour 5 minutes, and the initial repo source build: ~ 15 minutes), the rate-determining step is the slowest build.

The main trade-off with running the tests in parallel is the number of cores used for a given run. Instead of using a single DC4 instance for the whole run, one DC8 instance is used for ~1 hour 40 minutes, and three DC4 instances are used between 20 minutes to 1.5 hours.

To further expedite the build process, I introduced the use of a DC8 instance which will be used for the initial build, and is kept alive as long as it's been used within the past hour (@CyanDevs I'd especially like your feedback on this). This reduces the build process by several minutes it usually takes to create an instance; this change is more focused on the user experience.