### PR TITLE
Allow the pthread stack size to be configurable

### DIFF
--- a/crt/enter.c
+++ b/crt/enter.c
@@ -29,7 +29,6 @@
 static myst_wanted_secrets_t* _wanted_secrets;
 
 void _dlstart_c(size_t* sp, size_t* dynv);
-int __pthread_enlarge_default_stack_size(size_t size);
 
 typedef long (*syscall_callback_t)(long n, long params[6]);
 

--- a/crt/enter.c
+++ b/crt/enter.c
@@ -29,6 +29,7 @@
 static myst_wanted_secrets_t* _wanted_secrets;
 
 void _dlstart_c(size_t* sp, size_t* dynv);
+int __pthread_enlarge_default_stack_size(size_t size);
 
 typedef long (*syscall_callback_t)(long n, long params[6]);
 
@@ -167,10 +168,13 @@ void myst_enter_crt(
     void* stack,
     void* dynv,
     syscall_callback_t callback,
-    myst_wanted_secrets_t* wanted_secrets)
+    myst_crt_args_t* args)
 {
     _syscall_callback = callback;
-    _wanted_secrets = wanted_secrets;
+    if (args)
+    {
+        _wanted_secrets = args->wanted_secrets;
+    }
     _dlstart_c((size_t*)stack, (size_t*)dynv);
 }
 

--- a/doc/sign-package.md
+++ b/doc/sign-package.md
@@ -104,7 +104,7 @@ Settings | Type | Description
 ~~UserMemSize~~ | `int \| string` | Deprecated, use `MemorySize` instead
 MemorySize | `int \| string` | Amount of memory your application needs to run. Try not to make this just a very large number as the larger this number needs to be the slower load time will be. Value can be bytes (just a number), **k**ilobytes (for example `"128k"`), **m**egabytes (for example `"512m"`), or **g**igabytes (for example `"1g"`)
 MainStackSize | `int \| string` | Stack size of your application's main process. Defaults to 1536k (or 1.5M) bytes. Normally, you do not need to customize this. If running an application generates a OOM error like in [#612](https://github.com/deislabs/mystikos/issues/612), try tuning this value, e.g. to 8M. Value can be bytes (just a number), **k**ilobytes (for example `"128k"`), **m**egabytes (for example `"512m"`), or **g**igabytes (for example `"1g"`)
-ThreadStackSize | `int \| string` | The default stack size of pthreads created by the application.
+ThreadStackSize | `int \| string` | The default stack size of pthreads created by the application. Ignored if smaller than the existing default thread stack size
 MaxAffinityCPUs | `int` | This setting limits the number of CPUs reported by sched_getaffinity()
 NoBrk | `boolean \| int` | If set to true(or 1), brk syscall returns -ENOTSUP. Defaults to `false`. Set this to true for program involves multi-threading.
 ApplicationPath | `string` | The executable path relative to the root of your appdir. This executable name is also used to determine the final application name once packaged.

--- a/doc/sign-package.md
+++ b/doc/sign-package.md
@@ -104,6 +104,7 @@ Settings | Type | Description
 ~~UserMemSize~~ | `int \| string` | Deprecated, use `MemorySize` instead
 MemorySize | `int \| string` | Amount of memory your application needs to run. Try not to make this just a very large number as the larger this number needs to be the slower load time will be. Value can be bytes (just a number), **k**ilobytes (for example `"128k"`), **m**egabytes (for example `"512m"`), or **g**igabytes (for example `"1g"`)
 MainStackSize | `int \| string` | Stack size of your application's main process. Defaults to 1536k (or 1.5M) bytes. Normally, you do not need to customize this. If running an application generates a OOM error like in [#612](https://github.com/deislabs/mystikos/issues/612), try tuning this value, e.g. to 8M. Value can be bytes (just a number), **k**ilobytes (for example `"128k"`), **m**egabytes (for example `"512m"`), or **g**igabytes (for example `"1g"`)
+ThreadStackSize | `int \| string` | The default stack size of pthreads created by the application.
 MaxAffinityCPUs | `int` | This setting limits the number of CPUs reported by sched_getaffinity()
 NoBrk | `boolean \| int` | If set to true(or 1), brk syscall returns -ENOTSUP. Defaults to `false`. Set this to true for program involves multi-threading.
 ApplicationPath | `string` | The executable path relative to the root of your appdir. This executable name is also used to determine the final application name once packaged.

