### PR TITLE
EXPERIMENTAL: Unix-domain sockets (AF_LOCAL and AF_UNIX)

### DIFF
--- a/include/myst/crypt.h
+++ b/include/myst/crypt.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_CRYPT_H
+#define _MYST_CRYPT_H
+
+#include <stdint.h>
+
+/* 512-bit key */
+typedef struct myst_key_512
+{
+    uint8_t data[512 / 8];
+} myst_key_512_t;
+
+int myst_encrypt_aes_256_xts(
+    const myst_key_512_t* key,
+    const void* data_in,
+    void* data_out,
+    size_t data_size,
+    uint64_t counter); /* counter used in the initialization vector */
+
+int myst_decrypt_aes_256_xts(
+    const myst_key_512_t* key,
+    const void* data_in,
+    void* data_out,
+    size_t data_size,
+    uint64_t counter); /* counter used in the initialization vector */
+
+#endif /* _MYST_CRYPT_H */

--- a/include/myst/hex.h
+++ b/include/myst/hex.h
@@ -9,6 +9,8 @@
 
 void myst_hexdump(const char* label, const void* data, size_t size);
 
+void myst_ascii_dump(const char* label, const uint8_t* data, uint32_t size);
+
 ssize_t myst_ascii_to_bin(const char* s, uint8_t* buf, size_t buf_size);
 
 int myst_bin_to_ascii(

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -204,6 +204,9 @@ typedef struct myst_kernel_args
     /* whether this TEE is in debug mode */
     bool tee_debug_mode;
 
+    /* perform syslog when level is less than or equal to this */
+    int syslog_level;
+
     /* whether debug symbols are needed */
     bool debug_symbols;
 

--- a/include/myst/sockdev.h
+++ b/include/myst/sockdev.h
@@ -163,4 +163,14 @@ struct myst_sockdev
 
 myst_sockdev_t* myst_sockdev_get(void);
 
+myst_sockdev_t* myst_sockdev_get_uds(void);
+
+int myst_sockdev_resolve(int domain, int type, myst_sockdev_t** dev);
+
+const char* myst_socket_type_str(int type);
+
+const char* myst_socket_domain_str(int domain);
+
+const char* myst_format_socket_type(char* buf, size_t len, int type);
+
 #endif /* _MYST_SOCKDEV_H */

--- a/include/myst/syslog.h
+++ b/include/myst/syslog.h
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef _MYST_SYSLOG_H
+#define _MYST_SYSLOG_H
+
+#include <stdarg.h>
+#include <syslog.h>
+
+#include <myst/defs.h>
+
+void __myst_vsyslog(
+    const char* file,
+    unsigned int line,
+    const char* func,
+    int priority,
+    const char* format,
+    va_list ap);
+
+void myst_vsyslog(int priority, const char* format, va_list ap);
+
+MYST_PRINTF_FORMAT(2, 3)
+void myst_syslog(int priority, const char* format, ...);
+
+MYST_PRINTF_FORMAT(5, 6)
+void __myst_syslog(
+    const char* file,
+    unsigned int line,
+    const char* func,
+    int priority,
+    const char* format,
+    ...);
+
+#define MYST_ELOG(FORMAT, ...) \
+    __myst_syslog(             \
+        __FILE__, __LINE__, __FUNCTION__, LOG_ERR, FORMAT, ##__VA_ARGS__)
+
+#define MYST_WLOG(FORMAT, ...) \
+    __myst_syslog(             \
+        __FILE__, __LINE__, __FUNCTION__, LOG_WARNING, FORMAT, ##__VA_ARGS__)
+
+#define MYST_ILOG(FORMAT, ...) \
+    __myst_syslog(             \
+        __FILE__, __LINE__, __FUNCTION__, LOG_INFO, FORMAT, ##__VA_ARGS__)
+
+#define MYST_DLOG(FORMAT, ...) \
+    __myst_syslog(             \
+        __FILE__, __LINE__, __FUNCTION__, LOG_DEBUG, FORMAT, ##__VA_ARGS__)
+
+#define MYST_SYSLOG(PRIORITY, FORMAT, ...) \
+    __myst_syslog(                         \
+        PRIORITY, FORMAT, __FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__)
+
+#endif /* _MYST_SYSLOG_H */

--- a/include/myst/tcall.h
+++ b/include/myst/tcall.h
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include <myst/blockdevice.h>
+#include <myst/crypt.h>
 #include <myst/defs.h>
 #include <myst/fssig.h>
 
@@ -66,6 +67,9 @@ typedef enum myst_tcall_number
     MYST_TCALL_SENDTO_BLOCK,
     MYST_TCALL_RECVMSG_BLOCK,
     MYST_TCALL_SENDMSG_BLOCK,
+    MYST_TCALL_GET_TEMPFILE_NAME,
+    MYST_TCALL_ENCRYPT_AES_256_XTS,
+    MYST_TCALL_DECRYPT_AES_256_XTS,
 } myst_tcall_number_t;
 
 long myst_tcall(long n, long params[6]);
@@ -263,5 +267,21 @@ ssize_t myst_tcall_sendmsg_block(
     int flags);
 
 ssize_t myst_tcall_recvmsg_block(int sockfd, struct msghdr* msg, int flags);
+
+long myst_tcall_get_tempfile_name(char* buf, size_t size);
+
+int myst_tcall_encrypt_aes_256_xts(
+    const myst_key_512_t* key,
+    const void* data_in,
+    void* data_out,
+    size_t data_size,
+    uint64_t index);
+
+int myst_tcall_decrypt_aes_256_xts(
+    const myst_key_512_t* key,
+    const void* data_in,
+    void* data_out,
+    size_t data_size,
+    uint64_t index);
 
 #endif /* _MYST_TCALL_H */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -42,6 +42,7 @@
 #include <myst/stack.h>
 #include <myst/strings.h>
 #include <myst/syscall.h>
+#include <myst/syslog.h>
 #include <myst/thread.h>
 #include <myst/time.h>
 #include <myst/times.h>
@@ -682,7 +683,13 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     __myst_kernel_args = *args;
     args = &__myst_kernel_args;
 
-    /* turn off various options when TEE is not in debug mode */
+    /* set the syslog level, depending on whether in TEE debug mode */
+    if (args->tee_debug_mode)
+        args->syslog_level = LOG_DEBUG;
+    else
+        args->syslog_level = LOG_NOTICE;
+
+    /* turn off or reduce various options when TEE is not in debug mode */
     if (!args->tee_debug_mode)
     {
         args->trace_errors = false;

--- a/kernel/sockdev.c
+++ b/kernel/sockdev.c
@@ -13,7 +13,9 @@
 #include <myst/sockdev.h>
 #include <myst/spinlock.h>
 #include <myst/syscall.h>
+#include <myst/syslog.h>
 #include <myst/tcall.h>
+#include <myst/strings.h>
 
 #define MAGIC 0xc436d7e6
 
@@ -757,7 +759,7 @@ done:
     return ret;
 }
 
-extern myst_sockdev_t* myst_sockdev_get(void)
+myst_sockdev_t* myst_sockdev_get(void)
 {
     // clang-format-off
     static myst_sockdev_t _sockdev = {
@@ -804,4 +806,119 @@ extern myst_sockdev_t* myst_sockdev_get(void)
     // clang-format-on
 
     return &_sockdev;
+}
+
+const char* myst_socket_type_str(int type)
+{
+    type &= ~SOCK_NONBLOCK;
+    type &= ~SOCK_CLOEXEC;
+
+    switch (type)
+    {
+        case SOCK_STREAM:
+            return "SOCK_STREAM";
+        case SOCK_DGRAM:
+            return "SOCK_DGRAM";
+        case SOCK_RAW:
+            return "SOCK_RAW";
+        case SOCK_RDM:
+            return "SOCK_RDM";
+        case SOCK_SEQPACKET:
+            return "SOCK_SEQPACKET";
+        case SOCK_DCCP:
+            return "SOCK_DCCP";
+        case SOCK_PACKET:
+            return "SOCK_PACKET";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+const char* myst_socket_domain_str(int domain)
+{
+    static const char* _names[] = {
+        "AF_UNSPEC",     "AF_LOCAL",     "AF_INET",     "AF_AX25",
+        "AF_IPX",        "AF_APPLETALK", "AF_NETROM",   "AF_BRIDGE",
+        "AF_ATMPVC",     "AF_X25",       "AF_INET6",    "AF_ROSE",
+        "AF_DECnet",     "AF_NETBEUI",   "AF_SECURITY", "AF_KEY",
+        "AF_NETLINK",    "AF_PACKET",    "AF_ASH",      "AF_ECONET",
+        "AF_ATMSVC",     "AF_RDS",       "AF_SNA",      "AF_IRDA",
+        "AF_PPPOX",      "AF_WANPIPE",   "AF_LLC",      "AF_IB",
+        "AF_MPLS",       "AF_CAN",       "AF_TIPC",     "AF_BLUETOOTH",
+        "AF_IUCV",       "AF_RXRPC",     "AF_ISDN",     "AF_PHONET",
+        "AF_IEEE802154", "AF_CAIF",      "AF_ALG",      "AF_NFC",
+        "AF_VSOCK",      "AF_KCM",       "AF_QIPCRTR",  "AF_SMC",
+        "AF_XDP",
+    };
+
+    if (domain >= 0 && domain < (int)MYST_COUNTOF(_names))
+        return _names[domain];
+
+    return "UNKNOWN";
+}
+
+const char* myst_format_socket_type(char* buf, size_t len, int type)
+{
+    myst_strlcpy(buf, myst_socket_type_str(type), len);
+
+    if (type & SOCK_NONBLOCK)
+        myst_strlcat(buf, "|SOCK_NONBLOCK", len);
+
+    if (type & SOCK_CLOEXEC)
+        myst_strlcat(buf, "|SOCK_CLOEXEC", len);
+
+    return buf;
+}
+
+int myst_sockdev_resolve(
+    int domain, /* AF_UNIX, AF_LOCAL, AF_INET or AF_INET6 */
+    int type,   /* SOCK_STREAM or SOCK_DGRAM */
+    myst_sockdev_t** dev)
+{
+    int ret = 0;
+
+    if (dev)
+        *dev = NULL;
+
+    if (!dev)
+        ERAISE(-EINVAL);
+
+    switch (domain)
+    {
+        case AF_UNIX: /* same value as AF_LOCAL */
+        {
+            if (!(type & SOCK_STREAM) && !(type & SOCK_DGRAM))
+            {
+                const char* str = myst_socket_type_str(type);
+                MYST_WLOG("unsupported socket type: %d: %s", type, str);
+                ERAISE(-ENOTSUP);
+            }
+
+            *dev = myst_sockdev_get_uds();
+            goto done;
+        }
+        case AF_INET:
+        case AF_INET6:
+        case AF_PACKET:
+        {
+            if (!(type & SOCK_STREAM) && !(type & SOCK_DGRAM))
+            {
+                const char* str = myst_socket_type_str(type);
+                MYST_WLOG("unsupported socket type: %d: %s", type, str);
+                ERAISE(-ENOTSUP);
+            }
+
+            *dev = myst_sockdev_get();
+            goto done;
+        }
+        default:
+        {
+            const char* str = myst_socket_domain_str(domain);
+            MYST_WLOG("unsupported socket domain: %d: %s", domain, str);
+            ERAISE(-EAFNOSUPPORT);
+        }
+    }
+
+done:
+    return ret;
 }

--- a/kernel/syslog.c
+++ b/kernel/syslog.c
@@ -1,0 +1,90 @@
+#include <syslog.h>
+
+#include <myst/kernel.h>
+#include <myst/printf.h>
+#include <myst/syslog.h>
+
+#define COLOR_RED "\e[31m"
+#define COLOR_YELLOW "\e[33m"
+#define COLOR_GREEN "\e[32m"
+#define COLOR_RESET "\e[0m"
+
+void __myst_vsyslog(
+    const char* file,
+    unsigned int line,
+    const char* func,
+    int priority,
+    const char* format,
+    va_list ap)
+{
+    static const char* _names[8] = {
+        "panic",  /* LOG_EMERG */
+        "alert",  /* LOG_ALERT */
+        "crit",   /* LOG_CRIT */
+        "err",    /* LOG_ERR */
+        "warn",   /* LOG_WARNING */
+        "notice", /* LOG_NOTICE */
+        "info",   /* LOG_INFO */
+        "debug",  /* LOG_DEBUG */
+    };
+    const int pri = (priority & 7);
+    const char* name = _names[pri];
+
+    if (!(pri <= __myst_kernel_args.syslog_level))
+        return;
+
+    switch (pri)
+    {
+        case LOG_EMERG:
+        case LOG_ALERT:
+        case LOG_CRIT:
+        case LOG_ERR:
+            myst_eprintf(COLOR_RED);
+            break;
+        case LOG_WARNING:
+        case LOG_NOTICE:
+            myst_eprintf(COLOR_YELLOW);
+            break;
+        case LOG_INFO:
+        case LOG_DEBUG:
+            myst_eprintf(COLOR_GREEN);
+            break;
+    }
+
+    myst_eprintf("mytikos: %s: ", name);
+
+    if (file && line && func)
+        myst_eprintf("%s(%u): %s(): ", file, line, func);
+
+    myst_veprintf(format, ap);
+
+    myst_eprintf("\n");
+    myst_eprintf(COLOR_RESET);
+}
+
+void myst_vsyslog(int priority, const char* format, va_list ap)
+{
+    __myst_vsyslog(NULL, 0, NULL, priority, format, ap);
+}
+
+void myst_syslog(int priority, const char* format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    myst_vsyslog(priority, format, ap);
+    va_end(ap);
+}
+
+void __myst_syslog(
+    const char* file,
+    unsigned int line,
+    const char* func,
+    int priority,
+    const char* format,
+    ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    __myst_vsyslog(file, line, func, priority, format, ap);
+    va_end(ap);
+}

--- a/kernel/tcall.c
+++ b/kernel/tcall.c
@@ -435,3 +435,33 @@ ssize_t myst_tcall_recvmsg_block(int sockfd, struct msghdr* msg, int flags)
     long params[6] = {(long)sockfd, (long)msg, (long)flags};
     return myst_tcall(MYST_TCALL_RECVMSG_BLOCK, params);
 }
+
+long myst_tcall_get_tempfile_name(char* buf, size_t size)
+{
+    long params[6] = {(long)buf, (long)size};
+    return myst_tcall(MYST_TCALL_GET_TEMPFILE_NAME, params);
+}
+
+int myst_tcall_encrypt_aes_256_xts(
+    const myst_key_512_t* key,
+    const void* data_in,
+    void* data_out,
+    size_t data_size,
+    uint64_t index)
+{
+    long params[6] = {
+        (long)key, (long)data_in, (long)data_out, (long)data_size, (long)index};
+    return myst_tcall(MYST_TCALL_ENCRYPT_AES_256_XTS, params);
+}
+
+int myst_tcall_decrypt_aes_256_xts(
+    const myst_key_512_t* key,
+    const void* data_in,
+    void* data_out,
+    size_t data_size,
+    uint64_t index)
+{
+    long params[6] = {
+        (long)key, (long)data_in, (long)data_out, (long)data_size, (long)index};
+    return myst_tcall(MYST_TCALL_DECRYPT_AES_256_XTS, params);
+}

--- a/kernel/udsdev.c
+++ b/kernel/udsdev.c
@@ -5,7 +5,7 @@
 **==============================================================================
 **
 ** Unix-domain sockets
-** ===================
+** -------------------
 **
 ** This module implements Unix-domain sockets (UDS), which are created with
 ** the AF_LOCAL or AF_UNIX socket domain (which are equivalent in Linux).

--- a/kernel/udsdev.c
+++ b/kernel/udsdev.c
@@ -1,0 +1,1695 @@
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+
+#include <myst/crypt.h>
+#include <myst/defs.h>
+#include <myst/eraise.h>
+#include <myst/hex.h>
+#include <myst/iov.h>
+#include <myst/once.h>
+#include <myst/sha256.h>
+#include <myst/sockdev.h>
+#include <myst/strings.h>
+#include <myst/syscall.h>
+#include <myst/syslog.h>
+#include <myst/tcall.h>
+#include <myst/time.h>
+
+#define MAGIC 0xd731a683
+
+#define PAYLOAD_SIZE (512 - sizeof(uint64_t) - sizeof(myst_sha256_t))
+
+#define FRAME_CONTROL_MAGIC 0x9ef92565
+#define FRAME_DATA_MAGIC 0x3fd95160
+
+/*
+**==============================================================================
+**
+** Unix-domain sockets
+** ===================
+**
+** This module implements Unix-domain sockets (UDS), which are created with
+** the AF_LOCAL or AF_UNIX socket domain (which are equivalent in Linux).
+**
+**     int sockfd = socket(AF_LOCAL, SOCK_STREAM, 0);
+**     int sockfd = socket(AF_UNIX, SOCK_DGRAM, 0);
+**     int sockfd = socket(AF_LOCAL, SOCK_STREAM, 0);
+**     int sockfd = socket(AF_UNIX, SOCK_DGRAM, 0);
+**
+** UDS is subject to the following limitations.
+**
+**     - Works only between two pseudo processes within the same kernel image
+**         - No support for host-to-kernel UDS
+**         - No support for kernel-to-kernel UDS
+**     - Only supports SOCK_STREAM and SOCK_DGRAM
+**     - Does not support ancillary data (aka, control data)
+**
+** This implementation employs host-side sockets but adds a layer of encryption
+** performed inside the kernel. Each read/write is encapsulated in one or more
+** encrypted frames (see frame_t below). Frames are 512 bytes and contain the
+** following elements.
+**
+**     - magic number (FRAME_DATA_MAGIC or FRAME_CONTROL_MAGIC)
+**     - size (the size in bytes of the user payload data)
+**     - payload (zero-padded buffer of user data)
+**     - hash (the hash of the full payload, including any zero padding)
+**
+** A frame may be a "data frame" or a "control frame" as indicated by the
+** magic number (control frames are experimental and disabled by default).
+**
+** It may take multiple frames to encode the user data being transmitted. Each
+** 512-byte frame may encode at most 472 bytes of data (512 minus the 40-byte
+** header). So 512 bytes of user data will require two frames:
+**
+**     Frame-1:
+**         40-byte header
+**         472 bytes of user data
+**         0 bytes of padding
+**     Frame-2:
+**         40-byte header
+**         40 bytes of user data
+**         432 bytes of zero padding
+**
+** The SHA-256 hash is the hash of the full payload, including any zero padding.
+**
+** Frames are encrypted/decrypted with the AES-256-XTS cipher, which is
+** currently the default cipher for Linux file block encryption. The
+** initialization vector is given by a message "counter" maintained within the
+** kernel. Each socket endpoint increments this counter during each encrypt or
+** decrypt operation.
+**
+** A single key is used for the lifetime of the kernel image. The key is
+** obtained by myst_tcall_random(), which eventually calls oe_random() in
+** SGX (based on either the RDRAND or SDRAND instruction).
+**
+** The combination between the initialization vector and random key renders
+** replay attacks ineffective. The hash of the payload is not strictly necessary
+** but provides additional data integrity for detecting possible programming
+** errors. It is not a security measure. If messages are replayed out of order,
+** the decryption operation will fail, since the cipher operation incorporates
+** an initialization vector (containing a monotonically increasing message
+** counter).
+**
+**==============================================================================
+*/
+
+typedef struct frame
+{
+    struct
+    {
+        uint32_t magic;
+        uint32_t size;
+        myst_sha256_t hash;
+    } header;
+    uint8_t payload[PAYLOAD_SIZE];
+} frame_t;
+
+MYST_STATIC_ASSERT(sizeof(frame_t) == 512);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(frame_t, payload) == 40);
+
+struct myst_sock
+{
+    uint32_t magic;
+    bool nonblock;
+    myst_sock_t* impl;
+    uint8_t inbuf[PAYLOAD_SIZE];
+    size_t inbuf_size;
+    char sun_path[PATH_MAX]; /* the socket file path if any */
+    size_t counter;
+};
+
+static int _sha256(myst_sha256_t* sha256, const void* data, size_t size)
+{
+    int ret = 0;
+    myst_sha256_ctx_t ctx;
+
+    if (!sha256 || !data)
+        ERAISE(-EINVAL);
+
+    ECHECK(myst_sha256_start(&ctx));
+    ECHECK(myst_sha256_update(&ctx, data, size));
+    ECHECK(myst_sha256_finish(&ctx, sha256));
+
+done:
+    return ret;
+}
+
+/* get or generate the key to be used for UDS encryption */
+static const myst_key_512_t* _get_key(void)
+{
+    myst_key_512_t* ret = NULL;
+    static myst_key_512_t _key;
+    static myst_key_512_t _zero_key;
+    static int _initialized;
+    static myst_spinlock_t _lock;
+
+    myst_spin_lock(&_lock);
+    {
+        if (_initialized == 0)
+        {
+            if (myst_tcall_random(_key.data, sizeof(_key)) == 0 &&
+                memcmp(&_key, &_zero_key, sizeof(_key)) != 0)
+            {
+                _initialized = 1;
+                ret = &_key;
+            }
+        }
+        else
+        {
+            ret = &_key;
+        }
+    }
+    myst_spin_unlock(&_lock);
+
+    return ret;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+static int _encrypt_frame(frame_t* frame, size_t counter)
+{
+#ifdef DISABLE_ENCRYPTION
+    (void)counter;
+    (void)_get_key;
+    frame_t in = *frame;
+    memcpy(frame, &in, sizeof(in));
+    return 0;
+#else
+    const myst_key_512_t* key = _get_key();
+
+    if (!key)
+        return -ENOSYS;
+
+    frame_t in = *frame;
+    _sha256(&in.header.hash, in.payload, PAYLOAD_SIZE);
+
+    return myst_tcall_encrypt_aes_256_xts(key, &in, frame, sizeof(in), counter);
+#endif
+}
+#pragma GCC diagnostic pop
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+static int _decrypt_frame(frame_t* frame, size_t counter)
+{
+    int ret = 0;
+    const myst_key_512_t* key = _get_key();
+    myst_sha256_t hash;
+    frame_t in = *frame;
+
+    if (!key)
+        return -ENOSYS;
+
+    if (myst_tcall_decrypt_aes_256_xts(key, &in, frame, sizeof(in), counter) !=
+        0)
+    {
+        ERAISE(-EIO);
+    }
+
+    if (frame->header.magic != FRAME_DATA_MAGIC &&
+        frame->header.magic != FRAME_CONTROL_MAGIC)
+    {
+        ERAISE(-EIO);
+    }
+
+    if (frame->header.size > PAYLOAD_SIZE)
+    {
+        ERAISE(-EIO);
+    }
+
+    if (_sha256(&hash, frame->payload, PAYLOAD_SIZE) != 0)
+        ERAISE(-EIO);
+
+    if (memcmp(&hash, &frame->header.hash, sizeof(hash)) != 0)
+        ERAISE(-EIO);
+
+done:
+    return ret;
+}
+#pragma GCC diagnostic pop
+
+MYST_INLINE bool _valid_sock(const myst_sock_t* sock)
+{
+    return sock && sock->magic == MAGIC;
+}
+
+static void _free_sock(myst_sock_t* sock)
+{
+    if (sock)
+    {
+        memset(sock, 0, sizeof(myst_sock_t));
+        free(sock);
+    }
+}
+
+static size_t _min(size_t x, size_t y)
+{
+    return (x < y) ? x : y;
+}
+
+static int _new_sock(bool nonblock, myst_sock_t* impl, myst_sock_t** sock_out)
+{
+    int ret = 0;
+    myst_sock_t* sock = NULL;
+
+    if (!sock_out)
+        ERAISE(-EINVAL);
+
+    if (!(sock = calloc(1, sizeof(myst_sock_t))))
+        ERAISE(-ENOMEM);
+
+    sock->magic = MAGIC;
+    sock->nonblock = nonblock;
+    sock->impl = impl;
+
+    *sock_out = sock;
+    sock = NULL;
+
+done:
+
+    if (sock)
+        _free_sock(sock);
+
+    return ret;
+}
+
+static ssize_t _read(
+    myst_sock_t* sock,
+    myst_sockdev_t* sockdev,
+    myst_sock_t* sock_impl,
+    void* buf,
+    size_t len)
+{
+    ssize_t ret = 0;
+    uint8_t* ptr = buf;
+    size_t rem = len;
+    size_t total = 0;
+    frame_t* frame = NULL;
+
+    if (!(frame = calloc(1, sizeof(frame_t))))
+        ERAISE(-ENOMEM);
+
+    /* if any bytes left over in the input buffer form previous call */
+    if (rem > 0 && sock->inbuf_size > 0)
+    {
+        const size_t min = _min(rem, sock->inbuf_size);
+        memcpy(ptr, sock->inbuf, min);
+        memmove(sock->inbuf, &sock->inbuf[min], sock->inbuf_size - min);
+        sock->inbuf_size -= min;
+
+        ptr += min;
+        rem -= min;
+        total += min;
+    }
+
+    while (rem > 0)
+    {
+        ssize_t n;
+
+        /* delegate to socket device */
+        n = (*sockdev->sd_read)(sockdev, sock_impl, frame, sizeof(frame_t));
+
+        if (n < 0)
+        {
+            if (total > 0)
+            {
+                ret = total;
+                goto done;
+            }
+
+            ECHECK(n);
+        }
+
+        if (n == 0)
+        {
+            ret = total;
+            goto done;
+        }
+
+        assert(n == sizeof(frame_t));
+        ECHECK(_decrypt_frame(frame, sock->counter++));
+
+        const size_t min = _min(rem, frame->header.size);
+        memcpy(ptr, frame->payload, min);
+        ptr += min;
+        rem -= min;
+        total += min;
+
+        /* if there are unused bytes, then save them for later */
+        if (min < frame->header.size)
+        {
+            sock->inbuf_size = frame->header.size - min;
+            memcpy(sock->inbuf, &frame->payload[min], sock->inbuf_size);
+        }
+    }
+
+    ret = total;
+
+done:
+
+    if (frame)
+        free(frame);
+
+    return ret;
+}
+
+static ssize_t _write(
+    myst_sock_t* sock,
+    myst_sockdev_t* sockdev,
+    myst_sock_t* sock_impl,
+    const void* buf,
+    size_t len)
+{
+    ssize_t ret = 0;
+    const uint8_t* ptr = buf;
+    size_t rem = len;
+    size_t total = 0;
+    frame_t* frame = NULL;
+
+    if (!(frame = calloc(1, sizeof(frame_t))))
+        ERAISE(-ENOMEM);
+
+    while (rem > 0)
+    {
+        size_t min = _min(rem, PAYLOAD_SIZE);
+        ssize_t n;
+
+        frame->header.magic = FRAME_DATA_MAGIC;
+        frame->header.size = min;
+        memcpy(frame->payload, ptr, min);
+        memset(frame->payload + min, 0, PAYLOAD_SIZE - min);
+        ECHECK(_encrypt_frame(frame, sock->counter++));
+
+        /* delegate to socket device */
+        n = (*sockdev->sd_write)(sockdev, sock_impl, frame, sizeof(frame_t));
+
+        if (n < 0)
+        {
+            if (total > 0)
+            {
+                ret = total;
+                goto done;
+            }
+
+            ECHECK(n);
+        }
+
+        if (n == 0)
+        {
+            ret = total;
+            goto done;
+        }
+
+        assert(n == sizeof(frame_t));
+
+        ptr += min;
+        rem -= min;
+        total += min;
+    }
+
+    ret = total;
+
+done:
+
+    if (frame)
+        free(frame);
+
+    return ret;
+}
+
+static ssize_t _recvfrom(
+    myst_sock_t* sock,
+    myst_sockdev_t* sockdev,
+    myst_sock_t* sock_impl,
+    void* buf,
+    size_t len,
+    int flags,
+    struct sockaddr* src_addr,
+    socklen_t* addrlen)
+{
+    ssize_t ret = 0;
+    uint8_t* ptr = buf;
+    size_t rem = len;
+    size_t total = 0;
+    frame_t* frame = NULL;
+
+    if (!(frame = calloc(1, sizeof(frame_t))))
+        ERAISE(-ENOMEM);
+
+    /* if any bytes left over in the input buffer form previous call */
+    if (rem > 0 && sock->inbuf_size > 0)
+    {
+        const size_t min = _min(rem, sock->inbuf_size);
+        memcpy(ptr, sock->inbuf, min);
+        memmove(sock->inbuf, &sock->inbuf[min], sock->inbuf_size - min);
+        sock->inbuf_size -= min;
+
+        ptr += min;
+        rem -= min;
+        total += min;
+    }
+
+    while (rem > 0)
+    {
+        ssize_t n;
+
+        /* delegate to socket device */
+        n = (*sockdev->sd_recvfrom)(
+            sockdev,
+            sock_impl,
+            frame,
+            sizeof(frame_t),
+            flags,
+            src_addr,
+            addrlen);
+
+        if (n < 0)
+        {
+            if (total > 0)
+            {
+                ret = total;
+                goto done;
+            }
+
+            ECHECK(n);
+        }
+
+        if (n == 0)
+        {
+            ret = total;
+            goto done;
+        }
+
+        assert(n == sizeof(frame_t));
+        ECHECK(_decrypt_frame(frame, sock->counter++));
+
+        const size_t min = _min(rem, frame->header.size);
+        memcpy(ptr, frame->payload, min);
+        ptr += min;
+        rem -= min;
+        total += min;
+
+        /* if there are unused bytes, then save them for later */
+        if (min < frame->header.size)
+        {
+            sock->inbuf_size = frame->header.size - min;
+            memcpy(sock->inbuf, &frame->payload[min], sock->inbuf_size);
+        }
+    }
+
+    ret = total;
+
+done:
+
+    if (frame)
+        free(frame);
+
+    return ret;
+}
+
+static ssize_t _sendto(
+    myst_sock_t* sock,
+    myst_sockdev_t* sockdev,
+    myst_sock_t* sock_impl,
+    const void* buf,
+    size_t len,
+    int flags,
+    const struct sockaddr* dest_addr,
+    socklen_t addrlen)
+{
+    ssize_t ret = 0;
+    const uint8_t* ptr = buf;
+    size_t rem = len;
+    size_t total = 0;
+    frame_t* frame = NULL;
+
+    if (!(frame = calloc(1, sizeof(frame_t))))
+        ERAISE(-ENOMEM);
+
+    while (rem > 0)
+    {
+        size_t min = _min(rem, PAYLOAD_SIZE);
+        ssize_t n;
+
+        frame->header.magic = FRAME_DATA_MAGIC;
+        frame->header.size = min;
+        memcpy(frame->payload, ptr, min);
+        memset(frame->payload + min, 0, PAYLOAD_SIZE - min);
+        ECHECK(_encrypt_frame(frame, sock->counter++));
+
+        /* delegate to socket device */
+        n = (*sockdev->sd_sendto)(
+            sockdev,
+            sock_impl,
+            frame,
+            sizeof(frame_t),
+            flags,
+            dest_addr,
+            addrlen);
+
+        if (n < 0)
+        {
+            if (total > 0)
+            {
+                ret = total;
+                goto done;
+            }
+
+            ECHECK(n);
+        }
+
+        if (n == 0)
+        {
+            ret = total;
+            goto done;
+        }
+
+        assert(n == sizeof(frame_t));
+
+        ptr += min;
+        rem -= min;
+        total += min;
+    }
+
+    ret = total;
+
+done:
+
+    if (frame)
+        free(frame);
+
+    return ret;
+}
+
+static ssize_t _recvmsg(
+    myst_sock_t* sock,
+    myst_sockdev_t* sockdev,
+    myst_sock_t* sock_impl,
+    struct msghdr* msg,
+    int flags)
+{
+    ssize_t ret = 0;
+    size_t len;
+    frame_t* frame = NULL;
+    void* buf = NULL;
+    struct peek_state
+    {
+        size_t counter;
+        uint8_t inbuf[PAYLOAD_SIZE];
+        size_t inbuf_size;
+    };
+    struct peek_state* peek_state = NULL;
+    uint8_t* ptr;
+    size_t rem;
+    size_t total = 0; /* total data received */
+
+    /* backup state if MSG_PEEK request */
+    if (flags & MSG_PEEK)
+    {
+        if (!(peek_state = calloc(1, sizeof(struct peek_state))))
+            ERAISE(-ENOMEM);
+
+        peek_state->counter = sock->counter;
+        memcpy(peek_state->inbuf, sock->inbuf, sizeof(peek_state->inbuf));
+        peek_state->inbuf_size = sock->inbuf_size;
+    }
+
+    if (!(frame = calloc(1, sizeof(frame_t))))
+        ERAISE(-ENOMEM);
+
+    ERAISE(len = myst_iov_len(msg->msg_iov, msg->msg_iovlen));
+
+    if (len == 0)
+        goto done;
+
+    if (!(buf = malloc(len)))
+        ERAISE(-ENOMEM);
+
+    ptr = buf;
+    rem = len;
+
+    /* if any bytes left over in the input buffer form previous call */
+    if (rem > 0 && sock->inbuf_size > 0)
+    {
+        const size_t min = _min(rem, sock->inbuf_size);
+        memcpy(ptr, sock->inbuf, min);
+        memmove(sock->inbuf, &sock->inbuf[min], sock->inbuf_size - min);
+        sock->inbuf_size -= min;
+
+        ptr += min;
+        rem -= min;
+        total += min;
+    }
+
+#ifdef ENABLE_CONTROL_DATA
+    if (msg->msg_control && msg->msg_controllen)
+    {
+        uint8_t* cptr = msg->msg_control;
+        size_t crem = msg->msg_controllen;
+        size_t ctotal = 0;
+
+        msg->msg_controllen = 0;
+
+        /* handle any control data */
+        while (crem > 0)
+        {
+            ssize_t n;
+            struct iovec iov_buf = {frame, sizeof(frame_t)};
+            struct msghdr msg_buf;
+            size_t min;
+
+            memset(&msg_buf, 0, sizeof(msg_buf));
+            msg_buf.msg_name = msg->msg_name;
+            msg_buf.msg_namelen = msg->msg_namelen;
+            msg_buf.msg_iov = &iov_buf;
+            msg_buf.msg_iovlen = 1;
+
+            /* peek at the next frame (leaving it on the wire) */
+            {
+                n = (*sockdev->sd_recvmsg)(
+                    sockdev, sock_impl, &msg_buf, flags | MSG_PEEK);
+                ECHECK(n);
+
+                if (n == 0)
+                    goto done;
+
+                if (n != sizeof(frame_t))
+                    ERAISE(-EIO);
+
+                ECHECK(_decrypt_frame(frame, sock->counter));
+
+                if (frame->header.magic != FRAME_CONTROL_MAGIC)
+                    break;
+            }
+
+            /* read the frame for real now */
+            {
+                n = (*sockdev->sd_recvmsg)(sockdev, sock_impl, &msg_buf, flags);
+                ECHECK(n);
+
+                if (n == 0)
+                    goto done;
+
+                if (n != sizeof(frame_t))
+                    ERAISE(-EIO);
+
+                ECHECK(_decrypt_frame(frame, sock->counter++));
+
+                if (frame->header.magic != FRAME_CONTROL_MAGIC)
+                    break;
+            }
+
+            if ((min = _min(crem, frame->header.size)))
+            {
+                memcpy(cptr, frame->payload, min);
+                cptr += min;
+                crem -= min;
+                ctotal += min;
+            }
+        }
+
+        msg->msg_controllen = ctotal;
+    }
+#endif /* ENABLE_CONTROL_DATA */
+
+    while (rem > 0)
+    {
+        ssize_t n;
+        struct iovec iov_buf = {frame, sizeof(frame_t)};
+        struct msghdr msg_buf;
+
+        memset(&msg_buf, 0, sizeof(msg_buf));
+        msg_buf.msg_name = msg->msg_name;
+        msg_buf.msg_namelen = msg->msg_namelen;
+        msg_buf.msg_iov = &iov_buf;
+        msg_buf.msg_iovlen = 1;
+
+        /* delegate to socket device */
+        n = (*sockdev->sd_recvmsg)(sockdev, sock_impl, &msg_buf, flags);
+
+        if (n < 0)
+        {
+            if (total > 0)
+            {
+                ret = total;
+                break;
+            }
+
+            ECHECK(n);
+        }
+
+        if (n == 0)
+        {
+            ret = total;
+            break;
+        }
+
+        assert(n == sizeof(frame_t));
+        ECHECK(_decrypt_frame(frame, sock->counter++));
+
+        const size_t min = _min(rem, frame->header.size);
+        memcpy(ptr, frame->payload, min);
+        ptr += min;
+        rem -= min;
+        total += min;
+
+        /* if there are unused bytes, then save them for later */
+        if (min < frame->header.size)
+        {
+            sock->inbuf_size = frame->header.size - min;
+            memcpy(sock->inbuf, &frame->payload[min], sock->inbuf_size);
+        }
+
+#ifdef ENABLE_CONTROL_DATA
+        if (msg->msg_controllen)
+            break;
+#endif /* ENABLE_CONTROL_DATA */
+    }
+
+    ECHECK(myst_iov_scatter(msg->msg_iov, msg->msg_iovlen, buf, total));
+
+    ret = total;
+
+done:
+
+    /* restore the state if MSG_PEEK request */
+    if (peek_state)
+    {
+        sock->counter = peek_state->counter;
+        memcpy(sock->inbuf, peek_state->inbuf, sizeof(sock->inbuf));
+        sock->inbuf_size = peek_state->inbuf_size;
+        free(peek_state);
+    }
+
+    if (frame)
+        free(frame);
+
+    if (buf)
+        free(buf);
+
+    return ret;
+}
+
+static ssize_t _sendmsg(
+    myst_sock_t* sock,
+    myst_sockdev_t* sockdev,
+    myst_sock_t* sock_impl,
+    const struct msghdr* msg,
+    int flags)
+{
+    ssize_t ret = 0;
+    const uint8_t* ptr;
+    size_t rem;
+    size_t total = 0;
+    frame_t* frame = NULL;
+    void* base = NULL;
+
+    if (!(frame = calloc(1, sizeof(frame_t))))
+        ERAISE(-ENOMEM);
+
+    if (msg->msg_iovlen != 1)
+    {
+        ERAISE((rem = myst_iov_gather(msg->msg_iov, msg->msg_iovlen, &base)));
+        ptr = base;
+    }
+    else
+    {
+        ptr = msg->msg_iov[0].iov_base;
+        rem = msg->msg_iov[0].iov_len;
+    }
+
+#ifdef ENABLE_CONTROL_DATA
+    {
+        const uint8_t* cptr = msg->msg_control;
+        size_t crem = msg->msg_controllen;
+        size_t ctotal = 0;
+
+        /* send the ancillary data (control data) if any */
+        while (crem > 0)
+        {
+            size_t min = _min(crem, PAYLOAD_SIZE);
+            ssize_t n;
+            struct iovec iov_buf = {frame, sizeof(frame_t)};
+            struct msghdr msg_buf;
+
+            memset(&msg_buf, 0, sizeof(msg_buf));
+            msg_buf.msg_name = msg->msg_name;
+            msg_buf.msg_namelen = msg->msg_namelen;
+            msg_buf.msg_iov = &iov_buf;
+            msg_buf.msg_iovlen = 1;
+
+            frame->header.magic = FRAME_CONTROL_MAGIC;
+            frame->header.size = min;
+            memcpy(frame->payload, cptr, min);
+            memset(frame->payload + min, 0, PAYLOAD_SIZE - min);
+            ECHECK(_encrypt_frame(frame, sock->counter++));
+
+            /* delegate to socket device */
+            n = (*sockdev->sd_sendmsg)(sockdev, sock_impl, &msg_buf, flags);
+            ECHECK(n);
+
+            assert(n == sizeof(frame_t));
+
+            cptr += min;
+            crem -= min;
+            ctotal += min;
+        }
+    }
+#endif /* ENABLE_CONTROL_DATA */
+
+    /* send the payload */
+    while (rem > 0)
+    {
+        size_t min = _min(rem, PAYLOAD_SIZE);
+        ssize_t n;
+        struct iovec iov_buf = {frame, sizeof(frame_t)};
+        struct msghdr msg_buf;
+
+        memset(&msg_buf, 0, sizeof(msg_buf));
+        msg_buf.msg_name = msg->msg_name;
+        msg_buf.msg_namelen = msg->msg_namelen;
+        msg_buf.msg_iov = &iov_buf;
+        msg_buf.msg_iovlen = 1;
+
+        frame->header.magic = FRAME_DATA_MAGIC;
+        frame->header.size = min;
+
+        memcpy(frame->payload, ptr, min);
+        memset(frame->payload + min, 0, PAYLOAD_SIZE - min);
+        ECHECK(_encrypt_frame(frame, sock->counter++));
+
+        /* delegate to socket device */
+        n = (*sockdev->sd_sendmsg)(sockdev, sock_impl, &msg_buf, flags);
+
+        if (n < 0)
+        {
+            if (total > 0)
+            {
+                ret = total;
+                goto done;
+            }
+
+            ECHECK(n);
+        }
+
+        if (n == 0)
+        {
+            ret = total;
+            goto done;
+        }
+
+        assert(n == sizeof(frame_t));
+
+        ptr += min;
+        rem -= min;
+        total += min;
+    }
+
+    ret = total;
+
+done:
+
+    if (base)
+        free(base);
+
+    if (frame)
+        free(frame);
+
+    return ret;
+}
+
+static int _udsdev_socket(
+    myst_sockdev_t* dev,
+    int domain,
+    int type,
+    int protocol,
+    myst_sock_t** sock_out)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+    myst_sock_t* sock = NULL;
+    myst_sock_t* sock_impl = NULL;
+
+    if (sock_out)
+        *sock_out = NULL;
+
+    if (!dev || !sock_out)
+        ERAISE(-EINVAL);
+
+    if (domain != AF_UNIX && domain != AF_LOCAL)
+        ERAISE(-ENOTSUP);
+
+    if (!(type & SOCK_STREAM) && !(type & SOCK_DGRAM))
+        ERAISE(-ENOTSUP);
+
+    ECHECK((sockdev->sd_socket)(sockdev, domain, type, protocol, &sock_impl));
+    const bool nonblock = type & SOCK_NONBLOCK;
+    ECHECK(_new_sock(nonblock, sock_impl, &sock));
+
+    *sock_out = sock;
+    sock_impl = NULL;
+    sock = NULL;
+
+done:
+
+    if (sock)
+        _free_sock(sock);
+
+    if (sock_impl)
+        _free_sock(sock_impl);
+
+    return ret;
+}
+
+static int _udsdev_listen(myst_sockdev_t* dev, myst_sock_t* sock, int backlog)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK((*sockdev->sd_listen)(sockdev, sock->impl, backlog));
+
+done:
+
+    return ret;
+}
+
+static int _udsdev_connect(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    const struct sockaddr* addr,
+    socklen_t addrlen)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+    struct locals
+    {
+        struct sockaddr_un addr;
+        char path[PATH_MAX];
+    };
+    struct locals* locals = NULL;
+    const struct sockaddr_un* sun = (const struct sockaddr_un*)addr;
+
+    if (!dev || !_valid_sock(sock) || !addr)
+        ERAISE(-EINVAL);
+
+    /* Read the Unix-domain socket file link */
+    if (*sun->sun_path)
+    {
+        const size_t size = sizeof(locals->path) - 1;
+        ssize_t n;
+
+        if (!(locals = calloc(1, sizeof(struct locals))))
+            ERAISE(-ENOMEM);
+
+        ECHECK(n = myst_syscall_readlink(sun->sun_path, locals->path, size));
+        locals->path[n] = '\0';
+
+        /* fixup the address to use the host-side address */
+        memcpy(&locals->addr, addr, sizeof(struct sockaddr_un));
+        myst_strlcpy(
+            locals->addr.sun_path, locals->path, sizeof(locals->addr.sun_path));
+
+        /* delegate to socket device */
+        ECHECK((*sockdev->sd_connect)(
+            sockdev, sock->impl, (struct sockaddr*)&locals->addr, addrlen));
+    }
+    else
+    {
+        /* delegate to socket device */
+        ECHECK((*sockdev->sd_connect)(sockdev, sock->impl, addr, addrlen));
+    }
+
+done:
+
+    if (locals)
+        free(locals);
+
+    return ret;
+}
+
+static int _udsdev_accept4(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    struct sockaddr* addr,
+    socklen_t* addrlen,
+    int flags,
+    myst_sock_t** new_sock_out)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+    myst_sock_t* new_sock = NULL;
+    myst_sock_t* new_sock_impl = NULL;
+
+    if (!dev || !_valid_sock(sock) || !new_sock_out)
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK((*sockdev->sd_accept4)(
+        dev, sock->impl, addr, addrlen, flags, &new_sock_impl));
+
+    const bool nonblock = flags & SOCK_NONBLOCK;
+    ECHECK(_new_sock(nonblock, new_sock_impl, &new_sock));
+    *new_sock_out = new_sock;
+    new_sock = NULL;
+    new_sock_impl = NULL;
+
+done:
+
+    if (new_sock)
+        _free_sock(new_sock);
+
+    if (new_sock_impl)
+        _free_sock(new_sock_impl);
+
+    return ret;
+}
+
+static int _udsdev_getsockopt(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    int level,
+    int optname,
+    void* optval,
+    socklen_t* optlen)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK((*sockdev->sd_getsockopt)(
+        sockdev, sock->impl, level, optname, optval, optlen));
+
+done:
+    return ret;
+}
+
+static int _udsdev_setsockopt(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    int level,
+    int optname,
+    const void* optval,
+    socklen_t optlen)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK((*sockdev->sd_setsockopt)(
+        sockdev, sock->impl, level, optname, optval, optlen));
+
+done:
+    return ret;
+}
+
+static int _udsdev_target_fd(myst_sockdev_t* dev, myst_sock_t* sock)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ret = (*sockdev->sd_target_fd)(sockdev, sock->impl);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static int _udsdev_fstat(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    struct stat* statbuf)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK((*sockdev->sd_fstat)(sockdev, sock->impl, statbuf));
+
+done:
+
+    return ret;
+}
+
+static int _udsdev_bind(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    const struct sockaddr* addr,
+    socklen_t addrlen)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+    struct locals
+    {
+        struct sockaddr_un addr;
+        char path[PATH_MAX];
+        struct sockaddr_un addr_buf;
+    };
+    struct locals* locals = NULL;
+    const struct sockaddr_un* sun = (const struct sockaddr_un*)addr;
+
+    if (!dev || !_valid_sock(sock) || !addr || !addrlen)
+        ERAISE(-EINVAL);
+
+    if (addrlen <= MYST_OFFSETOF(struct sockaddr_un, sun_path))
+        ERAISE(-EINVAL);
+
+    if (addrlen > sizeof(struct sockaddr_un))
+        ERAISE(-EINVAL);
+
+    if (!(locals = calloc(1, sizeof(struct locals))))
+        ERAISE(-ENOMEM);
+
+    memcpy(&locals->addr_buf, addr, addrlen);
+    locals->addr_buf.sun_path[sizeof(sun->sun_path) - 1] = '\0';
+    sun = &locals->addr_buf;
+
+    /* create the Unix-domain socket file (use a symlink) */
+    if (*sun->sun_path)
+    {
+        struct stat statbuf;
+
+        /* raise EADDRINUSE if symbolic link already exists */
+        if (myst_syscall_lstat(sun->sun_path, &statbuf) == 0)
+            ERAISE(-EADDRINUSE);
+
+        /* get a temporary file name on the host file system */
+        ECHECK(
+            myst_tcall_get_tempfile_name(locals->path, sizeof(locals->path)));
+
+        ECHECK(myst_syscall_symlink(locals->path, sun->sun_path));
+
+        myst_strlcpy(sock->sun_path, sun->sun_path, sizeof(sock->sun_path));
+
+        locals->addr = locals->addr_buf;
+        myst_strlcpy(
+            locals->addr.sun_path, locals->path, sizeof(locals->addr.sun_path));
+
+        /* delegate to socket device */
+        ECHECK((*sockdev->sd_bind)(
+            sockdev,
+            sock->impl,
+            (const struct sockaddr*)&locals->addr,
+            addrlen));
+    }
+    else
+    {
+        /* delegate to socket device */
+        ECHECK((*sockdev->sd_bind)(sockdev, sock->impl, addr, addrlen));
+    }
+
+done:
+
+    if (locals)
+        free(locals);
+
+    return ret;
+}
+
+static ssize_t _udsdev_sendto(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    const void* buf,
+    size_t len,
+    int flags,
+    const struct sockaddr* dest_addr,
+    socklen_t addrlen)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    ret =
+        _sendto(sock, sockdev, sock->impl, buf, len, flags, dest_addr, addrlen);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static ssize_t _udsdev_recvfrom(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    void* buf,
+    size_t len,
+    int flags,
+    struct sockaddr* src_addr,
+    socklen_t* addrlen)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ret = _recvfrom(
+        sock, sockdev, sock->impl, buf, len, flags, src_addr, addrlen);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static ssize_t _udsdev_read(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    void* buf,
+    size_t count)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    ret = _read(sock, sockdev, sock->impl, buf, count);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static ssize_t _udsdev_write(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    const void* buf,
+    size_t count)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ret = _write(sock, sockdev, sock->impl, buf, count);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static ssize_t _udsdev_readv(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    const struct iovec* iov,
+    int iovcnt)
+{
+    ssize_t ret = 0;
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    ret = myst_fdops_readv(&dev->fdops, sock, iov, iovcnt);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static ssize_t _udsdev_writev(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    const struct iovec* iov,
+    int iovcnt)
+{
+    ssize_t ret = 0;
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    ret = myst_fdops_writev(&dev->fdops, sock, iov, iovcnt);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static int _udsdev_close(myst_sockdev_t* dev, myst_sock_t* sock)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK((*sockdev->sd_close)(sockdev, sock->impl));
+
+    memset(sock, 0, sizeof(myst_sock_t));
+    free(sock);
+
+done:
+    return ret;
+}
+
+static int _udsdev_fcntl(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    int cmd,
+    long arg)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK(ret = (*sockdev->sd_fcntl)(sockdev, sock->impl, cmd, arg));
+
+done:
+    return ret;
+}
+
+static int _udsdev_ioctl(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    unsigned long request,
+    long arg)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK(ret = (*sockdev->sd_ioctl)(sockdev, sock->impl, request, arg));
+
+done:
+    return ret;
+}
+
+static int _udsdev_dup(
+    myst_sockdev_t* dev,
+    const myst_sock_t* sock,
+    myst_sock_t** sock_out)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+    myst_sock_t* new_sock = NULL;
+    myst_sock_t* new_sock_impl = NULL;
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ECHECK((*sockdev->sd_dup)(sockdev, sock->impl, &new_sock_impl));
+
+    ECHECK(_new_sock(sock->nonblock, new_sock_impl, &new_sock));
+    *sock_out = new_sock;
+    new_sock = NULL;
+    new_sock_impl = NULL;
+
+done:
+
+    if (new_sock_impl)
+        (*sockdev->sd_close)(sockdev, new_sock_impl);
+
+    if (new_sock)
+        _free_sock(new_sock);
+
+    return ret;
+}
+
+static int _udsdev_get_events(myst_sockdev_t* dev, myst_sock_t* sock)
+{
+    int ret = 0;
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    ret = -ENOTSUP;
+
+done:
+    return ret;
+}
+
+static int _udsdev_sendmsg(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    const struct msghdr* msg,
+    int flags)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    if (!msg)
+        ERAISE(-EINVAL);
+
+#ifndef ENABLE_CONTROL_DATA
+    /* ATTN: control information is not supported */
+    if (msg->msg_control || msg->msg_controllen)
+    {
+        MYST_WLOG("AF_LOCAL control data unsuuported");
+        ERAISE(-ENOTSUP);
+    }
+#endif /* !ENABLE_CONTROL_DATA */
+
+    ret = _sendmsg(sock, sockdev, sock->impl, msg, flags);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static int _udsdev_recvmsg(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    struct msghdr* msg,
+    int flags)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    if (!msg)
+        ERAISE(-EINVAL);
+
+#ifndef ENABLE_CONTROL_DATA
+    /* ATTN: control information is not supported */
+    if (msg->msg_control || msg->msg_controllen)
+    {
+        MYST_WLOG("AF_LOCAL control data unsuuported");
+        ERAISE(-ENOTSUP);
+    }
+#endif /* !ENABLE_CONTROL_DATA */
+
+    ret = _recvmsg(sock, sockdev, sock->impl, msg, flags);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static int _udsdev_shutdown(myst_sockdev_t* dev, myst_sock_t* sock, int how)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ret = (*sockdev->sd_shutdown)(sockdev, sock->impl, how);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static int _udsdev_getpeername(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    struct sockaddr* addr,
+    socklen_t* addrlen)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+
+    if (!dev || !_valid_sock(sock))
+        ERAISE(-EINVAL);
+
+    /* delegate to socket device */
+    ret = (*sockdev->sd_getpeername)(sockdev, sock->impl, addr, addrlen);
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static int _udsdev_getsockname(
+    myst_sockdev_t* dev,
+    myst_sock_t* sock,
+    struct sockaddr* addr,
+    socklen_t* addrlen)
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+    size_t original_addrlen = 0;
+    struct sockaddr_un* sun = (struct sockaddr_un*)addr;
+
+    if (!dev || !_valid_sock(sock) || !addr || !addrlen)
+        ERAISE(-EINVAL);
+
+    original_addrlen = *addrlen;
+
+    /* delegate to socket device */
+    ret = (*sockdev->sd_getsockname)(sockdev, sock->impl, addr, addrlen);
+
+    if (ret >= 0 && original_addrlen >= sizeof(struct sockaddr_un))
+    {
+        if (*sock->sun_path)
+        {
+            myst_strlcpy(sun->sun_path, sock->sun_path, sizeof(sun->sun_path));
+            *addrlen = sizeof(struct sockaddr_un);
+        }
+        else
+        {
+            sun->sun_path[0] = '\0';
+        }
+    }
+
+    ECHECK(ret);
+
+done:
+    return ret;
+}
+
+static int _udsdev_socketpair(
+    myst_sockdev_t* dev,
+    int domain,
+    int type,
+    int protocol,
+    myst_sock_t* pair[2])
+{
+    int ret = 0;
+    myst_sockdev_t* sockdev = myst_sockdev_get();
+    myst_sock_t* new_pair[2] = {NULL, NULL};
+    myst_sock_t* new_pair_impl[2] = {NULL, NULL};
+
+    if (pair)
+    {
+        pair[0] = NULL;
+        pair[1] = NULL;
+    }
+
+    if (!dev || !pair)
+        ERAISE(-EINVAL);
+
+    if (domain != AF_UNIX && domain != AF_LOCAL)
+        ERAISE(-ENOTSUP);
+
+    if (!(type & SOCK_STREAM) && !(type & SOCK_DGRAM))
+        ERAISE(-ENOTSUP);
+
+    ECHECK((sockdev->sd_socketpair)(
+        sockdev, domain, type, protocol, new_pair_impl));
+
+    const bool nonblock = type & SOCK_NONBLOCK;
+    ECHECK(_new_sock(nonblock, new_pair_impl[0], &new_pair[0]));
+    ECHECK(_new_sock(nonblock, new_pair_impl[1], &new_pair[1]));
+
+    pair[0] = new_pair[0];
+    pair[1] = new_pair[1];
+    new_pair_impl[0] = NULL;
+    new_pair_impl[1] = NULL;
+    new_pair[0] = NULL;
+    new_pair[1] = NULL;
+
+done:
+
+    if (new_pair[0])
+        _free_sock(new_pair[0]);
+
+    if (new_pair[1])
+        _free_sock(new_pair[1]);
+
+    if (new_pair_impl[0])
+        (*sockdev->sd_close)(sockdev, new_pair_impl[0]);
+
+    if (new_pair_impl[1])
+        (*sockdev->sd_close)(sockdev, new_pair_impl[1]);
+
+    return ret;
+}
+
+myst_sockdev_t* myst_sockdev_get_uds(void)
+{
+    // clang-format off
+    static myst_sockdev_t _dev =
+    {
+        {
+            .fd_read = (void*)_udsdev_read,
+            .fd_write = (void*)_udsdev_write,
+            .fd_readv = (void*)_udsdev_readv,
+            .fd_writev = (void*)_udsdev_writev,
+            .fd_fstat = (void*)_udsdev_fstat,
+            .fd_fcntl = (void*)_udsdev_fcntl,
+            .fd_ioctl = (void*)_udsdev_ioctl,
+            .fd_dup = (void*)_udsdev_dup,
+            .fd_close = (void*)_udsdev_close,
+            .fd_target_fd = (void*)_udsdev_target_fd,
+            .fd_get_events = (void*)_udsdev_get_events,
+        },
+        .sd_socket = _udsdev_socket,
+        .sd_socketpair = _udsdev_socketpair,
+        .sd_connect = _udsdev_connect,
+        .sd_accept4 = _udsdev_accept4,
+        .sd_bind = _udsdev_bind,
+        .sd_listen = _udsdev_listen,
+        .sd_sendto = _udsdev_sendto,
+        .sd_recvfrom = _udsdev_recvfrom,
+        .sd_sendmsg = _udsdev_sendmsg,
+        .sd_recvmsg = _udsdev_recvmsg,
+        .sd_shutdown = _udsdev_shutdown,
+        .sd_getsockopt = _udsdev_getsockopt,
+        .sd_setsockopt = _udsdev_setsockopt,
+        .sd_getpeername = _udsdev_getpeername,
+        .sd_getsockname = _udsdev_getsockname,
+        .sd_read = _udsdev_read,
+        .sd_write = _udsdev_write,
+        .sd_readv = _udsdev_readv,
+        .sd_writev = _udsdev_writev,
+        .sd_fstat = _udsdev_fstat,
+        .sd_fcntl = _udsdev_fcntl,
+        .sd_ioctl = _udsdev_ioctl,
+        .sd_dup = _udsdev_dup,
+        .sd_close = _udsdev_close,
+        .sd_target_fd = _udsdev_target_fd,
+        .sd_get_events = _udsdev_get_events,
+    };
+    // clang-format on
+
+    return &_dev;
+}

