### PR TITLE
tests/dotnet-sos fix

### DIFF
--- a/tests/dotnet-sos/Dockerfile-prereqs
+++ b/tests/dotnet-sos/Dockerfile-prereqs
@@ -1,6 +1,35 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM ubuntu:18.04
+ARG PSW_VERSION
+
+RUN apt-get update && apt-get install -y \
+    wget \
+    gnupg
+
+RUN if [ -z "$PSW_VERSION" ]; then echo "Please set PSW_VERSION (e.g. 2.15.100)." >&2; exit 1; fi
 
 WORKDIR /tmp
+
+# Use the APT preference file to pin sgx packages to specific versions
+# Reference https://manpages.debian.org/buster/apt/apt_preferences.5.en.html
+# Download the pref file from https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/
+# Assuming file name to follow *sgx_<PSW_VERSION>_bionic_custom_version.cfg convention
+RUN ["/bin/bash", "-c", "wget -r -l1 --no-parent -nd -A *sgx_$(echo ${PSW_VERSION//./_})_bionic_custom_version.cfg https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/"]
+RUN ["/bin/bash", "-c", "mv *sgx_$(echo ${PSW_VERSION//./_})_bionic_custom_version.cfg /etc/apt/preferences.d/intel-sgx.pref"]
+
+# Add the repository to sources, and add the key to the list of
+# trusted keys used by the apt to authenticate packages
+RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/intel-sgx.list \
+    && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+# Add Microsoft repo for az-dcap-client
+RUN echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | tee /etc/apt/sources.list.d/msprod.list \
+    && wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+
+RUN apt-get update && apt-get install -y \
+    libsgx-enclave-common \
+    libsgx-dcap-ql \
+    libsgx-quote-ex \
+    az-dcap-client
+
 # Install lldb-10
 RUN apt update && \
      apt install -y lsb-release software-properties-common gnupg
@@ -8,13 +37,19 @@ RUN wget https://apt.llvm.org/llvm.sh && \
         chmod +x llvm.sh && \
         ./llvm.sh 10
 
+RUN wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb
+
+#RUN apt update \
+#    apt install -y apt-transport-https
+RUN apt update && \
+    apt install -y dotnet-sdk-5.0
+
 # Install SOS debugger extension
 RUN dotnet tool install -g dotnet-sos \
 	&& /root/.dotnet/tools/dotnet-sos install
 
-# Install intel library required to run enclaves
-RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
-    wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
-    apt update && apt -y install libsgx-enclave-common
+ENV SGX_AESM_ADDR=1
 
 WORKDIR /app

--- a/tests/dotnet-sos/Dockerfile-prereqs
+++ b/tests/dotnet-sos/Dockerfile-prereqs
@@ -1,38 +1,11 @@
-FROM ubuntu:18.04
-ARG PSW_VERSION
-
-RUN apt-get update && apt-get install -y \
-    wget \
-    gnupg
-
-RUN if [ -z "$PSW_VERSION" ]; then echo "Please set PSW_VERSION (e.g. 2.15.100)." >&2; exit 1; fi
+FROM oeciteam/openenclave-base-ubuntu-18.04
 
 WORKDIR /tmp
 
-# Use the APT preference file to pin sgx packages to specific versions
-# Reference https://manpages.debian.org/buster/apt/apt_preferences.5.en.html
-# Download the pref file from https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/
-# Assuming file name to follow *sgx_<PSW_VERSION>_bionic_custom_version.cfg convention
-RUN ["/bin/bash", "-c", "wget -r -l1 --no-parent -nd -A *sgx_$(echo ${PSW_VERSION//./_})_bionic_custom_version.cfg https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/"]
-RUN ["/bin/bash", "-c", "mv *sgx_$(echo ${PSW_VERSION//./_})_bionic_custom_version.cfg /etc/apt/preferences.d/intel-sgx.pref"]
-
-# Add the repository to sources, and add the key to the list of
-# trusted keys used by the apt to authenticate packages
-RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/intel-sgx.list \
-    && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
-# Add Microsoft repo for az-dcap-client
-RUN echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | tee /etc/apt/sources.list.d/msprod.list \
-    && wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-
 RUN apt-get update && apt-get install -y \
