### PR TITLE
add sighandler to lockfs to unlock on signal

### DIFF
--- a/kernel/lockfs.c
+++ b/kernel/lockfs.c
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 #include <stdlib.h>
+#include <string.h>
 
 #include <myst/eraise.h>
 #include <myst/lockfs.h>
 #include <myst/mutex.h>
+#include <myst/thread.h>
 
 #define LOCKFS_MAGIC 0x94639c1a101f4a1d
 
@@ -16,6 +18,39 @@ typedef struct lockfs
     myst_mutex_t lock;
     myst_fs_t* fs;
 } lockfs_t;
+
+typedef struct lockfs_sighandler
+{
+    // Used by thread signal handler infrastructure
+    myst_thread_sig_handler_t sig_handler;
+
+    // our condition variable details to clean up;
+    myst_mutex_t* lock;
+
+} lockfs_sighandler_t;
+
+static void _unlock_sighandler(MYST_UNUSED unsigned signum, void* _sig_handler)
+{
+    lockfs_sighandler_t* sig_handler = (lockfs_sighandler_t*)_sig_handler;
+    myst_mutex_unlock(sig_handler->lock);
+}
+
+static void _install_sig_handler(
+    lockfs_sighandler_t* sig_handler,
+    myst_mutex_t* lock)
+{
+    memset(sig_handler, 0, sizeof(*sig_handler));
+
+    sig_handler->lock = lock;
+
+    myst_thread_sig_handler_install(
+        &sig_handler->sig_handler, _unlock_sighandler, sig_handler);
+}
+
+static void _uninstall_sig_handler(lockfs_sighandler_t* sig_handler)
+{
+    myst_thread_sig_handler_uninstall(&sig_handler->sig_handler);
+}
 
 static bool _lockfs_valid(const lockfs_t* lockfs)
 {
@@ -41,12 +76,15 @@ static int _fs_mount(myst_fs_t* fs, const char* source, const char* target)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_mount)(lockfs->fs, source, target);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -62,12 +100,15 @@ static int _fs_creat(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_creat)(lockfs->fs, pathname, mode, fs_out, file_out);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -84,13 +125,16 @@ static int _fs_open(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_open)(
         lockfs->fs, pathname, flags, mode, fs_out, file_out);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -105,12 +149,15 @@ static off_t _fs_lseek(
 {
     off_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_lseek)(lockfs->fs, file, offset, whence);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -125,12 +172,15 @@ static ssize_t _fs_read(
 {
     ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_read)(lockfs->fs, file, buf, count);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -145,12 +195,15 @@ static ssize_t _fs_write(
 {
     ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_write)(lockfs->fs, file, buf, count);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -166,12 +219,15 @@ static ssize_t _fs_pread(
 {
     ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_pread)(lockfs->fs, file, buf, count, offset);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -187,12 +243,15 @@ static ssize_t _fs_pwrite(
 {
     ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_pwrite)(lockfs->fs, file, buf, count, offset);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -207,12 +266,15 @@ static ssize_t _fs_readv(
 {
     ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_readv)(lockfs->fs, file, iov, iovcnt);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -227,12 +289,15 @@ static ssize_t _fs_writev(
 {
     ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_writev)(lockfs->fs, file, iov, iovcnt);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -243,12 +308,15 @@ static int _fs_close(myst_fs_t* fs, myst_file_t* file)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_close)(lockfs->fs, file);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -259,12 +327,15 @@ static int _fs_access(myst_fs_t* fs, const char* pathname, int mode)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_access)(lockfs->fs, pathname, mode);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -275,12 +346,15 @@ static int _fs_stat(myst_fs_t* fs, const char* pathname, struct stat* statbuf)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_stat)(lockfs->fs, pathname, statbuf);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -291,12 +365,15 @@ static int _fs_lstat(myst_fs_t* fs, const char* pathname, struct stat* statbuf)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_lstat)(lockfs->fs, pathname, statbuf);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -307,12 +384,15 @@ static int _fs_fstat(myst_fs_t* fs, myst_file_t* file, struct stat* statbuf)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_fstat)(lockfs->fs, file, statbuf);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -323,12 +403,15 @@ static int _fs_link(myst_fs_t* fs, const char* oldpath, const char* newpath)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_link)(lockfs->fs, oldpath, newpath);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -339,12 +422,15 @@ static int _fs_unlink(myst_fs_t* fs, const char* pathname)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_unlink)(lockfs->fs, pathname);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -355,12 +441,15 @@ static int _fs_rename(myst_fs_t* fs, const char* oldpath, const char* newpath)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_rename)(lockfs->fs, oldpath, newpath);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -371,12 +460,15 @@ static int _fs_truncate(myst_fs_t* fs, const char* pathname, off_t length)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_truncate)(lockfs->fs, pathname, length);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -387,12 +479,15 @@ static int _fs_ftruncate(myst_fs_t* fs, myst_file_t* file, off_t length)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_ftruncate)(lockfs->fs, file, length);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -403,12 +498,15 @@ static int _fs_mkdir(myst_fs_t* fs, const char* pathname, mode_t mode)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_mkdir)(lockfs->fs, pathname, mode);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -419,12 +517,15 @@ static int _fs_rmdir(myst_fs_t* fs, const char* pathname)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_rmdir)(lockfs->fs, pathname);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -439,12 +540,15 @@ static int _fs_getdents64(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_getdents64)(lockfs->fs, file, dirp, count);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -459,12 +563,15 @@ static ssize_t _fs_readlink(
 {
     ssize_t ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_readlink)(lockfs->fs, pathname, buf, bufsiz);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -475,12 +582,15 @@ static int _fs_symlink(myst_fs_t* fs, const char* target, const char* linkpath)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_symlink)(lockfs->fs, target, linkpath);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -495,12 +605,15 @@ static int _fs_realpath(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_realpath)(lockfs->fs, file, buf, size);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -511,12 +624,15 @@ static int _fs_fcntl(myst_fs_t* fs, myst_file_t* file, int cmd, long arg)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_fcntl)(lockfs->fs, file, cmd, arg);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -531,12 +647,15 @@ static int _fs_ioctl(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_ioctl)(lockfs->fs, file, request, arg);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -550,12 +669,15 @@ static int _fs_dup(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_dup)(lockfs->fs, file, file_out);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -566,12 +688,15 @@ static int _fs_target_fd(myst_fs_t* fs, myst_file_t* file)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_target_fd)(lockfs->fs, file);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -582,12 +707,15 @@ static int _fs_get_events(myst_fs_t* fs, myst_file_t* file)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_get_events)(lockfs->fs, file);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -598,12 +726,15 @@ static int _fs_statfs(myst_fs_t* fs, const char* pathname, struct statfs* buf)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_statfs)(lockfs->fs, pathname, buf);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -614,12 +745,15 @@ static int _fs_fstatfs(myst_fs_t* fs, myst_file_t* file, struct statfs* buf)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_fstatfs)(lockfs->fs, file, buf);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -633,12 +767,15 @@ static int _fs_futimens(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_futimens)(lockfs->fs, file, times);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -653,12 +790,15 @@ static int _fs_chown(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_chown)(lockfs->fs, pathname, owner, group);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -673,12 +813,15 @@ static int _fs_fchown(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_fchown)(lockfs->fs, file, owner, group);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -693,12 +836,15 @@ static int _fs_lchown(
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_lchown)(lockfs->fs, pathname, owner, group);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -709,12 +855,15 @@ static int _fs_chmod(myst_fs_t* fs, const char* pathname, mode_t mode)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_chmod)(lockfs->fs, pathname, mode);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -725,12 +874,15 @@ static int _fs_fchmod(myst_fs_t* fs, myst_file_t* file, mode_t mode)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_fchmod)(lockfs->fs, file, mode);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -741,12 +893,15 @@ static int _fs_fdatasync(myst_fs_t* fs, myst_file_t* file)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_fdatasync)(lockfs->fs, file);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -757,12 +912,15 @@ static int _fs_fsync(myst_fs_t* fs, myst_file_t* file)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs))
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_fsync)(lockfs->fs, file);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:
@@ -773,12 +931,15 @@ static int _fs_release_tree(myst_fs_t* fs, const char* pathname)
 {
     int ret = 0;
     lockfs_t* lockfs = (lockfs_t*)fs;
+    lockfs_sighandler_t sig_handler;
 
     if (!_lockfs_valid(lockfs) || !pathname)
         ERAISE(-EINVAL);
 
     myst_mutex_lock(&lockfs->lock);
+    _install_sig_handler(&sig_handler, &lockfs->lock);
     ret = (*lockfs->fs->fs_release_tree)(lockfs->fs, pathname);
+    _uninstall_sig_handler(&sig_handler);
     myst_mutex_unlock(&lockfs->lock);
 
 done:


### PR DESCRIPTION
in case of terminating signal within the filesystem the lock may still
be held, so make sure it is unlocked before the thread goes away

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>