### PR TITLE
strace filtering

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -63,6 +63,26 @@ typedef struct myst_crt_args
     myst_wanted_secrets_t* wanted_secrets;
 } myst_crt_args_t;
 
+typedef struct _myst_strace_config
+{
+    /* Is tracing enabled or not */
+    bool trace_syscalls;
+
+    /* Should failing syscalls be traced or not*/
+    bool trace_failing;
+
+    /* Is filtering enabled or not */
+    bool filter;
+
+    /*
+        If filter is enabled, should the given syscall be traced or not.
+        Note: ausyscall --dump shows that maximum syscall value on Ubuntu 18.04
+              is 332 statx.
+              MYST_MAX_SYSCALLS value is much higher (3000).
+    */
+    bool trace[MYST_MAX_SYSCALLS];
+} myst_strace_config_t;
+
 typedef struct myst_kernel_args
 {
     /* The image that contains the kernel and crt etc. */
@@ -170,7 +190,7 @@ typedef struct myst_kernel_args
 
     /* Tracing options */
     bool trace_errors;
-    bool trace_syscalls;
+    myst_strace_config_t strace_config;
 
     /* Whether the target supports the SYSCALL instruction */
     bool have_syscall_instruction;

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -16,7 +16,6 @@ typedef struct myst_options
     bool have_syscall_instruction;
     bool have_fsgsbase_instructions;
     bool trace_errors;
-    bool trace_syscalls;
     bool shell_mode;
     bool debug_symbols;
     bool memcheck;
@@ -31,6 +30,7 @@ typedef struct myst_options
     char rootfs[PATH_MAX];
     myst_fork_mode_t fork_mode;
     myst_host_enc_uid_gid_mappings host_enc_uid_gid_mappings;
+    myst_strace_config_t strace_config;
 } myst_options_t;
 
 typedef struct myst_final_options

--- a/include/myst/syscallext.h
+++ b/include/myst/syscallext.h
@@ -29,8 +29,10 @@ typedef enum
     SYS_myst_get_process_thread_stack = 2016,
     SYS_myst_fork_wait_exec_exit = 2017,
     SYS_myst_get_exec_stack_option = 2018,
-    SYS_myst_interrupt_thread = 2019,
+    SYS_myst_interrupt_thread = 2019
 } myst_syscall_t;
+
+#define MYST_MAX_SYSCALLS 3000
 
 /* Used for SYS_myst_get_fork_info parameter */
 typedef enum

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -683,7 +683,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     if (!args->tee_debug_mode)
     {
         args->trace_errors = false;
-        args->trace_syscalls = false;
+        memset(&args->strace_config, 0, sizeof(args->strace_config));
         args->shell_mode = false;
         args->memcheck = false;
         args->perf = false;
@@ -693,7 +693,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     }
 
     /* ATTN: it seems __options can be eliminated */
