### PR TITLE
Linux target: Unmask signal on host before delivering it to Mystikos …

### DIFF
--- a/tests/dotnet-ubuntu/hello/Program.cs
+++ b/tests/dotnet-ubuntu/hello/Program.cs
@@ -5,18 +5,34 @@ namespace hello
 {
     class Program
     {
-        static void Main(string[] args)
+        static void test_divide_by_zero()
         {
-            Console.WriteLine("Hello World!");
             int q, a = 5, b = 0;
             try {
                 q = a / b;
             } catch (DivideByZeroException e) {
                 Console.WriteLine("Exception caught: {0}", e);
-                return;
             }
-            // unreachable
-            Environment.Exit(1);
+        }
+        static void test_null_str_op()
+        {
+            string s = null;
+            try {
+                int len = s.Length;
+            } catch (NullReferenceException e) {
+                Console.WriteLine("Exception caught: {0}", e);
+            }
+        }
+        static void Main(string[] args)
+        {
+            // test handling multiple SIGFPEs.
+            test_divide_by_zero();
+            test_divide_by_zero();
+            
+            // test handling mutliple SIGSEGVs.
+            test_null_str_op();
+            test_null_str_op();
+
         }  
     }
 }

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -318,6 +318,10 @@ static void _install_signal_handlers()
 {
     struct sigaction sa;
     sa.sa_flags = SA_SIGINFO;
+    // Specify SA_NODEFER, so that if same signal is thrown from the handler, it
+    // can be caught. This is encountered in .net runtime, where the signal
+    // handler never returns.
+    sa.sa_flags |= SA_NODEFER;
     sigemptyset(&sa.sa_mask);
     sa.sa_sigaction = _sigaction_handler;
 


### PR DESCRIPTION
…kernel

For scenarios where the signal handler may never return,
and same signal may be generated again(for eg: dotnet runtime).

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>