### PR TITLE
Fix path/filename limitations in EXT2

### DIFF
--- a/include/myst/bufu64.h
+++ b/include/myst/bufu64.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 
 // clang-format off
-#define BUFU64_INITIALIZER { NULL, 0, 0 }
+#define MYST_BUFU64_INITIALIZER { NULL, 0, 0 }
 // clang-format on
 
 typedef struct myst_bufu64

--- a/include/myst/ext2.h
+++ b/include/myst/ext2.h
@@ -23,7 +23,7 @@
 **==============================================================================
 */
 
-#define EXT2_PATH_MAX 256
+#define EXT2_FILENAME_MAX 255
 
 #define EXT2_MAX_BLOCK_SIZE (8 * 1024)
 
@@ -187,7 +187,7 @@ struct ext2_dirent
     uint16_t rec_len;
     uint8_t name_len;
     uint8_t file_type;
-    char name[EXT2_PATH_MAX];
+    char name[EXT2_FILENAME_MAX];
 };
 
 // This structure keeps track of the number of times an inode has been opened
@@ -216,7 +216,7 @@ struct ext2
     uint32_t group_count;
     ext2_group_desc_t* groups;
     ext2_inode_t root_inode;
-    char target[EXT2_PATH_MAX];
+    char target[PATH_MAX];
     myst_mount_resolve_callback_t resolve;
     myst_fs_t* wrapper_fs;
     ext2_inode_ref_t* inode_refs;

--- a/tests/ext2/plain/ext2.c
+++ b/tests/ext2/plain/ext2.c
@@ -163,14 +163,14 @@ int mock_mount_resolve(
 
 static void _rand_name(char buf[PATH_MAX])
 {
-    size_t len = random() % EXT2_PATH_MAX;
+    size_t len = random() % EXT2_FILENAME_MAX;
 
     if (len == 0)
         len++;
 
     const char chars[] = "abcdefghijklmnopqrstuvwxyz0123456789";
 
-    assert(len <= EXT2_PATH_MAX);
+    assert(len <= EXT2_FILENAME_MAX);
 
     for (size_t i = 0; i < len; i++)
     {


### PR DESCRIPTION
This PR corrects errors EXT2 errors with:
- maximum filename length (now ``EXT2_FILENAME_MAX``)
- maximum path length (now ``PATH_MAX``)
- maximum path depth (now arbitrary)