--- a/kernel/udsdev.c
+++ b/kernel/udsdev.c
@@ -1,31 +1,5 @@
-#include <assert.h>
-#include <limits.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/un.h>
-
-#include <myst/crypt.h>
-#include <myst/defs.h>
-#include <myst/eraise.h>
-#include <myst/hex.h>
-#include <myst/iov.h>
-#include <myst/once.h>
-#include <myst/sha256.h>
-#include <myst/sockdev.h>
-#include <myst/strings.h>
-#include <myst/syscall.h>
-#include <myst/syslog.h>
-#include <myst/tcall.h>
-#include <myst/time.h>
-
-#define MAGIC 0xd731a683
-
-#define PAYLOAD_SIZE (512 - sizeof(uint64_t) - sizeof(myst_sha256_t))
-
-#define FRAME_CONTROL_MAGIC 0x9ef92565
-#define FRAME_DATA_MAGIC 0x3fd95160
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 /*
 **==============================================================================
@@ -97,6 +71,35 @@
 **
 **==============================================================================
 */
+
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+
+#include <myst/crypt.h>
+#include <myst/defs.h>
+#include <myst/eraise.h>
+#include <myst/hex.h>
+#include <myst/iov.h>
+#include <myst/once.h>
+#include <myst/sha256.h>
+#include <myst/sockdev.h>
+#include <myst/strings.h>
+#include <myst/syscall.h>
+#include <myst/syslog.h>
+#include <myst/tcall.h>
+#include <myst/time.h>
+
+#define MAGIC 0xd731a683
+
+#define PAYLOAD_SIZE (512 - sizeof(uint64_t) - sizeof(myst_sha256_t))
+
+#define FRAME_CONTROL_MAGIC 0x9ef92565
+#define FRAME_DATA_MAGIC 0x3fd95160
 
 typedef struct frame
 {

--- a/target/linux/Makefile
+++ b/target/linux/Makefile
@@ -20,6 +20,7 @@ SOURCES += ../shared/sha256.c
 SOURCES += ../shared/verify.c
 SOURCES += ../shared/nanosleep.c
 SOURCES += ../shared/interrupt.c
+SOURCES += ../shared/crypt.c
 
 CFLAGS = $(DEFAULT_CFLAGS)
 

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -631,6 +631,32 @@ long myst_tcall(long n, long params[6])
         {
             return myst_tcall_interrupt_thread((pid_t)x1);
         }
+        case MYST_TCALL_GET_TEMPFILE_NAME:
+        {
+            char* path = (char*)x1;
+            size_t size = (size_t)x2;
+            return myst_tcall_get_tempfile_name(path, size);
+        }
+        case MYST_TCALL_ENCRYPT_AES_256_XTS:
+        {
+            const myst_key_512_t* key = (const myst_key_512_t*)x1;
+            const void* data_in = (const void*)x2;
+            void* data_out = (void*)x3;
+            size_t data_size = (size_t)x4;
+            uint64_t index = (uint64_t)x5;
+            return myst_encrypt_aes_256_xts(
+                key, data_in, data_out, data_size, index);
+        }
+        case MYST_TCALL_DECRYPT_AES_256_XTS:
+        {
+            const myst_key_512_t* key = (const myst_key_512_t*)x1;
+            const void* data_in = (const void*)x2;
+            void* data_out = (void*)x3;
+            size_t data_size = (size_t)x4;
+            uint64_t index = (uint64_t)x5;
+            return myst_decrypt_aes_256_xts(
+                key, data_in, data_out, data_size, index);
+        }
         case SYS_ioctl:
         {
             int fd = (int)x1;

--- a/target/sgx/enclave/Makefile
+++ b/target/sgx/enclave/Makefile
@@ -15,6 +15,7 @@ SOURCES += ../../shared/luks.c
 SOURCES += ../../shared/crypto.c
 SOURCES += ../../shared/sha256.c
 SOURCES += ../../shared/verify.c
+SOURCES += ../../shared/crypt.c
 
 CFLAGS = $(OEENCLAVE_CFLAGS)
 

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -562,6 +562,32 @@ long myst_tcall(long n, long params[6])
         {
             return myst_tcall_interrupt_thread((pid_t)x1);
         }
+        case MYST_TCALL_GET_TEMPFILE_NAME:
+        {
+            char* path = (char*)x1;
+            size_t size = (size_t)x2;
+            return myst_tcall_get_tempfile_name(path, size);
+        }
+        case MYST_TCALL_ENCRYPT_AES_256_XTS:
+        {
+            const myst_key_512_t* key = (const myst_key_512_t*)x1;
+            const void* data_in = (const void*)x2;
+            void* data_out = (void*)x3;
+            size_t data_size = (size_t)x4;
+            uint64_t index = (uint64_t)x5;
+            return myst_encrypt_aes_256_xts(
+                key, data_in, data_out, data_size, index);
+        }
+        case MYST_TCALL_DECRYPT_AES_256_XTS:
+        {
+            const myst_key_512_t* key = (const myst_key_512_t*)x1;
+            const void* data_in = (const void*)x2;
+            void* data_out = (void*)x3;
+            size_t data_size = (size_t)x4;
+            uint64_t index = (uint64_t)x5;
+            return myst_decrypt_aes_256_xts(
+                key, data_in, data_out, data_size, index);
+        }
         case SYS_read:
         case SYS_write:
         case SYS_close:

--- a/target/shared/crypt.c
+++ b/target/shared/crypt.c
@@ -1,0 +1,111 @@
+#include <mbedtls/aes.h>
+#include <mbedtls/cipher.h>
+#include <mbedtls/sha256.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <myst/crypt.h>
+#include <myst/eraise.h>
+#include <myst/sha256.h>
+
+#define IV_SIZE 16
+
+/* initialization vector */
+struct iv
+{
+    uint64_t counter;
+    uint64_t padding;
+};
+
+static int _crypt(
+    mbedtls_operation_t op, /* MBEDTLS_ENCRYPT or MBEDTLS_DECRYPT */
+    const myst_key_512_t* key,
+    const uint8_t* data_in,
+    uint8_t* data_out,
+    size_t data_size,
+    uint64_t counter)
+{
+    int ret = 0;
+    const mbedtls_cipher_info_t* ci;
+    struct context_wrapper
+    {
+        uint64_t header;
+        mbedtls_cipher_context_t ctx;
+        uint64_t footer1;
+        uint64_t footer2;
+    };
+    struct context_wrapper wrapper;
+    struct iv iv = {counter, 0};
+    const size_t key_bits = sizeof(myst_key_512_t) * 8;
+    size_t olen;
+
+    // mbedtls_cipher_init() writes 8 bytes past the end of its parameter. At
+    // first it seemed that this was due to a header/library mismatch (but this
+    // turns out not to be the case: both are using OE mbedtls artifacts). To
+    // work around this, mbedtls_cipher_context_t is wrapped in a structure and
+    // sandwhiched between one header and two footers. We verify below that the
+    // first header and the second footer have not been disrupted. The first
+    // footer is disrupted in all cases we have observed so far.
+    {
+        const uint64_t magic = 0x7b800f55ffb7403e;
+        wrapper.header = magic;
+        wrapper.footer1 = magic;
+        wrapper.footer2 = magic;
+        mbedtls_cipher_init(&wrapper.ctx);
+
+        if (wrapper.header != magic)
+            ERAISE(-ENOSYS);
+
+        if (wrapper.footer2 != magic)
+            ERAISE(-ENOSYS);
+    }
+
+    if (!(ci = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_256_XTS)))
+        ERAISE(-ENOSYS);
+
+    if (mbedtls_cipher_setup(&wrapper.ctx, ci) != 0)
+        ERAISE(-ENOSYS);
+
+    if (mbedtls_cipher_setkey(&wrapper.ctx, key->data, (int)key_bits, op) != 0)
+        ERAISE(-ENOSYS);
+
+    if (mbedtls_cipher_crypt(
+            &wrapper.ctx,
+            (const uint8_t*)&iv, /* iv */
+            IV_SIZE,             /* iv_size */
+            data_in,             /* input */
+            data_size,           /* ilen */
+            data_out,            /* output */
+            &olen) != 0)         /* olen */
+    {
+        ERAISE(-ENOSYS);
+    }
+
+    if (olen != data_size)
+        ERAISE(-ENOSYS);
+
+done:
+    mbedtls_cipher_free(&wrapper.ctx);
+
+    return ret;
+}
+
+int myst_encrypt_aes_256_xts(
+    const myst_key_512_t* key,
+    const void* data_in,
+    void* data_out,
+    size_t data_size,
+    uint64_t counter)
+{
+    return _crypt(MBEDTLS_ENCRYPT, key, data_in, data_out, data_size, counter);
+}
+
+int myst_decrypt_aes_256_xts(
+    const myst_key_512_t* key,
+    const void* data_in,
+    void* data_out,
+    size_t data_size,
+    uint64_t counter)
+{
+    return _crypt(MBEDTLS_DECRYPT, key, data_in, data_out, data_size, counter);
+}

--- a/tests/sockets/Makefile
+++ b/tests/sockets/Makefile
@@ -22,17 +22,11 @@ ifdef ETRACE
 OPTS = --etrace
 endif
 
-UDSPATH=$(OBJDIR)/uds1
-
 tests: all
-	rm -rf $(UDSPATH)
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/sockets $(UDSPATH)
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/sockets
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst
 
 clean:
 	rm -rf $(APPDIR) rootfs export ramfs
-
-ls:
-	ls $(UDSPATH)

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -977,6 +977,16 @@ done:
     return ret;
 }
 
