### PR TITLE
Parallel Test Execution

### DIFF
--- a/.jenkins/pipelines/code-coverage.Jenkinsfile
+++ b/.jenkins/pipelines/code-coverage.Jenkinsfile
@@ -1,0 +1,88 @@
+/* A Jenkins pipeline that will handle code coverage and nightly tests
+*  These are the original pipelines:
+*  https://github.com/deislabs/mystikos/blob/main/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
+*/
+
+pipeline {
+    agent {
+        label 'ACC-1804-DC2'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        choice(name: "REGION", choices:['useast', 'canadacentral'], description: "Azure region for SQL test")
+    }
+    stages {
+        stage('Run Tests') {
+            parallel {
+                stage("Run Unit Tests") {
+                    steps {
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        build job: "Standalone-Pipelines/Unit-Test-Pipeline",
+                        parameters: [
+                            string(name: "REPOSITORY", value: REPOSITORY),
+                            string(name: "BRANCH", value: BRANCH),
+                            string(name: "TEST_CONFIG", value: "Code Coverage"),
+                            string(name: "COMMIT_SYNC", value: GIT_COMMIT)
+                        ]
+                    }}
+                }
+                stage("Run SQL Tests") {
+                    steps {
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        build job: "Standalone-Pipelines/SQL-Test-Pipeline",
+                        parameters: [
+                            string(name: "REPOSITORY", value: REPOSITORY),
+                            string(name: "BRANCH", value: BRANCH),
+                            string(name: "TEST_CONFIG", value: "Code Coverage"),
+                            string(name: "REGION", value: REGION),
+                            string(name: "COMMIT_SYNC", value: GIT_COMMIT)
+                        ]
+                    }}
+                }
+                stage("Run DotNet Tests") {
+                    steps {
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        build job: "Standalone-Pipelines/DotNet-Test-Pipeline",
+                        parameters: [
+                            string(name: "REPOSITORY", value: REPOSITORY),
+                            string(name: "BRANCH", value: BRANCH),
+                            string(name: "TEST_CONFIG", value: "Code Coverage"),
+                            string(name: "COMMIT_SYNC", value: GIT_COMMIT)
+                        ]
+                    }}
+                }
+                stage("Run Azure SDK Tests") {
+                    steps {
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        build job: "Standalone-Pipelines/Azure-SDK-Test-Pipeline",
+                        parameters: [
+                            string(name: "REPOSITORY", value: REPOSITORY),
+                            string(name: "BRANCH", value: BRANCH),
+                            string(name: "TEST_CONFIG", value: "Code Coverage"),
+                            string(name: "COMMIT_SYNC", value: GIT_COMMIT)
+                        ]
+                    }}
+                }
+            }
+        }
+        stage('Measure and report code coverage') {
+            steps {
+                build job: "Standalone-Pipelines/Measure-Code-Coverage",
+                parameters: [
+                    string(name: "REPOSITORY", value: REPOSITORY),
+                    string(name: "BRANCH", value: BRANCH),
+                    string(name: "COMMIT_ID", value: GIT_COMMIT[0..7])
+                ]
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -1,0 +1,130 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC4'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        choice(name: "TEST_CONFIG", choices:['None','Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        string(name: "COMMIT_SYNC", description: "optional - used to sync outputs of parallel jobs")
+    }
+    environment {
+        MYST_SCRIPTS =      "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
+        MYST_NIGHTLY_TEST = "${TEST_CONFIG == 'Nightly' || TEST_CONFIG == 'Code Coverage' ? 1 : ''}"
+        MYST_ENABLE_GCOV =  "${TEST_CONFIG == 'Code Coverage' ? 1 : ''}"
+        TEST_TYPE =         "sdk"
+        LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+    }
+    stages {
+        stage("Cleanup files") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+            }
+        }
+        stage('Verify commit sync') {
+            when { allOf {
+                expression { params.COMMIT_SYNC != "" }
+                expression { params.COMMIT_SYNC != GIT_COMMIT }
+            }}
+            steps {
+                script {
+                    currentBuild.result = 'ABORTED'
+                    error("Aborting build: mismatched commit - commit($GIT_COMMIT), expected(${COMMIT_SYNC})")
+                }
+            }
+        }
+        stage('Init Config') {
+            steps {
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Build repo source') {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/make-world.sh
+                   """
+            }
+        }
+        stage('Setup Solutions Access') {
+            steps {
+                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
+                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
+                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
+                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
+                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
+                    sh """
+                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
+                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
+                       """
+                }
+            }
+        }
+        stage('Run Azure SDK tests') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'servicePrincipalId'),
+                                     string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'tenantId'),
+                                     string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'servicePrincipalKey'),
+                                     string(credentialsId: 'mystikos-ci-keyvault-url', variable: 'AZURE_KEYVAULT_URL'),
+                                     string(credentialsId: 'mystikos-ci-keyvault-url', variable: 'AZURE_TEST_KEYVAULT_URL'),
+                                     string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                                     string(credentialsId: 'mystikos-storage-mystikosciacc-connectionstring', variable: 'STANDARD_STORAGE_CONNECTION_STRING')]) {
+                        sh """
+                           ${JENKINS_SCRIPTS}/global/run-azure-tests.sh \
+                             ${WORKSPACE}/tests/azure-sdk-for-cpp  \
+                             ${WORKSPACE}/solutions/dotnet_azure_sdk
+                           """
+                    }
+                }
+            }
+        }
+        stage('Upload code coverage') {
+            when {
+                expression { params.TEST_CONFIG == 'Code Coverage' }
+            }
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/code-coverage/init-install.sh
+
+                   ${MYST_SCRIPTS}/myst_cc_info
+                   sed -i 's|SF:${WORKSPACE}|SF:|g' lcov.info
+
+                   mv lcov.info ${LCOV_INFO}
+                   """
+
+                azureUpload(
+                    containerName: 'mystikos-build-resources',
+                    storageType: 'container',
+                    uploadZips: true,
+                    filesPath: "${LCOV_INFO}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
@@ -1,0 +1,124 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC4'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        choice(name: "TEST_CONFIG", choices:['None','Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        string(name: "COMMIT_SYNC", description: "optional - used to sync outputs of parallel jobs")
+    }
+    environment {
+        MYST_SCRIPTS =      "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
+        MYST_NIGHTLY_TEST = "${TEST_CONFIG == 'Nightly' || TEST_CONFIG == 'Code Coverage' ? 1 : ''}"
+        MYST_ENABLE_GCOV =  "${TEST_CONFIG == 'Code Coverage' ? 1 : ''}"
+        TEST_TYPE =         "dotnet"
+        LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+    }
+    stages {
+        stage("Cleanup files") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+            }
+        }
+        stage('Verify commit sync') {
+            when { allOf {
+                expression { params.COMMIT_SYNC != "" }
+                expression { params.COMMIT_SYNC != GIT_COMMIT }
+            }}
+            steps {
+                script {
+                    currentBuild.result = 'ABORTED'
+                    error("Aborting build: mismatched commit - commit($GIT_COMMIT), expected(${COMMIT_SYNC})")
+                }
+            }
+        }
+        stage('Init Config') {
+            steps {
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Build repo source') {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/make-world.sh
+                   """
+            }
+        }
+        stage('Setup Solutions Access') {
+            steps {
+                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
+                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
+                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
+                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
+                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
+                    sh """
+                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
+                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
+                       """
+                }
+            }
+        }
+        stage('Run DotNet 5 Test Suite') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    sh """
+                       make tests -C ${WORKSPACE}/solutions/coreclr
+                       """
+                }
+            }
+        }
+        stage('Upload code coverage') {
+            when {
+                expression { params.TEST_CONFIG == 'Code Coverage' }
+            }
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/code-coverage/init-install.sh
+
+                   ${MYST_SCRIPTS}/myst_cc_info
+                   sed -i 's|SF:${WORKSPACE}|SF:|g' lcov.info
+
+                   mv lcov.info ${LCOV_INFO}
+                   """
+
+                azureUpload(
+                    containerName: 'mystikos-build-resources',
+                    storageType: 'container',
+                    uploadZips: true,
+                    filesPath: "${LCOV_INFO}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/standalone/measure-code-coverage.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/measure-code-coverage.Jenkinsfile
@@ -1,0 +1,76 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC4'
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        string(name: "COMMIT_ID", description: "Short commit ID used to archive build resoures")
+    }
+    environment {
+        MYST_SCRIPTS =      "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
+        MYST_NIGHTLY_TEST = 1
+        MYST_ENABLE_GCOV =  1
+        LCOV_PREFIX =       "lcov-${COMMIT_ID}"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+    }
+    stages {
+        stage('Measure and report code coverage') {
+            steps {
+                script {
+                    LCOV_DIR="mystikos-cc-${COMMIT_ID}"
+                }
+
+                azureDownload(
+                    downloadType: 'container',
+                    containerName: 'mystikos-build-resources',
+                    includeFilesPattern: "${LCOV_PREFIX}-*",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+
+                sh """
+                   ls -l
+
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/code-coverage/init-install.sh
+
+                   lcov -a ${LCOV_PREFIX}-dotnet.info -a ${LCOV_PREFIX}-sdk.info -a ${LCOV_PREFIX}-sql.info -a ${LCOV_PREFIX}-unit.info -o lcov.info
+                   lcov --list lcov.info | tee -a code-coverage-report
+
+                   ${MYST_SCRIPTS}/myst_cc_report
+
+                   mkdir ${LCOV_DIR}
+                   mv lcov* ${LCOV_DIR}
+                   tar -zcvf ${LCOV_DIR}.tar.gz ${LCOV_DIR}
+                   """
+
+                azureUpload(
+                    containerName: 'mystikos-code-coverage',
+                    storageType: 'container',
+                    uploadZips: true,
+                    filesPath: "${LCOV_DIR}.tar.gz",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/standalone/sql-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/sql-tests.Jenkinsfile
@@ -1,0 +1,137 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC4'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        choice(name: "REGION", choices:['useast', 'canadacentral'], description: "Azure region for SQL test")
+        choice(name: "TEST_CONFIG", choices:['None','Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        string(name: "COMMIT_SYNC", description: "optional - used to sync outputs of parallel jobs")
+    }
+    environment {
+        MYST_SCRIPTS =      "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
+        MYST_NIGHTLY_TEST = "${TEST_CONFIG == 'Nightly' || TEST_CONFIG == 'Code Coverage' ? 1 : ''}"
+        MYST_ENABLE_GCOV =  "${TEST_CONFIG == 'Code Coverage' ? 1 : ''}"
+        TEST_TYPE =         "sql"
+        LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+    }
+    stages {
+        stage("Cleanup files") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+            }
+        }
+        stage('Verify commit sync') {
+            when { allOf {
+                expression { params.COMMIT_SYNC != "" }
+                expression { params.COMMIT_SYNC != GIT_COMMIT }
+            }}
+            steps {
+                script {
+                    currentBuild.result = 'ABORTED'
+                    error("Aborting build: mismatched commit - commit($GIT_COMMIT), expected(${COMMIT_SYNC})")
+                }
+            }
+        }
+        stage('Init Config') {
+            steps {
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Build repo source') {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/make-world.sh
+                   """
+            }
+        }
+        stage('Setup Solutions Access') {
+            steps {
+                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
+                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
+                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
+                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
+                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
+                    sh """
+                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
+                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
+                       """
+                }
+            }
+        }
+        stage('Run SQL Solution') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    withCredentials([string(credentialsId: "mystikos-sql-db-name-${REGION}", variable: 'DB_NAME'),
+                                     string(credentialsId: "mystikos-sql-db-server-name-${REGION}", variable: 'DB_SERVER_NAME'),
+                                     string(credentialsId: "mystikos-maa-url-${REGION}", variable: 'MAA_URL'),
+                                     string(credentialsId: 'mystikos-managed-identity-objectid', variable: 'DB_USERID'),
+                                     string(credentialsId: 'mystikos-mhsm-client-secret', variable: 'CLIENT_SECRET'),
+                                     string(credentialsId: 'mystikos-mhsm-client-id', variable: 'CLIENT_ID'),
+                                     string(credentialsId: 'mystikos-mhsm-app-id', variable: 'APP_ID'),
+                                     string(credentialsId: 'mystikos-mhsm-aad-url', variable: 'MHSM_AAD_URL'),
+                                     string(credentialsId: 'mystikos-mhsm-ssr-pkey', variable: 'SSR_PKEY')
+                    ]) {
+                        sh """
+                           echo "Running in ${REGION}"
+                           make tests -C ${WORKSPACE}/solutions
+                           """
+                    }
+                }
+            }
+        }
+        stage('Upload code coverage') {
+            when {
+                expression { params.TEST_CONFIG == 'Code Coverage' }
+            }
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/code-coverage/init-install.sh
+
+                   ${MYST_SCRIPTS}/myst_cc_info
+                   sed -i 's|SF:${WORKSPACE}|SF:|g' lcov.info
+
+                   mv lcov.info ${LCOV_INFO}
+                   """
+
+                azureUpload(
+                    containerName: 'mystikos-build-resources',
+                    storageType: 'container',
+                    uploadZips: true,
+                    filesPath: "${LCOV_INFO}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
@@ -1,0 +1,108 @@
+pipeline {
+    agent {
+        label 'ACC-1804-DC4'
+    }
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY", defaultValue: "deislabs")
+        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
+        choice(name: "TEST_CONFIG", choices:['None','Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        string(name: "COMMIT_SYNC", description: "optional - used to sync outputs of parallel jobs")
+    }
+    environment {
+        MYST_SCRIPTS =      "${WORKSPACE}/scripts"
+        JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
+        MYST_NIGHTLY_TEST = "${TEST_CONFIG == 'Nightly' || TEST_CONFIG == 'Code Coverage' ? 1 : ''}"
+        MYST_ENABLE_GCOV =  "${TEST_CONFIG == 'Code Coverage' ? 1 : ''}"
+        TEST_TYPE =         "unit"
+        LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
+        BUILD_USER = sh(
+            returnStdout: true,
+            script: 'echo \${USER}'
+        )
+    }
+    stages {
+        stage("Initialize Workspace") {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
+                   """
+            }
+        }
+        stage('Verify commit sync') {
+            when { allOf {
+                expression { params.COMMIT_SYNC != "" }
+                expression { params.COMMIT_SYNC != GIT_COMMIT }
+            }}
+            steps {
+                script {
+                    currentBuild.result = 'ABORTED'
+                    error("Aborting build: mismatched commit - commit($GIT_COMMIT), expected(${COMMIT_SYNC})")
+                }
+            }
+        }
+        stage('Init Config') {
+            steps {
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
+                sh """
+                   # Initialize dependencies repo
+                   ${JENKINS_SCRIPTS}/global/init-config.sh
+
+                   # Install global dependencies
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/global/init-install.sh
+                   """
+            }
+        }
+        stage('Build repo source') {
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/make-world.sh
+                   """
+            }
+        }
+        stage("Run Unit Tests") {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    sh """
+                       ${JENKINS_SCRIPTS}/global/make-tests.sh
+                       """
+                }
+            }
+        }
+        stage('Upload code coverage') {
+            when {
+                expression { params.TEST_CONFIG == 'Code Coverage' }
+            }
+            steps {
+                sh """
+                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                   ${JENKINS_SCRIPTS}/code-coverage/init-install.sh
+
+                   ${MYST_SCRIPTS}/myst_cc_info
+                   sed -i 's|SF:${WORKSPACE}|SF:|g' lcov.info
+
+                   mv lcov.info ${LCOV_INFO}
+                   """
+
+                azureUpload(
+                    containerName: 'mystikos-build-resources',
+                    storageType: 'container',
+                    uploadZips: true,
+                    filesPath: "${LCOV_INFO}",
+                    storageCredentialId: 'mystikosreleaseblobcontainer'
+                )
+            }
+        }
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+    }
+}

--- a/.jenkins/scripts/global/build-repo-source.sh
+++ b/.jenkins/scripts/global/build-repo-source.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+make distclean
+make -j world
+
+rm build/bin/myst-lldb build/bin/myst-gdb
+cp build/openenclave/bin/oelldb build/bin/myst-lldb
+cp build/openenclave/bin/oegdb build/bin/myst-gdb

--- a/scripts/myst_cc_info
+++ b/scripts/myst_cc_info
@@ -7,7 +7,7 @@
 # 2. Copies crt, kernel, tools *.gcno and *.gcda files to the same location as their *.c and *.h files
 # 3. Copies *.c and *.h source files as needed (only ones whos location is redefined in their Makefile)
 # 4. Generates lcov.info from all the files into the $MYST_ROOT folder
-# 5. From info files it generates html code coverage report into ROOT/lcov
+# 5. use myst_cc_report to generate the code coverage report
 
 MYST_ROOT="$(realpath "$(dirname "$0")/..")"
 
@@ -33,9 +33,3 @@ rm $(find "${MYST_ROOT}"/tests/ -name "*.gc*")
 
 lcov --rc lcov_branch_coverage=1 -c -d . -o "${MYST_ROOT}"/lcov.info
 lcov --list lcov.info
-
-rm -rf "${MYST_ROOT}"/lcov
-mkdir "${MYST_ROOT}"/lcov
-genhtml --branch-coverage -o "${MYST_ROOT}"/lcov "${MYST_ROOT}"/lcov.info
-
-python3 -m "lcov_cobertura" lcov.info -o lcov.xml

--- a/scripts/myst_cc_report
+++ b/scripts/myst_cc_report
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script generates the code coverage data for myst project. 
+# You must run tests with MYST_ENABLE_GCOV=1 to populate the required files
+# This script does these steps:
+# 1. Creates lcov info using myst_cc_info 
+# 2. From info files generate html code coverage report into ROOT/lcov
+
+MYST_ROOT="$(realpath "$(dirname "$0")/..")"
+
+rm -rf "${MYST_ROOT}"/lcov
+mkdir "${MYST_ROOT}"/lcov
+genhtml --branch-coverage -o "${MYST_ROOT}"/lcov "${MYST_ROOT}"/lcov.info
+
+python3 -m "lcov_cobertura" lcov.info -o lcov.xml


### PR DESCRIPTION
Parallel test execution workflow:

1. Run make build on DC8 node to improve build time from ~30 minutes to under 15 minutes. The resulting build folder will be used for the solutions tests.
2. The solutions tests (SQL, Azure SDK, and DotNet) will download the prebuilt build folder, and run the respective tests. These tests are built on DC4 nodes, as test runs on DC8 nodes did not show much improvements.
3. Due to some build bits using absolute paths, the build folder will need to rebuilt in the node running the unit tests. Tests will be built and ran on a DC8 node as the build time is reduced by ~20 minutes, and the test runtime is further reduced by another ~20 minutes. Code coverage analysis will run if enabled.

Running the equivalent of the nightly/code coverage build in the manner described above reduces build/run time from ~5 hours, to ~2 hours. Though the total compute runtime is the same, (Unit tests: ~1 hour 40 minutes, Azure SDK: ~25 minutes, DotNet: ~1 hour 30 minutes, SQL: ~1 hour 5 minutes, and the initial repo source build: ~ 15 minutes), the rate-determining step is the slowest build.

The main trade-off with running the tests in parallel is the number of cores used for a given run. Instead of using a single DC4 instance for the whole run, one DC8 instance is used for ~1 hour 40 minutes, and three DC4 instances are used between 20 minutes to 1.5 hours.

To further expedite the build process, I introduced the use of a DC8 instance which will be used for the initial build, and is kept alive as long as it's been used within the past hour (@CyanDevs I'd especially like your feedback on this). This reduces the build process by several minutes it usually takes to create an instance; this change is more focused on the user experience.

Moving forward, users could be given the option to select which tests they would like to run, reducing the number of test files we have.