### PR TITLE
Fix bug where recvmsg writes too much data

### DIFF
--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -522,7 +522,7 @@ static long _recvmsg(
         int iovlen = msg->msg_iovlen;
 
         /* scatter the single buffer onto multiple iovec buffers */
-        if ((r = myst_iov_scatter(iov, iovlen, buf, (size_t)len)) < 0)
+        if ((r = myst_iov_scatter(iov, iovlen, buf, (size_t)retval)) < 0)
         {
             ret = r;
             goto done;


### PR DESCRIPTION
copying result back to iov buffers caused a buffer overrun because it
was not using the length returned from the recvmsg, rather used the
oriiginal length. It should only write what was read and nothing else.
Doing so caused some python socket tests to fail with scatter buffers.

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>