### PR TITLE
Increase fdtable size to 2048

### DIFF
--- a/include/myst/fdtable.h
+++ b/include/myst/fdtable.h
@@ -19,7 +19,7 @@
 #include <myst/spinlock.h>
 #include <myst/ttydev.h>
 
-#define MYST_FDTABLE_SIZE 1024
+#define MYST_FDTABLE_SIZE 2048
 
 typedef enum myst_fdtable_type
 {


### PR DESCRIPTION
### Summary
fdtable size of 1024 is insufficient for some aspnetcore tests.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>