### PR TITLE
Multiple fixes and enhancements for ext2-fs and ramfs for issues exposed by cpython test suite.

### DIFF
--- a/hostfs/hostfs.c
+++ b/hostfs/hostfs.c
@@ -874,7 +874,7 @@ static int _fs_ioctl(
     if (request == TIOCGWINSZ)
         ERAISE(-EINVAL);
 
-    if (request == FIOCLEX || request == FIONCLEX)
+    if (request == FIOCLEX || request == FIONCLEX || request == FIONBIO)
     {
         long tret, params[6] = {file->fd, request, arg};
         ECHECK((tret = myst_tcall(SYS_ioctl, params)));

--- a/kernel/chown.c
+++ b/kernel/chown.c
@@ -71,12 +71,16 @@ long myst_syscall_chown(const char* pathname, uid_t owner, gid_t group)
 
     ECHECK(_path_checks(pathname));
 
-    if (((owner != (uid_t)-1) &&
-         (myst_valid_uid_against_passwd_file(owner) < 0)) ||
-        ((group != (gid_t)-1) &&
-         (myst_valid_gid_against_group_file(group) < 0)))
+    /* if not root, check target uid/gid validity */
+    if (thread->euid != 0)
     {
-        ret = -EINVAL;
+        if (((owner != (uid_t)-1) &&
+             (myst_valid_uid_against_passwd_file(owner) < 0)) ||
+            ((group != (gid_t)-1) &&
+             (myst_valid_gid_against_group_file(group) < 0)))
+        {
+            ret = -EINVAL;
+        }
     }
 
     if (!(locals = malloc(sizeof(struct locals))))
@@ -121,12 +125,16 @@ long myst_syscall_fchown(int fd, uid_t owner, gid_t group)
     if (fd < 0)
         return -EINVAL;
 
-    if (((owner != (uid_t)-1) &&
-         (myst_valid_uid_against_passwd_file(owner) < 0)) ||
-        ((group != (gid_t)-1) &&
-         (myst_valid_gid_against_group_file(group) < 0)))
+    /* if not root, check target uid/gid validity */
+    if (thread->euid != 0)
     {
-        ret = -EINVAL;
+        if (((owner != (uid_t)-1) &&
+             (myst_valid_uid_against_passwd_file(owner) < 0)) ||
+            ((group != (gid_t)-1) &&
+             (myst_valid_gid_against_group_file(group) < 0)))
+        {
+            ret = -EINVAL;
+        }
     }
 
     if (!(locals = malloc(sizeof(struct locals))))
@@ -167,12 +175,16 @@ long myst_syscall_lchown(const char* pathname, uid_t owner, gid_t group)
 
     ECHECK(_path_checks(pathname));
 
-    if (((owner != (uid_t)-1) &&
-         (myst_valid_uid_against_passwd_file(owner) < 0)) ||
-        ((group != (gid_t)-1) &&
-         (myst_valid_gid_against_group_file(group) < 0)))
+    /* if not root, check target uid/gid validity */
+    if (thread->euid != 0)
     {
-        ret = -EINVAL;
+        if (((owner != (uid_t)-1) &&
+             (myst_valid_uid_against_passwd_file(owner) < 0)) ||
+            ((group != (gid_t)-1) &&
+             (myst_valid_gid_against_group_file(group) < 0)))
+        {
+            ret = -EINVAL;
+        }
     }
 
     if (!(locals = malloc(sizeof(struct locals))))

--- a/kernel/devfs.c
+++ b/kernel/devfs.c
@@ -243,7 +243,7 @@ int devfs_setup()
 
     ECHECK(set_overrides_for_special_fs(_devfs));
 
-    if (myst_mkdirhier("/dev", 777) != 0)
+    if (myst_mkdirhier("/dev", 0777) != 0)
     {
         myst_eprintf("cannot create mount point for devfs\n");
         ERAISE(-EINVAL);
@@ -256,7 +256,7 @@ int devfs_setup()
     }
 
     /* Create standard /dev files */
-    ECHECK(myst_mkdirhier("/dev/pts", 777));
+    ECHECK(myst_mkdirhier("/dev/pts", 0777));
 
     /* /dev/urandom */
     {
@@ -265,7 +265,7 @@ int devfs_setup()
         v_cb.write_cb = _ignore_write_cb;
 
         myst_create_virtual_file(
-            _devfs, "/urandom", S_IFREG | S_IRUSR | S_IWUSR, v_cb);
+            _devfs, "/urandom", S_IFCHR | S_IRUSR | S_IWUSR, v_cb);
     }
 
     /* /dev/random - same as /dev/urandom */
@@ -275,7 +275,7 @@ int devfs_setup()
         v_cb.write_cb = _ignore_write_cb;
 
         myst_create_virtual_file(
-            _devfs, "/random", S_IFREG | S_IRUSR | S_IWUSR, v_cb);
+            _devfs, "/random", S_IFCHR | S_IRUSR | S_IWUSR, v_cb);
     }
 
     /* /dev/null */
