### PR TITLE
Add tcalls sched_setscheduler, sched_getscheduler, sched_getparam, sched_get_priority_max, sched_get_priority_min

### DIFF
--- a/crt/sched.c
+++ b/crt/sched.c
@@ -1,0 +1,24 @@
+#include <myst/syscallext.h>
+#include <sched.h>
+#include <stdio.h>
+#include <string.h>
+#include <syscall.h>
+#include <unistd.h>
+
+int sched_getscheduler(pid_t pid)
+{
+    return syscall(SYS_sched_getscheduler, pid);
+}
+
+int sched_setscheduler(pid_t pid, int sched, const struct sched_param* param)
+{
+    return syscall(SYS_sched_setscheduler, pid);
+}
+
+int sched_getparam(pid_t pid, struct sched_param* param)
+{
+    if (param)
+        memset(param, 0, sizeof(struct sched_param));
+
+    return syscall(SYS_sched_getparam, pid, param);
+}

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -667,6 +667,11 @@ long myst_tcall(long n, long params[6])
             return myst_tcall_poll(fds, nfds, timeout);
         }
         case SYS_sched_yield:
+        case SYS_sched_setscheduler:
+        case SYS_sched_getscheduler:
+        case SYS_sched_getparam:
+        case SYS_sched_get_priority_max:
+        case SYS_sched_get_priority_min:
         case SYS_fstat:
         case SYS_close:
         case SYS_readv:

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -599,6 +599,11 @@ long myst_tcall(long n, long params[6])
         case SYS_ioctl:
         case SYS_fstat:
         case SYS_sched_yield:
+        case SYS_sched_setscheduler:
+        case SYS_sched_getscheduler:
+        case SYS_sched_getparam:
+        case SYS_sched_get_priority_max:
+        case SYS_sched_get_priority_min:
         case SYS_fchmod:
         case SYS_poll:
         case SYS_open:

--- a/tests/ltp/ext2fs_tests_other_errors.txt
+++ b/tests/ltp/ext2fs_tests_other_errors.txt
@@ -538,12 +538,9 @@
 /ltp/testcases/kernel/syscalls/sbrk/sbrk01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk03
 /ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max01
-/ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max02
 /ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min01
-/ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
 /ltp/testcases/kernel/syscalls/sched_getaffinity/sched_getaffinity01
 /ltp/testcases/kernel/syscalls/sched_getattr/sched_getattr02
-/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam03
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler01
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler02

--- a/tests/ltp/ext2fs_tests_passed.txt
+++ b/tests/ltp/ext2fs_tests_passed.txt
@@ -234,6 +234,9 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
+/ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max02
+/ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
+/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/tests/ltp/hostfs_tests_other_errors.txt
+++ b/tests/ltp/hostfs_tests_other_errors.txt
@@ -526,12 +526,9 @@
 /ltp/testcases/kernel/syscalls/sbrk/sbrk01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk03
 /ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max01
-/ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max02
 /ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min01
-/ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
 /ltp/testcases/kernel/syscalls/sched_getaffinity/sched_getaffinity01
 /ltp/testcases/kernel/syscalls/sched_getattr/sched_getattr02
-/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam03
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler01
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler02

--- a/tests/ltp/hostfs_tests_passed.txt
+++ b/tests/ltp/hostfs_tests_passed.txt
@@ -244,6 +244,9 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
+/ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max02
+/ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
+/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/tests/ltp/ramfs_tests_other_errors.txt
+++ b/tests/ltp/ramfs_tests_other_errors.txt
@@ -553,12 +553,9 @@
 /ltp/testcases/kernel/syscalls/sbrk/sbrk01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk03
 /ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max01
-/ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max02
 /ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min01
-/ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
 /ltp/testcases/kernel/syscalls/sched_getaffinity/sched_getaffinity01
 /ltp/testcases/kernel/syscalls/sched_getattr/sched_getattr02
-/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam03
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler01
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler02

--- a/tests/ltp/ramfs_tests_passed.txt
+++ b/tests/ltp/ramfs_tests_passed.txt
@@ -219,6 +219,9 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
+/ltp/testcases/kernel/syscalls/sched_get_priority_max/sched_get_priority_max02
+/ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
+/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -157,19 +157,6 @@ index 984db680..9adecf2b 100644
  #endif
  
  #if _REDIR_TIME64