+long myst_tcall_get_tempfile_name(char* buf, size_t size)
+{
+    long retval = 0;
+
+    if (myst_get_tempfile_name_ocall(&retval, buf, size) != OE_OK)
+        return -ENOSYS;
+
+    return retval;
+}
+
 OE_SET_ENCLAVE_SGX2(
     ENCLAVE_PRODUCT_ID,
     ENCLAVE_SECURITY_VERSION,

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -46,6 +46,7 @@
 #include "regions.h"
 #include "roothash.h"
 #include "strace.h"
+#include "tempfile.h"
 #include "utils.h"
 
 // This is a default enclave configuration that we use when overriding the
@@ -793,4 +794,9 @@ long myst_write_console_ocall(int fd, const void* buf, size_t count)
 
 done:
     return ret;
+}
+
+long myst_get_tempfile_name_ocall(char* buf, size_t size)
+{
+    return myst_tcall_get_tempfile_name(buf, size);
 }

--- a/tools/myst/host/host.c
+++ b/tools/myst/host/host.c
@@ -36,6 +36,7 @@
 #include "package.h"
 #include "regions.h"
 #include "sign.h"
+#include "tempfile.h"
 #include "utils.h"
 
 _Static_assert(sizeof(struct myst_timespec) == sizeof(struct timespec), "");