--- a/doc/user-getting-started.md
+++ b/doc/user-getting-started.md
@@ -59,6 +59,12 @@ Options:
                             main thread, where <size> may have a
                             multiplier suffix: k 1024, m 1024*1024, or
                             g 1024*1024*1024
+    --thread-stack-size <size>
+                         -- the default stack size of threads created by the
+                            application, where <size> may have a
+                            multiplier suffix: k 1024, m 1024*1024, or
+                            g 1024*1024*1024. Ignored if smaller than the
+                            existing default thread stack size
     --app-config-path <json> -- specifies the configuration json file for
                                 running an unsigned binary. The file can be
                                 the same one used for the signing process.

--- a/include/myst/exec.h
+++ b/include/myst/exec.h
@@ -22,7 +22,8 @@ int myst_exec(
     const char* argv[],
     size_t envc,
     const char* envp[],
-    myst_wanted_secrets_t* wanted_secrets,
+    myst_crt_args_t* crt_args,
+    size_t thread_stacksize,
     void (*callback)(void*),
     void* callback_arg);
 

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -58,6 +58,11 @@ typedef struct _myst_wanted_secrets_config
     size_t secrets_count;
 } myst_wanted_secrets_t;
 
+typedef struct myst_crt_args
+{
+    myst_wanted_secrets_t* wanted_secrets;
+} myst_crt_args_t;
+
 typedef struct myst_kernel_args
 {
     /* The image that contains the kernel and crt etc. */
@@ -202,6 +207,9 @@ typedef struct myst_kernel_args
 
     // From the --main-stack-size=<size> option.
     size_t main_stack_size;
+
+    // From the --thread-stack-size=<size> option.
+    size_t thread_stack_size;
 
     // From the --max-affinity-cpus=<num> option. This setting limits the
     // CPUs reported by sched_getaffinity().

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -26,6 +26,7 @@ typedef struct myst_options
     bool report_native_tids;
     bool unhandled_syscall_enosys;
     size_t main_stack_size;
+    size_t thread_stack_size;
     size_t max_affinity_cpus;
     char rootfs[PATH_MAX];
     myst_fork_mode_t fork_mode;

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -823,6 +823,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     /* Run the main program: wait for SYS_exit to perform longjmp() */
     if (myst_setjmp(&thread->jmpbuf) == 0)
     {
+        myst_crt_args_t crt_args = {args->wanted_secrets};
         /* enter the C-runtime on the target thread descriptor */
         if ((tmp_ret = myst_exec(
                  thread,
@@ -834,7 +835,8 @@ int myst_enter_kernel(myst_kernel_args_t* args)
                  args->argv,
                  args->envc,
                  args->envp,
-                 args->wanted_secrets,
+                 &crt_args,
+                 args->thread_stack_size,
                  NULL,
                  NULL)) != 0)
         {

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2130,7 +2130,8 @@ long myst_syscall_execve(
             (const char**)argv,
             _count_args((const char* const*)envp),
             (const char**)envp,
-            NULL, /* wanted secrets */
+            NULL, /* CRT args */
+            0,    /* thread stack size */
             free,
             argv) != 0)
     {

--- a/tests/cpython-tests/config.json
+++ b/tests/cpython-tests/config.json
@@ -10,6 +10,7 @@
 
     // The heap size of the user application. Increase this setting if your app experienced OOM.
     "MemorySize": "8g",
+    "ThreadStackSize": "2m",
     // The path to the entry point application in rootfs
     "ApplicationPath": "/cpython/python",
     "CurrentWorkingDirectory": "/cpython/",

--- a/tests/pthread/Makefile
+++ b/tests/pthread/Makefile
@@ -20,6 +20,8 @@ endif
 
 OPTS += --memory-size=512m
 
+OPTS += --thread-stack-size=1m
+
 ifdef ALLTESTS
 COUNT = 10
 endif

--- a/tools/myst/config.c
+++ b/tools/myst/config.c
@@ -202,6 +202,14 @@ static json_result_t _json_read_callback(
                     CONFIG_RAISE(ret);
                 parsed_data->main_stack_size = main_stack_pages * PAGE_SIZE;
             }
+            else if (json_match(parser, "ThreadStackSize") == JSON_OK)
+            {
+                uint64_t thread_stack_pages = 0;
+                ret = _extract_mem_size(type, un, &thread_stack_pages);
+                if (ret != JSON_OK)
+                    CONFIG_RAISE(ret);
+                parsed_data->thread_stack_size = thread_stack_pages * PAGE_SIZE;
+            }
             else if (json_match(parser, "MaxAffinityCPUs") == JSON_OK)
             {
                 if (type != JSON_TYPE_INTEGER)

--- a/tools/myst/config.h
+++ b/tools/myst/config.h
@@ -83,6 +83,7 @@ typedef struct _config_parsed_data_t
     bool unhandled_syscall_enosys;
 
     size_t main_stack_size;
+    size_t thread_stack_size;
     /* maximum number of CPUs in the kernel (for thread affinity) */
     size_t max_affinity_cpus;
 

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -643,6 +643,7 @@ static long _enter(void* arg_)
         _kargs.main_stack_size = final_options.base.main_stack_size
                                      ? final_options.base.main_stack_size
                                      : MYST_PROCESS_INIT_STACK_SIZE;
+        _kargs.thread_stack_size = final_options.base.thread_stack_size;
 
         /* whether user-space FSGSBASE instructions are supported */
         _kargs.have_fsgsbase_instructions =

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -535,6 +535,30 @@ int exec_action(int argc, const char* argv[], const char* envp[])
             }
         }
 
+        /* Get --thread-stack-size */
+        {
+            const char* opt = "--thread-stack-size";
+            const char* arg = NULL;
+
+            if (cli_getopt(&argc, argv, opt, &arg) == 0)
+            {
+                if (arg)
+                {
+                    if ((myst_expand_size_string_to_ulong(
+                             arg, &options.thread_stack_size) != 0) ||
+                        (myst_round_up(
+                             options.thread_stack_size,
+                             PAGE_SIZE,
+                             &options.thread_stack_size) != 0))
+                    {
+                        _err(
+                            "%s <size> -- bad suffix (must be k, m, or g)\n",
+                            opt);
+                    }
+                }
+            }
+        }
+
         /* Get --app-config option if it exists, otherwise we use default values
          */
         cli_getopt(&argc, argv, "--app-config-path", &commandline_config);

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -232,6 +232,28 @@ static void _get_options(
         }
     }
 
+    /* Get --thread-stack-size */
+    {
+        const char* opt = "--thread-stack-size";
+        const char* arg = NULL;
+
+        if ((cli_getopt(argc, argv, opt, &arg) == 0))
+        {
+            if (arg)
+            {
+                if ((myst_expand_size_string_to_ulong(
+                         arg, &opts->thread_stack_size) != 0) ||
+                    (myst_round_up(
+                         opts->thread_stack_size,
+                         PAGE_SIZE,
+                         &opts->thread_stack_size) != 0))
+                {
+                    _err("%s <size> -- bad suffix (must be k, m, or g)\n", opt);
+                }
+            }
+        }
+    }
+
     // get app config if present
     cli_getopt(argc, argv, "--app-config-path", app_config_path);
 
@@ -492,6 +514,8 @@ static int _enter_kernel(
     kernel_args.main_stack_size = final_options.base.main_stack_size
                                       ? final_options.base.main_stack_size
                                       : MYST_PROCESS_INIT_STACK_SIZE;
+
+    kernel_args.thread_stack_size = final_options.base.thread_stack_size;
 
     /* Resolve the the kernel entry point */
     const elf_ehdr_t* ehdr = kernel_args.kernel_data;

--- a/tools/myst/options.c
+++ b/tools/myst/options.c
@@ -65,6 +65,7 @@ long determine_final_options(
         final_opts->hostname = parsed_config->hostname;
         final_opts->base.max_affinity_cpus = parsed_config->max_affinity_cpus;
         final_opts->base.main_stack_size = parsed_config->main_stack_size;
+        final_opts->base.thread_stack_size = parsed_config->thread_stack_size;
         final_opts->base.fork_mode = parsed_config->fork_mode;
         final_opts->base.nobrk = parsed_config->no_brk;
         final_opts->base.exec_stack = parsed_config->exec_stack;


### PR DESCRIPTION
* The default pthread stack size can be configured either with config.json or from "myst" command line.
* Parse the desired pthread stack size from either of the two sources and pass it into the kernel.
* The kernel patches the PT_GNU_STACK header of the CRT elf image to the correct stack size.
* We don't have to patch MUSL as it already has logics to use the bigger value in PT_GNU_STACK or the default 128k.
* Rewrite tests/pthread to verify that the command line route is open.
* Enlarge thread stack size to 2 MB for cpython test suites via config.json.

Signed-off-by: Xuejun Yang <xuejya@microsoft.com>