-diff --git a/include/sys/ioctl.h b/include/sys/ioctl.h
-index c2ce3b48..30de25bb 100644
---- a/include/sys/ioctl.h
-+++ b/include/sys/ioctl.h
-@@ -117,7 +117,7 @@ struct winsize {
- #define SIOCDEVPRIVATE     0x89F0
- #define SIOCPROTOPRIVATE   0x89E0
- 
--int ioctl (int, int, ...);
-+int ioctl (int, unsigned long, ...);
- 
- #ifdef __cplusplus
- }
 diff --git a/ldso/dlstart.c b/ldso/dlstart.c
 index 20d50f2c..17cd6ac3 100644
 --- a/ldso/dlstart.c
@@ -239,7 +226,7 @@ index 20d50f2c..17cd6ac3 100644
 +{
 +}
 diff --git a/ldso/dynlink.c b/ldso/dynlink.c
-index afec985a..acf447c4 100644
+index afec985a..4d4cd2a3 100644
 --- a/ldso/dynlink.c
 +++ b/ldso/dynlink.c
 @@ -3,6 +3,7 @@
@@ -401,32 +388,7 @@ index afec985a..acf447c4 100644
  
  	/* Avoid the danger of getting two versions of libc mapped into the
  	 * same process when an absolute pathname was used. The symbols
-@@ -1683,6 +1713,13 @@ void __dls2b(size_t *sp, size_t *auxv)
- 	else ((stage3_func)laddr(&ldso, dls3_def.sym->st_value))(sp, auxv);
- }
- 
-+/* override this to allow LD_PRELOAD */
-+__attribute__((__weak__))
-+int allow_ld_preload(void)
-+{
-+    return 0;
-+}
-+
- /* Stage 3 of the dynamic linker is called with the dynamic linker/libc
-  * fully functional. Its job is to load (if not already loaded) and
-  * process dependencies and relocations for the main application and
-@@ -1716,6 +1753,10 @@ void __dls3(size_t *sp, size_t *auxv)
- 		env_path = getenv("LD_LIBRARY_PATH");
- 		env_preload = getenv("LD_PRELOAD");
- 	}
-+        else if (allow_ld_preload())
-+        {
-+		env_preload = getenv("LD_PRELOAD");
-+        }
- 
- 	/* If the main program was already loaded by the kernel,
- 	 * AT_PHDR will point to some location other than the dynamic
-@@ -1797,6 +1838,7 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1797,6 +1827,7 @@ void __dls3(size_t *sp, size_t *auxv)
  			dprintf(2, "%s: %s: Not a valid dynamic program\n", ldname, argv[0]);
  			_exit(1);
  		}
@@ -434,7 +396,7 @@ index afec985a..acf447c4 100644
  		close(fd);
  		ldso.name = ldname;
  		app.name = argv[0];
-@@ -1936,6 +1978,7 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1936,6 +1967,7 @@ void __dls3(size_t *sp, size_t *auxv)
  	/* Determine if malloc was interposed by a replacement implementation
  	 * so that calloc and the memalign family can harden against the
  	 * possibility of incomplete replacement. */
@@ -442,7 +404,7 @@ index afec985a..acf447c4 100644
  	if (find_sym(head, "malloc", 1).dso != &ldso)
  		__malloc_replaced = 1;
  
-@@ -1955,7 +1998,13 @@ void __dls3(size_t *sp, size_t *auxv)
+@@ -1955,7 +1987,13 @@ void __dls3(size_t *sp, size_t *auxv)
  
  	errno = 0;
  
@@ -456,7 +418,7 @@ index afec985a..acf447c4 100644
  	for(;;);
  }
  
-@@ -2058,6 +2107,10 @@ void *dlopen(const char *file, int mode)
+@@ -2058,6 +2096,10 @@ void *dlopen(const char *file, int mode)
  	pthread_mutex_lock(&init_fini_lock);
  	if (!p->constructed) ctor_queue = queue_ctors(p);
  	pthread_mutex_unlock(&init_fini_lock);
@@ -467,7 +429,7 @@ index afec985a..acf447c4 100644
  	if (!p->relocated && (mode & RTLD_LAZY)) {
  		prepare_lazy(p);
  		for (i=0; p->deps[i]; i++)
-@@ -2100,6 +2153,7 @@ end:
+@@ -2100,6 +2142,7 @@ end:
  		free(ctor_queue);
  	}
  	pthread_setcancelstate(cs, 0);
@@ -475,7 +437,7 @@ index afec985a..acf447c4 100644
  	return p;
  }
  