-    __options.trace_syscalls = args->trace_syscalls;
+    __options.strace_config = args->strace_config;
     __options.have_syscall_instruction = args->have_syscall_instruction;
     __options.have_fsgsbase_instructions = args->have_fsgsbase_instructions;
     __options.report_native_tids = args->report_native_tids;

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -262,7 +262,8 @@ const char* myst_signum_to_string(unsigned signum)
 // https://man7.org/linux/man-pages/man7/signal.7.html for details.
 static long _default_signal_handler(unsigned signum)
 {
-    if (__myst_kernel_args.trace_syscalls || __myst_kernel_args.trace_errors)
+    if (__myst_kernel_args.strace_config.trace_syscalls ||
+        __myst_kernel_args.trace_errors)
         myst_eprintf(
             "*** Terminating signal %u (%s): pid=%d tid=%d\n",
             signum,

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -201,12 +201,63 @@ static const char* _format_timespec(
     return buf->data;
 }
 
+static bool _trace_syscall(long n)
+{
+    // Check if syscall tracing is enabled.
+    if (__myst_kernel_args.strace_config.trace_syscalls)
+    {
+        if (__myst_kernel_args.strace_config.filter)
+        {
+            // If filtering is enabled, trace only this syscall has been
+            // specified in the filter.
+            return __myst_kernel_args.strace_config.trace[n];
+        }
+        else
+        {
+            // Trace all syscalls.
+            return true;
+        }
+    }
+    return false;
+}
+
+static void _syscall_failure_hook(long n, long ret)
+{
+    // Set breakpoint in this function to stop execution when a syscall fails.
+    // Set condition for the breakpoint to control which syscall failures
+    // trigger the breakpoint.
+    (void)n;
+    (void)ret;
+}
+
+static bool _trace_syscall_return(long n, long ret)
+{
+    // If this syscall has been configured to be traced, then trace the return
+    // too.
+    if (_trace_syscall(n))
+        return true;
+
+    // Check if tracing failing syscalls has been enabled.
+    if (__myst_kernel_args.strace_config.trace_failing)
+    {
+        // If the syscall returns a negative value and has a valid error name,
+        // then consider it a failure and enable tracing.
+        if (ret < 0)
+        {
+            const char* error_name = myst_error_name(-ret);
+            if (error_name)
+                return true;
+        }
+    }
+    return false;
+}
+
 __attribute__((format(printf, 2, 3))) static void _strace(
     long n,
     const char* fmt,
     ...)
 {
-    if (__myst_kernel_args.trace_syscalls)
+    if (_trace_syscall(n))
     {
         char null_char = '\0';
         char* buf = &null_char;
@@ -260,7 +311,7 @@ long myst_syscall_unmap_on_exit(myst_thread_t* thread, void* ptr, size_t size)
 
 static long _forward_syscall(long n, long params[6])
 {
-    if (__myst_kernel_args.trace_syscalls)
+    if (_trace_syscall(n))
         myst_eprintf("    [forward syscall]\n");
 
     return myst_tcall(n, params);
@@ -274,7 +325,7 @@ typedef struct fd_entry
 
 static long _return(long n, long ret)
 {
-    if (__myst_kernel_args.trace_syscalls)
+    if (_trace_syscall_return(n, ret))
     {
         const char* red = "";
         const char* reset = "";
@@ -304,6 +355,9 @@ static long _return(long n, long ret)
                 reset,
                 myst_getpid(),
                 myst_gettid());
+
+            // Trigger breakpoint if set.
+            _syscall_failure_hook(n, ret);
         }
         else
         {
@@ -1980,7 +2034,7 @@ long myst_syscall_pipe2(int pipefd[2], int flags)
     pipefd[0] = fd0;
     pipefd[1] = fd1;
 
-    if (__myst_kernel_args.trace_syscalls)
+    if (_trace_syscall(SYS_pipe2))
         myst_eprintf("pipe2(): [%d:%d]\n", fd0, fd1);
 
 done:
@@ -3343,7 +3397,7 @@ static long _syscall(void* args_)
 
             _strace(n, "fds=%p nfds=%ld timeout=%d", fds, nfds, timeout);
 
-            if (__myst_kernel_args.trace_syscalls && fds)
+            if (_trace_syscall(SYS_poll))
             {
                 for (nfds_t i = 0; i < nfds; i++)
                     myst_eprintf("fd=%d\n", fds[i].fd);
@@ -3602,7 +3656,7 @@ static long _syscall(void* args_)
             struct timeval* timeout = (struct timeval*)x5;
             long ret;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_select))
             {
                 struct timeval* _timeout = timeout;
                 if (timeout && !myst_is_addr_within_kernel(timeout))
@@ -5216,7 +5270,7 @@ static long _syscall(void* args_)
             const char* pathname = (const char*)x2;
             const struct timeval* times = (const struct timeval*)x3;
             long ret;
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_futimesat))
             {
                 const struct timeval* _times = times;
                 if (times && !myst_is_addr_within_kernel(times))
@@ -5470,7 +5524,7 @@ static long _syscall(void* args_)
             int flags = (int)x4;
             long ret;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_accept4))
             {
                 char addrstr[MAX_IPADDR_LEN];
 
@@ -5516,7 +5570,7 @@ static long _syscall(void* args_)
             _strace(n, "pipefd=%p flags=%0o", pipefd, flags);
             ret = myst_syscall_pipe2(pipefd, flags);
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_pipe2))
                 myst_eprintf("    pipefd[]=[%d:%d]\n", pipefd[0], pipefd[1]);
 
             BREAK(_return(n, ret));
@@ -5776,7 +5830,7 @@ static long _syscall(void* args_)
             socklen_t addrlen = (socklen_t)x3;
             long ret;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_bind))
             {
                 char addrstr[MAX_IPADDR_LEN];
 
@@ -5801,7 +5855,7 @@ static long _syscall(void* args_)
             socklen_t addrlen = (socklen_t)x3;
             long ret;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_connect))
             {
                 char addrstr[MAX_IPADDR_LEN];
 
@@ -5839,7 +5893,7 @@ static long _syscall(void* args_)
             socklen_t* addrlen = (socklen_t*)x6;
             long ret = 0;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_recvfrom))
             {
                 char addrstr[MAX_IPADDR_LEN];
 
@@ -5870,7 +5924,7 @@ static long _syscall(void* args_)
             socklen_t addrlen = (socklen_t)x6;
             long ret = 0;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_sendto))
             {
                 char addrstr[MAX_IPADDR_LEN];
 
@@ -5920,7 +5974,7 @@ static long _syscall(void* args_)
             socklen_t* addrlen = (socklen_t*)x3;
             long ret;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_accept))
             {
                 char addrstr[MAX_IPADDR_LEN];
 
@@ -6031,7 +6085,7 @@ static long _syscall(void* args_)
             socklen_t* addrlen = (socklen_t*)x3;
             long ret;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_getsockname))
             {
                 char addrstr[MAX_IPADDR_LEN];
 
@@ -6055,7 +6109,7 @@ static long _syscall(void* args_)
             socklen_t* addrlen = (socklen_t*)x3;
             long ret;
 
-            if (__myst_kernel_args.trace_syscalls)
+            if (_trace_syscall(SYS_getpeername))
             {
                 char addrstr[MAX_IPADDR_LEN];
 

--- a/kernel/times.c
+++ b/kernel/times.c
@@ -13,8 +13,6 @@
 #include <myst/thread.h>
 #include <myst/times.h>
 
-#define MYST_MAX_SYSCALLS 3000
-
 /* Time spent by the main thread and its children */
 struct tms process_times;
 

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -245,7 +245,7 @@ __attribute__((format(printf, 2, 3))) static void _exception_handler_strace(
     const char* fmt,
     ...)
 {
-    if (final_options.base.trace_syscalls)
+    if (final_options.base.strace_config.trace_syscalls)
     {
         char null_char = '\0';
         char* buf = &null_char;
@@ -612,7 +612,7 @@ static long _enter(void* arg_)
                 enclave_image_size, /* image_size */
                 _get_num_tcs(),     /* max threads */
                 final_options.base.trace_errors,
-                final_options.base.trace_syscalls,
+                &final_options.base.strace_config,
                 false, /* have_syscall_instruction */
                 tee_debug_mode,
                 event, /* thread_event */

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -45,6 +45,7 @@
 #include "pubkeys.h"
 #include "regions.h"
 #include "roothash.h"
+#include "strace.h"
 #include "utils.h"
 
 // This is a default enclave configuration that we use when overriding the
@@ -410,7 +411,12 @@ int exec_action(int argc, const char* argv[], const char* envp[])
         if (cli_getopt(&argc, argv, "--trace-syscalls", NULL) == 0 ||
             cli_getopt(&argc, argv, "--strace", NULL) == 0)
         {
-            options.trace_syscalls = true;
+            options.strace_config.trace_syscalls = true;
+        }
+
+        if (myst_parse_strace_config(&argc, argv, &options.strace_config) == 0)
+        {
+            options.strace_config.trace_syscalls = true;
         }
 
         /* Get --trace option */

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -40,6 +40,7 @@
 #include "pubkeys.h"
 #include "regions.h"
 #include "roothash.h"
+#include "strace.h"
 #include "utils.h"
 
 #define USAGE_FORMAT \
@@ -110,7 +111,12 @@ static void _get_options(
     if (cli_getopt(argc, argv, "--trace-syscalls", NULL) == 0 ||
         cli_getopt(argc, argv, "--strace", NULL) == 0)
     {
-        opts->trace_syscalls = true;
+        opts->strace_config.trace_syscalls = true;
+    }
+
+    if (myst_parse_strace_config(argc, argv, &opts->strace_config) == 0)
+    {
+        opts->strace_config.trace_syscalls = true;
     }
 
     /* Get --trace-errors option */
@@ -459,7 +465,7 @@ static int _enter_kernel(
                 image_size,
                 max_threads,
                 final_options.base.trace_errors,
-                final_options.base.trace_syscalls,
+                &final_options.base.strace_config,
                 have_syscall_instruction,
                 tee_debug_mode,
                 (uint64_t)&_thread_event,

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -30,6 +30,7 @@
 #include "roothash.h"
 #include "sections.h"
 #include "sign.h"
+#include "strace.h"
 #include "utils.h"
 
 _Static_assert(PAGE_SIZE == 4096, "");
@@ -613,7 +614,12 @@ int _exec_package(
         if (cli_getopt(&argc, argv, "--trace-syscalls", NULL) == 0 ||
             cli_getopt(&argc, argv, "--strace", NULL) == 0)
         {
-            options.trace_syscalls = true;
+            options.strace_config.trace_syscalls = true;
+        }
+
+        if (myst_parse_strace_config(&argc, argv, &options.strace_config) == 0)
+        {
+            options.strace_config.trace_syscalls = true;
         }
     }
 

--- a/tools/myst/host/strace.c
+++ b/tools/myst/host/strace.c
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "strace.h"
+#include <memory.h>
+#include "utils.h"
+
+#include <myst/strings.h>
+#include <myst/syscall.h>
+
+int myst_parse_strace_config(
+    int* argc,
+    const char** argv,
+    myst_strace_config_t* strace_config)
+{
+    int ret = -1;
+    const char* filter = NULL;
+    char** tokens = NULL;
+    size_t num_tokens = 0;
+
+    if (cli_getopt(argc, argv, "--strace-failing", NULL) == 0)
+    {
+        strace_config->trace_failing = 1;
+        strace_config->filter = 1;
+    }
+
+    if (cli_getopt(argc, argv, "--strace-filter", &filter) == 0 && filter)
+    {
+        if (myst_strsplit(filter, ":", &tokens, &num_tokens) != 0)
+        {
+            fprintf(stderr, "Invalid strace-filter '%s' specified.\n", filter);
+            abort();
+        }
+        for (size_t i = 0; i < num_tokens; ++i)
+        {
+            const char* name = tokens[i];
+            long num = myst_syscall_num(name);
+            if (num > 0)
+            {
+                if (num < MYST_MAX_SYSCALLS)
+                    strace_config->trace[num] = 1;
+                else
+                {
+                    fprintf(
+                        stderr,
+                        "Syscall %s exceeds trace array. Fix "
+                        "myst_syscall_config_t\n",
+                        name);
+                    abort();
+                }
+            }
+            else
+            {
+                fprintf(
+                    stderr,
+                    "Unknown syscall %s specified in --strace=filter\n",
+                    name);
+                abort();
+            }
+        }
+        strace_config->filter = 1;
+        ret = 0;
+    }
+
+    if (tokens)
+        free(tokens);
+
+    return ret;
+}

--- a/tools/myst/host/strace.h
+++ b/tools/myst/host/strace.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_HOST_STRACE_H
+#define _MYST_HOST_STRACE_H
+
+#include <myst/options.h>
+
+int myst_parse_strace_config(
+    int* argc,
+    const char** argv,
+    myst_strace_config_t* strace_config);
+
+#endif // _MYST_HOST_STRACE_H

--- a/tools/myst/kargs.c
+++ b/tools/myst/kargs.c
@@ -53,7 +53,7 @@ int init_kernel_args(
     size_t image_size,
     size_t max_threads,
     bool trace_errors,
-    bool trace_syscalls,
+    const myst_strace_config_t* strace_config,
     bool have_syscall_instruction,
     bool tee_debug_mode,
     uint64_t thread_event,
@@ -288,7 +288,7 @@ int init_kernel_args(
     args->envp = env.data;
     args->max_threads = max_threads;
     args->trace_errors = trace_errors;
-    args->trace_syscalls = trace_syscalls;
+    args->strace_config = *strace_config;
     args->have_syscall_instruction = have_syscall_instruction;
     args->event = thread_event;
     args->target_tid = target_tid;

--- a/tools/myst/kargs.h
+++ b/tools/myst/kargs.h
@@ -20,7 +20,7 @@ int init_kernel_args(
     size_t image_size,
     size_t max_threads,
     bool trace_errors,
-    bool trace_syscalls,
+    const myst_strace_config_t* strace_config,
     bool have_syscall_instruction,
     bool tee_debug_mode,
     uint64_t thread_event,

--- a/tools/myst/options.c
+++ b/tools/myst/options.c
@@ -75,7 +75,7 @@ long determine_final_options(
         // Some options should not be enabled unless running in debug mode
         if (tee_debug_mode)
         {
-            final_opts->base.trace_syscalls = cmdline_opts->trace_syscalls;
+            final_opts->base.strace_config = cmdline_opts->strace_config;
             final_opts->base.trace_errors = cmdline_opts->trace_errors;
             final_opts->base.shell_mode = cmdline_opts->shell_mode;
             final_opts->base.debug_symbols = cmdline_opts->debug_symbols;
@@ -86,7 +86,10 @@ long determine_final_options(
         }
         else
         {
-            final_opts->base.trace_syscalls = false;
+            memset(
+                &final_opts->base.strace_config,
+                0,
+                sizeof(final_opts->base.strace_config));
             final_opts->base.trace_errors = false;
             final_opts->base.shell_mode = false;
             final_opts->base.debug_symbols = false;


### PR DESCRIPTION
The following options are added to make strace more helpful
for debugging

- --strace-failing
  When specified, all syscalls that fail will be logged.
  Other syscalls will not be logged, unless specified via filter (see below).
  Set a breakpoing in `_strace_failure_hook` to stop execution whenever a
  syscall fails. Use breakpoint conditions to control the behavior of the breakpoint.

- --strace-filter "SYS_name1:SYS_name2:..."
  Specify the set of syscalls to be traced. When filters are specified, only those
  syscalls specified in the filter will be traced, in addition to failing syscalls if
  specified as described above.
  E.g: To trace open and mprotect syscalls, specify
     --strace-filter "SYS_open:SYS_mprotect"

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>