@@ -494,6 +495,9 @@ int main(int argc, const char* argv[], const char* envp[])
         gid = atoi(gid_str);
     }
 #endif
+
+    /* set the PID used by myst_get_tempfile_name() */
+    myst_set_tempfile_pid(getpid());
 
     int ec = _main(argc, argv, envp);
 

--- a/tools/myst/host/tempfile.c
+++ b/tools/myst/host/tempfile.c
@@ -1,0 +1,69 @@
+#include <unistd.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <pthread.h>
+
+#include "tempfile.h"
+#include <myst/eraise.h>
+
+static pid_t _pid;
+
+void myst_set_tempfile_pid(pid_t pid)
+{
+    _pid = pid;
+}
+
+long myst_tcall_get_tempfile_name(char* buf, size_t size)
+{
+    long ret = 0;
+    static size_t _num;
+    static pthread_mutex_t _lock = PTHREAD_MUTEX_INITIALIZER;
+    bool locked = false;
+    char dirname[PATH_MAX];
+
+    if (!buf || !size)
+        ERAISE(-EINVAL);
+
+    pthread_mutex_lock(&_lock);
+    locked = true;
+
+    /* create the PID directory (or verify it is a directory) */
+    {
+        struct stat statbuf;
+
+        snprintf(dirname, sizeof(dirname), "/tmp/myst-pid-%u", _pid);
+
+        if (stat(dirname, &statbuf) == 0)
+        {
+            if (!S_ISDIR(statbuf.st_mode))
+                ERAISE(-ENOTDIR);
+        }
+        else if (mkdir(dirname, 0775) != 0)
+        {
+            ERAISE(-errno);
+        }
+    }
+
+    /* format the temp file name */
+    {
+        int len = snprintf(buf, size, "%s/%zu", dirname, ++_num);
+
+        if (len < 0 || (size_t)len >= size)
+        {
+            memset(buf, 0, size);
+            ERAISE(-ENAMETOOLONG);
+        }
+    }
+
+done:
+
+    if (locked)
+        pthread_mutex_unlock(&_lock);
+
+    return ret;
+}