-    libsgx-enclave-common \
-    libsgx-dcap-ql \
-    libsgx-quote-ex \
-    az-dcap-client
+    wget gnupg lsb-release software-properties-common
 
 # Install lldb-10
-RUN apt update && \
-     apt install -y lsb-release software-properties-common gnupg
 RUN wget https://apt.llvm.org/llvm.sh && \
         chmod +x llvm.sh && \
         ./llvm.sh 10
@@ -41,8 +14,6 @@ RUN wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-p
     dpkg -i packages-microsoft-prod.deb && \
     rm packages-microsoft-prod.deb
 
-#RUN apt update \
-#    apt install -y apt-transport-https
 RUN apt update && \
     apt install -y dotnet-sdk-5.0
 

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -1,11 +1,12 @@
 TOP=$(abspath ../..)
 include $(TOP)/defs.mak
 
+PSW_VERSION   := 2.15.100
 APPBUILDER=$(TOP)/scripts/appbuilder
 HEAP_SIZE="768M"
 
 MYST_LLDB_DOCKER = /build/openenclave/bin/oelldb
-TEST_RUNNER_IMG = mystikos/dotnet-sos-prereqs:20200805
+TEST_RUNNER_IMG = mystikos/dotnet-sos-prereqs:nov-09-2021
 
 OPTS = --report-native-tids
 
@@ -31,7 +32,8 @@ clean:
 DOCKER_SGX_DRIVER_OPTIONS = -v /dev/sgx:/dev/sgx
 DOCKER_SGX_DRIVER_OPTIONS += --device /dev/sgx/enclave:/dev/sgx/enclave
 DOCKER_SGX_DRIVER_OPTIONS += --device /dev/sgx/provision:/dev/sgx/provision
-
+DOCKER_SGX_DRIVER_OPTIONS += --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
+DOCKER_SGX_DRIVER_OPTIONS += --env SGX_AESM_ADDR=1
 tests:
 	$(RUNTEST) docker run --rm -e TARGET=$(TARGET) -v $(abspath .):/app/ -v $(TOP)/build:/build $(DOCKER_SGX_DRIVER_OPTIONS) $(TEST_RUNNER_IMG) /app/exec.sh $(MYST_LLDB_DOCKER) /build/bin/myst $(EXEC) $(OPTS)
 	@ echo "=== passed test (dotnet-sos)"
@@ -43,7 +45,7 @@ tests-without-docker:
 #			dev targets			 #
 ##################################
 run-ext2:
-	$(MYST) exec ext2fs \
+	$(MYST_EXEC) ext2fs \
 	--memory-size $(HEAP_SIZE) \
 	/app/hello
 
@@ -61,3 +63,6 @@ ct:
 
 t:
 	echo ${DEV_SGX_ISDIR}
+
+prereqs:
+	@docker build --build-arg PSW_VERSION=$(PSW_VERSION) -f Dockerfile-prereqs .

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -1,7 +1,6 @@
 TOP=$(abspath ../..)
 include $(TOP)/defs.mak
 
-PSW_VERSION   := 2.15.100
 APPBUILDER=$(TOP)/scripts/appbuilder
 HEAP_SIZE="768M"
 
@@ -67,4 +66,4 @@ t:
 	echo ${DEV_SGX_ISDIR}
 
 prereqs:
-	@docker build --build-arg PSW_VERSION=$(PSW_VERSION) -f Dockerfile-prereqs .
+	@docker build -f Dockerfile-prereqs .

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -18,6 +18,8 @@ all: ext2fs runner-image
 
 appdir:
 	$(APPBUILDER) Dockerfile
+	# libmscordaccore is required by sos_test.py
+	cp appdir/app/libmscordaccore.so .
 
 ext2fs: appdir
 	rm -rf appdir/tmp/clr-debug-pipe*
@@ -27,7 +29,7 @@ runner-image:
 	docker pull $(TEST_RUNNER_IMG)
 
 clean:
-	sudo rm -fr appdir ext2fs rootfs stdouterr.txt
+	sudo rm -fr appdir ext2fs rootfs stdouterr.txt libmscordaccore.so
 
 DOCKER_SGX_DRIVER_OPTIONS = -v /dev/sgx:/dev/sgx
 DOCKER_SGX_DRIVER_OPTIONS += --device /dev/sgx/enclave:/dev/sgx/enclave

--- a/tests/dotnet-sos/sos_test.py
+++ b/tests/dotnet-sos/sos_test.py
@@ -3,31 +3,61 @@
 
 import lldb
 import os
+import re
+import subprocess
 import sys
+
+def copy_libmscordaccore(ci, res):
+    ci.HandleCommand("finish", res)
+    assert(res.Succeeded())
+
+    ci.HandleCommand("p tmpdir", res)
+    assert(res.Succeeded())
+    tmpdir_match = re.search('"(.*)"', res.GetOutput())    
+    assert(tmpdir_match)
+    tmpdir_path = tmpdir_match.group(0)[1:-1]
+
+    bashCommand = f"cp libmscordaccore.so {tmpdir_path}"
+    process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
+    output, error = process.communicate()
+    assert(not error)
 
 def run_test(debugger):
     debugger.SetAsync(False)
     res = lldb.SBCommandReturnObject()
     ci = debugger.GetCommandInterpreter()
 
-    # Set managed breakpoint
-    ci.HandleCommand("bpmd hello.dll hello.Program.Main", res)
-    assert(res.Succeeded())
-
     # The `personality` syscall is used by lldb to turn off ASLR.
     # This syscall may not be permitted within containers.
     # Therefore, turn off disable-aslr.
     lldb.debugger.HandleCommand("settings set target.disable-aslr false")
+
+    # Set breakpoint to get /tmp path with symbol files 
+    ci.HandleCommand("b init_symbol_file_tmpdir", res)
+    assert(res.Succeeded())
+    print(res)
+
     debugger.HandleCommand("run")
 
     process = debugger.GetSelectedTarget().GetProcess()
 
-    # For sgx, we hit the cpuid SIGILL pretty early in dotnet initialization
+    # For sgx, we hit the cpuid SIGILL pretty early in OE crypto initialization
     if os.getenv("TARGET") == "sgx":
         assert(process.GetState() == lldb.eStateStopped)
         assert(process.GetSelectedThread().GetStopReason() == lldb.eStopReasonSignal)
         debugger.HandleCommand("pro hand -p true -s false -n false SIGILL")
         process.Continue()
+
+    # Should've hit /tmp path init breakpoint
+    assert(process.GetState() == lldb.eStateStopped)
+    assert(process.GetSelectedThread().GetStopReason() == lldb.eStopReasonBreakpoint)
+    copy_libmscordaccore(ci, res)
+
+    # Set managed breakpoint
+    ci.HandleCommand("bpmd hello.dll hello.Program.Main", res)
+    assert(res.Succeeded())
+
+    process.Continue()
 
     # Should've hit managed breakpoint
     assert(process.GetState() == lldb.eStateStopped)

--- a/tools/myst/host/host.c
+++ b/tools/myst/host/host.c
@@ -171,6 +171,18 @@ done:
     return ret;
 }
 
+long init_symbol_file_tmpdir(char* tmpdir)
+{
+    long ret = 0;
+
+    if (!mkdtemp(tmpdir))
+        ERAISE(errno);
+    ECHECK(chmod(tmpdir, 0777));
+
+done:
+    return ret;
+}
+
 long myst_tcall_add_symbol_file(
     const void* file_data,
     size_t file_size,
@@ -192,10 +204,8 @@ long myst_tcall_add_symbol_file(
 
     if (!tmpdir_init)
     {
-        if (!mkdtemp(tmpdir))
-            ERAISE(errno);
+        ECHECK(init_symbol_file_tmpdir(tmpdir));
         tmpdir_init = 1;
-        ECHECK(chmod(tmpdir, 0777));
     }
 
     /* assume libmystcrt if no file data */


### PR DESCRIPTION
- Explicitly copy data access module(libmscordaccore.so) to /tmp symbol files path. This is required for SOS to function.
- Base prereqs image on Ubuntu 18.04.