@@ -285,7 +285,7 @@ int devfs_setup()
         v_cb.write_cb = _ignore_write_cb;
 
         myst_create_virtual_file(
-            _devfs, "/null", S_IFREG | S_IRUSR | S_IWUSR, v_cb);
+            _devfs, "/null", S_IFCHR | S_IRUSR | S_IWUSR, v_cb);
     }
 
     /* /dev/zero */
@@ -295,7 +295,7 @@ int devfs_setup()
         v_cb.write_cb = _ignore_write_cb;
 
         myst_create_virtual_file(
-            _devfs, "/zero", S_IFREG | S_IRUSR | S_IWUSR, v_cb);
+            _devfs, "/zero", S_IFCHR | S_IRUSR | S_IWUSR, v_cb);
     }
 
     /* /dev/ptmx */
@@ -307,7 +307,7 @@ int devfs_setup()
         v_cb.write_cb = _write_pty_cb;
 
         myst_create_virtual_file(
-            _devfs, "/ptmx", S_IFREG | S_IRUSR | S_IWUSR, v_cb);
+            _devfs, "/ptmx", S_IFCHR | S_IRUSR | S_IWUSR, v_cb);
     }
 
     /* /dev/fd symlink */

--- a/kernel/fdtable.c
+++ b/kernel/fdtable.c
@@ -333,7 +333,7 @@ int myst_fdtable_dup(
         int r;
 
         if (old->type == MYST_FDTABLE_TYPE_NONE)
-            ERAISE(-ENOENT);
+            ERAISE(-EBADF);
 
         if (newfd == oldfd) /* dup2() */
         {

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -252,7 +252,7 @@ long myst_syscall_umask(mode_t mask)
 
     myst_spin_lock(&process->umask_lock);
     ret = process->umask;
-    process->umask = mask;
+    process->umask = (mask & 0777);
     myst_spin_unlock(&process->umask_lock);
 
 done:

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -916,6 +916,12 @@ static int _fs_open(
             ramfs, locals->dirname, true, NULL, &parent, NULL, NULL));
 
         /* Create the new file inode */
+        /* ATTN: Current ramfs only support S_IFREG or S_ISCHR (virtual /dev) */
+        if (!S_ISCHR(mode))
+        {
+            /* in case upper layer does not set file type in mode */
+            mode = mode | S_IFREG;
+        }
         ECHECK(_inode_new(ramfs, parent, locals->basename, mode, &inode));
 
         /* Get the realpath of this file */

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -276,7 +276,7 @@ static int _inode_new(
 
         if (S_ISDIR(mode))
             type = DT_DIR;
-        else if (S_ISREG(mode))
+        else if (S_ISREG(mode) || S_ISCHR(mode))
             type = DT_REG;
         else if (S_ISLNK(mode))
             type = DT_LNK;
@@ -916,8 +916,7 @@ static int _fs_open(
             ramfs, locals->dirname, true, NULL, &parent, NULL, NULL));
 
         /* Create the new file inode */
-        ECHECK(_inode_new(
-            ramfs, parent, locals->basename, (S_IFREG | mode), &inode));
+        ECHECK(_inode_new(ramfs, parent, locals->basename, mode, &inode));
 
         /* Get the realpath of this file */
         ECHECK(_path_to_inode_realpath(
@@ -2747,7 +2746,7 @@ static int _fs_release_tree(myst_fs_t* fs, const char* pathname)
         int type, mode = self->mode;
         if (S_ISDIR(mode))
             type = DT_DIR;
-        else if (S_ISREG(mode))
+        else if (S_ISREG(mode) || S_ISCHR(mode))
             type = DT_REG;
         else if (S_ISLNK(mode))
             type = DT_LNK;
@@ -2957,7 +2956,7 @@ int myst_create_virtual_file(
         ERAISE(-EINVAL);
 
     /* create an empty file */
-    if (S_ISREG(mode))
+    if (S_ISREG(mode) || S_ISCHR(mode))
     {
         myst_file_t* file = NULL;
         ECHECK(

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -442,7 +442,7 @@ struct myst_file
     inode_t* inode;
     size_t offset;      /* the current file offset (files) */
     uint32_t access;    /* (O_RDONLY | O_RDWR | O_WRONLY) */
-    uint32_t operating; /* (O_APPEND | O_DIRECT | O_NOATIME) */
+    uint32_t operating; /* (O_APPEND | O_DIRECT | O_NOATIME | O_NONBLOCK) */
     int fdflags;        /* file descriptor flags: FD_CLOEXEC */
     char realpath[PATH_MAX];
     myst_buf_t vbuf;           /* virtual file buffer */
@@ -932,7 +932,7 @@ static int _fs_open(
     file->magic = FILE_MAGIC;
     file->inode = inode;
     file->access = (flags & (O_RDONLY | O_RDWR | O_WRONLY));
-    file->operating = (flags & O_APPEND);
+    file->operating = (flags & (O_APPEND | O_NONBLOCK));
     file->use_count = 1;
     inode->nopens++;
 
@@ -996,7 +996,8 @@ static off_t _fs_lseek(
         }
     }
 
-    /* ATTN: support seeking beyond the end of file */
+    /* ATTN: support seeking beyond the end of file, deficiency compared with
+     * EXT2FS support */
 
     /* Check whether new offset if out of range */
     if (new_offset < 0 || new_offset > (off_t)_file_size(file))
@@ -1046,9 +1047,9 @@ static ssize_t _fs_read(
         goto done;
     }
 
-    /* Verify that the offset is in bounds */
-    if (file->offset > _file_size(file))
-        ERAISE(-EINVAL);
+    /* If offset is beyond end of file, return 0 */
+    if (file->offset >= _file_size(file))
+        goto done;
 
     /* Read count bytes from the file or directory */
     {
@@ -2233,6 +2234,8 @@ static int _fs_fcntl(myst_fs_t* fs, myst_file_t* file, int cmd, long arg)
         {
             if (arg & O_APPEND)
                 file->operating |= O_APPEND;
+            if (arg & O_NONBLOCK)
+                file->operating |= O_NONBLOCK;
             if (arg & O_DIRECT)
                 // ATTN: implement O_DIRECT for files
                 file->operating |= O_DIRECT;
@@ -2287,6 +2290,20 @@ static int _fs_ioctl(
         case FIONCLEX:
         {
             _set_fd_flag(file, 0);
+            break;
+        }
+        case FIONBIO:
+        {
+            int* val = (int*)arg;
+
+            if (!val)
+                ERAISE(-EINVAL);
+
+            if (*val)
+                file->operating |= O_NONBLOCK;
+            else
+                file->operating &= ~O_NONBLOCK;
+
             break;
         }
         case TIOCSPTLCK:

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -3290,9 +3290,21 @@ static long _syscall(void* args_)
             const char* path = (const char*)x1;
             int flags = (int)x2;
             mode_t mode = (mode_t)x3;
+            myst_process_t* process = myst_process_self();
             long ret;
 
-            _strace(n, "path=\"%s\" flags=0%o mode=0%o", path, flags, mode);
+            _strace(
+                n,
+                "path=\"%s\" flags=0%o mode=0%o umask=0%o",
+                path,
+                flags,
+                mode,
+                process->umask);
+
+            /* Apply umask */
+            /* ATTN: Implementaiton need to be updated if directory ACL is
+             * supported */
+            mode = mode & (~(process->umask));
 
             ret = myst_syscall_open(path, flags, mode);
 
@@ -4109,8 +4121,19 @@ static long _syscall(void* args_)
         {
             const char* pathname = (const char*)x1;
             mode_t mode = (mode_t)x2;
+            myst_process_t* process = myst_process_self();
 
-            _strace(n, "pathname=\"%s\" mode=0%o", pathname, mode);
+            _strace(
+                n,
+                "pathname=\"%s\" mode=0%o umask=0%o",
+                pathname,
+                mode,
+                process->umask);
+
+            /* Apply umask */
+            /* ATTN: Implementaiton need to be updated if directory ACL is
+             * supported */
+            mode = mode & (~(process->umask));
 
             BREAK(_return(n, myst_syscall_mkdir(pathname, mode)));
         }
@@ -4126,8 +4149,19 @@ static long _syscall(void* args_)
         {
             const char* pathname = (const char*)x1;
             mode_t mode = (mode_t)x2;
+            myst_process_t* process = myst_process_self();
 
-            _strace(n, "pathname=\"%s\" mode=%x", pathname, mode);
+            _strace(
+                n,
+                "pathname=\"%s\" mode=0%o umask=0%o",
+                pathname,
+                mode,
+                process->umask);
+
+            /* Apply umask */
+            /* ATTN: Implementaiton need to be updated if directory ACL is
+             * supported */
+            mode = mode & (~(process->umask));
 
             BREAK(_return(n, myst_syscall_creat(pathname, mode)));
         }
@@ -5180,15 +5214,22 @@ static long _syscall(void* args_)
             const char* path = (const char*)x2;
             int flags = (int)x3;
             mode_t mode = (mode_t)x4;
+            myst_process_t* process = myst_process_self();
             long ret;
 
             _strace(
                 n,
-                "dirfd=%d path=\"%s\" flags=0%o mode=0%o",
+                "dirfd=%d path=\"%s\" flags=0%o mode=0%o umask=0%o",
                 dirfd,
                 path,
                 flags,
-                mode);
+                mode,
+                process->umask);
+
+            /* Apply umask */
+            /* ATTN: Implementaiton need to be updated if directory ACL is
+             * supported */
+            mode = mode & (~(process->umask));
 
             ret = myst_syscall_openat(dirfd, path, flags, mode);
 
@@ -5202,7 +5243,17 @@ static long _syscall(void* args_)
             long ret;
 
             _strace(
-                n, "dirfd=%d pathname=\"%s\" mode=0%o", dirfd, pathname, mode);
+                n,
+                "dirfd=%d pathname=\"%s\" mode=0%o umask=0%o",
+                dirfd,
+                pathname,
+                mode,
+                process->umask);
+
+            /* Apply umask */
+            /* ATTN: Implementaiton need to be updated if directory ACL is
+             * supported */
+            mode = mode & (~(process->umask));
 
             ret = myst_syscall_mkdirat(dirfd, pathname, mode);
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1854,7 +1854,7 @@ done:
     if (locals)
         free(locals);
 
-    return 0;
+    return ret;
 }
 
 long myst_syscall_fchmod(int fd, mode_t mode)

--- a/tests/cpython-tests/Makefile
+++ b/tests/cpython-tests/Makefile
@@ -17,8 +17,8 @@ endif
 
 MPDB=$(TOP)/scripts/mpdb.py
 TESTFILE=tests.passed
-TEST = test_bz2
-TESTCASE = test_socket.LinuxKernelCryptoAPI.test_aead_aes_gcm
+TEST = test_regrtest
+TESTCASE = test_glob.GlobTests.test_recursive_glob
 VER=3.9
 FS=ext2fs$(VER)
 
@@ -47,8 +47,8 @@ tests:
 	$(RUNTEST) ./exec.sh
 
 run-list: ext2fs3.8 ext2fs3.9
-	$(MYST_EXEC) $(OPTS) ext2fs3.8 /cpython/python -m test -f /$(TESTFILE) --timeout 90 -q
-	$(MYST_EXEC) $(OPTS) ext2fs3.9 /cpython/python -m test -f /$(TESTFILE) --timeout 90 -q
+	$(MYST_EXEC) $(OPTS) ext2fs3.8 /cpython/python -m test -f /$(TESTFILE) --timeout 120 -q
+	$(MYST_EXEC) $(OPTS) ext2fs3.9 /cpython/python -m test -f /$(TESTFILE) --timeout 120 -q
 
 one: $(FS)
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m test $(TEST) -v

--- a/tests/cpython-tests/test_config_v3.8.11/tests.failed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.failed
@@ -1,6 +1,7 @@
 test__locale
 test_asyncio
 test_asyncore
+test_builtin
 test_c_locale_coercion
 test_cmd_line
 test_compileall
@@ -15,7 +16,6 @@ test_fileio
 test_fork1
 test_gdb
 test_glob
-test_import
 test_importlib
 test_ioctl
 test_locale
@@ -48,7 +48,6 @@ test_stat
 test_strptime
 test_subprocess
 test_support
-test_tarfile
 test_tempfile
 test_thread
 test_threading

--- a/tests/cpython-tests/test_config_v3.8.11/tests.passed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.passed
@@ -28,7 +28,6 @@ test_bisect
 test_bool
 test_buffer
 test_bufio
-test_builtin
 test_bytes
 test_bz2
 test_calendar
@@ -160,6 +159,7 @@ test_idle
 test_imaplib
 test_imghdr
 test_imp
+test_import
 test_index
 test_inspect
 test_int
@@ -286,6 +286,7 @@ test_sys_settrace
 test_sysconfig
 test_syslog
 test_tabnanny
+test_tarfile
 test_tcl
 test_telnetlib
 test_textwrap

--- a/tests/cpython-tests/test_config_v3.9.7/tests.failed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.failed
@@ -1,6 +1,7 @@
 test__locale
 test_asyncio
 test_asyncore
+test_builtin
 test_c_locale_coercion
 test_cmd_line
 test_compileall
@@ -15,7 +16,6 @@ test_fileio
 test_fork1
 test_gdb
 test_glob
-test_import
 test_importlib
 test_ioctl
 test_locale
@@ -49,7 +49,6 @@ test_stat
 test_strptime
 test_subprocess
 test_support
-test_tarfile
 test_tempfile
 test_thread
 test_threading

--- a/tests/cpython-tests/test_config_v3.9.7/tests.passed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.passed
@@ -28,7 +28,6 @@ test_bisect
 test_bool
 test_buffer
 test_bufio
-test_builtin
 test_bytes
 test_bz2
 test_calendar
@@ -162,6 +161,7 @@ test_idle
 test_imaplib
 test_imghdr
 test_imp
+test_import
 test_index
 test_inspect
 test_int
@@ -289,6 +289,7 @@ test_sys_settrace
 test_sysconfig
 test_syslog
 test_tabnanny
+test_tarfile
 test_tcl
 test_telnetlib
 test_textwrap

--- a/tests/ext2/crypt/main.c
+++ b/tests/ext2/crypt/main.c
@@ -117,11 +117,11 @@ int main(int argc, const char* argv[])
         assert(close(fd) == 0);
     }
 
-    /* test unsupported ioctl(FIONBIO) */
+    /* test ioctl(FIONBIO) */
     {
         assert((fd = open(filename, O_RDONLY, 0)) >= 0);
         int val = 1;
-        assert(ioctl(fd, FIONBIO, &val) == -1 && errno == ENOTSUP);
+        assert(ioctl(fd, FIONBIO, &val) == 0);
         assert(close(fd) == 0);
     }
 

--- a/tests/ext2/verity/main.c
+++ b/tests/ext2/verity/main.c
@@ -180,11 +180,11 @@ int main(int argc, const char* argv[])
             assert(close(fd) == 0);
         }
 
-        /* test unsupported ioctl(FIONBIO) */
+        /* test ioctl(FIONBIO) */
         {
             assert((fd = open(filename, O_RDONLY, 0)) >= 0);
             int val = 1;
-            assert(ioctl(fd, FIONBIO, &val) == -1 && errno == ENOTSUP);
+            assert(ioctl(fd, FIONBIO, &val) == 0);
             assert(close(fd) == 0);
         }
 

--- a/tests/hostfs/hostfs.c
+++ b/tests/hostfs/hostfs.c
@@ -124,11 +124,11 @@ int main(int argc, const char* argv[])
         assert(close(fd) == 0);
     }
 
-    /* test unsupported ioctl(FIONBIO) */
+    /* test ioctl(FIONBIO) */
     {
         assert((fd = open(filename, O_RDONLY, 0)) >= 0);
         int val = 1;
-        assert(ioctl(fd, FIONBIO, &val) == -1 && errno == ENOTSUP);
+        assert(ioctl(fd, FIONBIO, &val) == 0);
         assert(close(fd) == 0);
     }
 


### PR DESCRIPTION
Fixes
  - Return EBADF instead of ENOENT on dup operation, if the old fd is not valid.
  - Return EINVAL on ext2-fs lseek operation, if the resulting file offset
    would be negative
  - Fix the typo bug in myst_syscall_chmod() return value
  - Return 0 on fs read() if lseek offset is beyond end of the file
  - Fix _ext2_futimens() bug of not writing the update to fs

Enhancement
  - Add O_NONBLOCK flag tracking and FIONBIO ioctl support in ext2fs and ramfs  
  - Add umask support in creat/open/mkdir syscalls 
  - Set S_IFCHR bit in file mode for devfs files such as /dev/null, dev/ptmx 
  - Allow root user to chown to uid/gid not in the passwd file