-@@ -2302,7 +2356,7 @@ static void error(const char *fmt, ...)
+@@ -2302,7 +2345,7 @@ static void error(const char *fmt, ...)
  {
  	va_list ap;
  	va_start(ap, fmt);
@@ -497,6 +459,16 @@ index 02cb1aa2..07e76f19 100644
  	} else if ((name&~4U)!=1 && name-_CS_POSIX_V6_ILP32_OFF32_CFLAGS>33U) {
  		errno = EINVAL;
  		return 0;
+diff --git a/src/errno/__strerror.h b/src/errno/__strerror.h
+index 2f04d400..3a7fc5d6 100644
+--- a/src/errno/__strerror.h
++++ b/src/errno/__strerror.h
+@@ -102,4 +102,4 @@ E(ENOMEDIUM,    "No medium found")
+ E(EMEDIUMTYPE,  "Wrong medium type")
+ E(EMULTIHOP,    "Multihop attempted")
+ 
+-E(0,            "No error information")
++E(0,            "Unknown error") // fix to unify the error message in MUSL and gcc
 diff --git a/src/exit/_Exit.c b/src/exit/_Exit.c
 index 7a6115c7..9f715d51 100644
 --- a/src/exit/_Exit.c
@@ -790,19 +762,6 @@ index f63c062f..50311758 100644
 +{
 +	return (double)yn(n, x);
 +}
-diff --git a/src/misc/ioctl.c b/src/misc/ioctl.c
-index 89477511..bff57fbc 100644
---- a/src/misc/ioctl.c
-+++ b/src/misc/ioctl.c
-@@ -112,7 +112,7 @@ static void convert_ioctl_struct(const struct ioctl_compat_map *map, char *old,
- 	else memcpy(new+new_offset, old+old_offset, old_size-old_offset);
- }
- 
--int ioctl(int fd, int req, ...)
-+int ioctl(int fd, unsigned long req, ...)
- {
- 	void *arg;
- 	va_list ap;
 diff --git a/src/misc/syscall.c b/src/misc/syscall.c
 index 6f3ef656..614121c3 100644
 --- a/src/misc/syscall.c
@@ -976,6 +935,51 @@ index 948ece41..fd7e7801 100644
 +	return 0;
 +}
 \ No newline at end of file
+diff --git a/src/sched/sched_getparam.c b/src/sched/sched_getparam.c
+index 76f10e49..c055a47f 100644
+--- a/src/sched/sched_getparam.c
++++ b/src/sched/sched_getparam.c
+@@ -2,7 +2,9 @@
+ #include <errno.h>
+ #include "syscall.h"
+ 
+-int sched_getparam(pid_t pid, struct sched_param *param)
++int do_sched_getparam(pid_t pid, struct sched_param *param)
+ {
+ 	return __syscall_ret(-ENOSYS);
+ }
++
++_Noreturn weak_alias(do_sched_getparam, sched_getparam);
+diff --git a/src/sched/sched_getscheduler.c b/src/sched/sched_getscheduler.c
+index 394e508b..077241fa 100644
+--- a/src/sched/sched_getscheduler.c
++++ b/src/sched/sched_getscheduler.c
+@@ -2,7 +2,9 @@
+ #include <errno.h>
+ #include "syscall.h"
+ 
+-int sched_getscheduler(pid_t pid)
++int do_sched_getscheduler(pid_t pid)
+ {
+ 	return __syscall_ret(-ENOSYS);
+ }
++
++_Noreturn weak_alias(do_sched_getscheduler, sched_getscheduler);
+diff --git a/src/sched/sched_setscheduler.c b/src/sched/sched_setscheduler.c
+index 4435f216..0252845b 100644
+--- a/src/sched/sched_setscheduler.c
++++ b/src/sched/sched_setscheduler.c
+@@ -2,7 +2,9 @@
+ #include <errno.h>
+ #include "syscall.h"
+ 
+-int sched_setscheduler(pid_t pid, int sched, const struct sched_param *param)
++int do_sched_setscheduler(pid_t pid, int sched, const struct sched_param *param)
+ {
+ 	return __syscall_ret(-ENOSYS);
+ }
++
++_Noreturn weak_alias(do_sched_setscheduler, sched_setscheduler);
 diff --git a/src/select/poll.c b/src/select/poll.c
 index c84c8a99..a5f561bd 100644
 --- a/src/select/poll.c

--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -865,6 +865,94 @@ done:
     return ret;
 }
 