--- a/tools/myst/host/tempfile.h
+++ b/tools/myst/host/tempfile.h
@@ -1,0 +1,11 @@
+#ifndef _MYST_HOST_H
+#define _MYST_HOST_H
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <myst/tcall.h>
+
+void myst_set_tempfile_pid(pid_t pid);
+
+#endif /* _MYST_HOST_H */

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -640,5 +640,17 @@ enclave
             int fd, /* STDOUT_FILENO or STDERR_FILENO */
             [in, size=count] const void* buf,
             size_t count);
+
+        /*
+        **======================================================================
+        **
+        ** temporary files:
+        **
+        **======================================================================
+        */
+
+        long myst_get_tempfile_name_ocall(
+            [out, count=size] char* buf,
+            size_t size);
     };
 };

--- a/utils/hex.c
+++ b/utils/hex.c
@@ -22,6 +22,28 @@ void myst_hexdump(const char* label, const void* data, size_t size)
     printf("\n");
 }
 
+void myst_ascii_dump(const char* label, const uint8_t* data, uint32_t size)
+{
+    uint32_t i;
+
+    printf("=== _ascii_dump(): %s\n", label);
+
+    for (i = 0; i < size; i++)
+    {
+        unsigned char c = data[i];
+
+        if (c >= ' ' && c <= '~')
+            printf("%c", c);
+        else
+            printf("<%x>", c);
+
+        if (i + 1 != size && !((i + 1) % 80))
+            printf("\n");
+    }
+
+    printf("\n");
+}
+
 static int _char_to_nibble(char c)
 {
     if (c >= 'A' && c <= 'F')


### PR DESCRIPTION
This PR implements Unix-domain sockets, which provide a way for two processes within the same kernel image to communicate securely using host-side sockets, where the kernel internally adds a layer of encryption. See the documentation under [./kernel/udsdev.c](https://github.com/deislabs/mystikos/blob/bed02f53fa5e875e5d4e608fda16685674b59532/kernel/udsdev.c) for details of the algorithm.

This PR also adds the ``myst_syslog()`` function for writing message to the console in different colors. This was added so that warning could be produced when apps attempt to use unsupported Unix-domain socket features.