+static long _sched_setscheduler(
+    pid_t pid,
+    int policy,
+    const struct myst_sched_param* param)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_sched_setscheduler_ocall(&retval, pid, policy, param) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+
+static long _sched_getscheduler(pid_t pid)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_sched_getscheduler_ocall(&retval, pid) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+
+static long _sched_getparam(pid_t pid, struct myst_sched_param* param)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_sched_getparam_ocall(&retval, pid, param) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+
+static long _sched_get_priority_max(int policy)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_sched_get_priority_max_ocall(&retval, policy) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+
+static long _sched_get_priority_min(int policy)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_sched_get_priority_min_ocall(&retval, policy) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+
 static long _fchmod(int fd, mode_t mode, uid_t host_euid, gid_t host_egid)
 {
     long ret = 0;
@@ -2048,6 +2136,27 @@ long myst_handle_tcall(long n, long params[6])
         case SYS_sched_yield:
         {
             return _sched_yield();
+        }
+        case SYS_sched_setscheduler:
+        {
+            return _sched_setscheduler(
+                (pid_t)a, (int)b, (struct myst_sched_param*)c);
+        }
+        case SYS_sched_getscheduler:
+        {
+            return _sched_getscheduler((pid_t)a);
+        }
+        case SYS_sched_getparam:
+        {
+            return _sched_getparam((pid_t)a, (struct myst_sched_param*)b);
+        }
+        case SYS_sched_get_priority_max:
+        {
+            return _sched_get_priority_max((int)a);
+        }
+        case SYS_sched_get_priority_min:
+        {
+            return _sched_get_priority_min((int)a);
         }
         case SYS_fchmod:
         {

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -663,6 +663,38 @@ long myst_ftruncate_ocall(int fd, off_t length)
     RETURN(ftruncate(fd, length));
 }
 
+long myst_sched_setscheduler_ocall(
+    pid_t pid,
+    int policy,
+    const struct myst_sched_param* param)
+{
+    return (sched_setscheduler(pid, policy, (struct sched_param*)param) == 0)
+               ? 0
+               : -errno;
+}
+
+long myst_sched_getscheduler_ocall(pid_t pid)
+{
+    return (sched_getscheduler(pid) == 0) ? 0 : -errno;
+}
+
+long myst_sched_getparam_ocall(pid_t pid, struct myst_sched_param* param)
+{
+    return (syscall(SYS_sched_getparam, pid, (struct sched_param*)param) == 0)
+               ? 0
+               : -errno;
+}
+
+long myst_sched_get_priority_max_ocall(int policy)
+{
+    return (sched_get_priority_max(policy) == 0) ? 0 : -errno;
+}
+
+long myst_sched_get_priority_min_ocall(int policy)
+{
+    return (sched_get_priority_min(policy) == 0) ? 0 : -errno;
+}
+
 long myst_symlink_ocall(
     const char* target,
     const char* linkpath,

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -9,6 +9,7 @@ enclave
     include "sys/socket.h"
     include "sys/epoll.h"
     include "sys/eventfd.h"
+    include "sched.h"
     include "myst/shm.h"
     include "myst/fssig.h"
     include "myst/blockdevice.h"
@@ -71,6 +72,18 @@ enclave
         char d_name[1];
     };
 
+    struct myst_sched_param_reserved {
+        time_t __reserved1;
+        long __reserved2;
+    };
+
+    struct myst_sched_param {
+        int sched_priority;
+        int __reserved1;
+        struct myst_sched_param_reserved __reserved2[2];
+        int __reserved3;
+    };
+
     trusted
     {
         public int myst_enter_ecall(
@@ -123,7 +136,28 @@ enclave
             uint64_t self_event,
             [in] const struct myst_timespec* timeout);
 
-        long myst_sched_yield_ocall();
+        long myst_sched_yield_ocall()
+            transition_using_threads;
+
+        long myst_sched_setscheduler_ocall(
+            pid_t pid,
+            int policy,
+            [in] const struct myst_sched_param* param)
+            transition_using_threads;
+
+        long myst_sched_getscheduler_ocall(pid_t pid)
+            transition_using_threads;
+        
+        long myst_sched_getparam_ocall(
+            pid_t pid,
+            [out] struct myst_sched_param* param)
+            transition_using_threads;
+
+        long myst_sched_get_priority_max_ocall(int policy)
+            transition_using_threads;
+
+        long myst_sched_get_priority_min_ocall(int policy)
+            transition_using_threads;
 
         long myst_poll_ocall(
             [in, out, count=nfds] struct pollfd* fds,


### PR DESCRIPTION
To-do:
1. enable ltp tests
 - sched_get_priority_min02/max02 pass. All the other tests fail.
2. Explore security implication of sending out sched_setscheduler call to the host.