### PR TITLE
SUBTEST: a solution to the multiple-line error summary problem

### DIFF
--- a/scripts/runtest
+++ b/scripts/runtest
@@ -25,10 +25,23 @@ magenta="\e[35m"
 cyan="\e[36m"
 reset="\e[39m"
 
+get_subtest()
+{
+    local cmd=$1
+
+    if [ -z "${SUBTEST}" ]
+    then
+        echo ${cmd##*/}
+    else
+        # use the SUBTEST environment variable
+        echo "${SUBTEST}"
+    fi
+}
+
 test_passed()
 {
     local cmd=$*
-    local subtest=${cmd##*/}
+    local subtest=$(get_subtest ${cmd})
     echo -e "${green}    passed (${TESTNAME}/${subtest})${reset}"
     mkdir -p "${TESTSUBDIR}/${subtest}"
     echo "" >> "${TESTSUBDIR}/${subtest}/passed"
@@ -37,7 +50,7 @@ test_passed()
 test_failed()
 {
     local cmd=$*
-    local subtest=${cmd##*/}
+    local subtest=$(get_subtest ${cmd})
     echo -e "${red}    failed (${TESTNAME}/${subtest})${reset}"
     mkdir -p "${TESTSUBDIR}/${subtest}"
     echo "" >> "${TESTSUBDIR}/${subtest}/failed"
@@ -46,7 +59,7 @@ test_failed()
 test_timedout()
 {
     local cmd=$*
-    local subtest=${cmd##*/}
+    local subtest=$(get_subtest ${cmd})
     echo -e "${red}    timedout (${TESTNAME}/${subtest})${reset}"
     mkdir -p "${TESTSUBDIR}/${subtest}"
     echo "" >> "${TESTSUBDIR}/${subtest}/failed"
@@ -68,7 +81,7 @@ run_test()
         cmd="${cmd} $i"
     done
 
-    local subtest=${cmd##*/}
+    local subtest=$(get_subtest ${cmd})
     echo -e "${lightblue}=== start (${TESTNAME}/${subtest})${reset}"
 
     local tempfile=$(/bin/mktemp)

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -36,7 +36,7 @@ DOCKER_SGX_DRIVER_OPTIONS += --device /dev/sgx/provision:/dev/sgx/provision
 DOCKER_SGX_DRIVER_OPTIONS += --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
 DOCKER_SGX_DRIVER_OPTIONS += --env SGX_AESM_ADDR=1
 tests:
-	$(RUNTEST) docker run --rm -e TARGET=$(TARGET) -v $(abspath .):/app/ -v $(TOP)/build:/build $(DOCKER_SGX_DRIVER_OPTIONS) $(TEST_RUNNER_IMG) /app/exec.sh $(MYST_LLDB_DOCKER) /build/bin/myst $(EXEC) $(OPTS)
+	SUBTEST=dotnet-sos $(RUNTEST) docker run --rm -e TARGET=$(TARGET) -v $(abspath .):/app/ -v $(TOP)/build:/build $(DOCKER_SGX_DRIVER_OPTIONS) $(TEST_RUNNER_IMG) /app/exec.sh $(MYST_LLDB_DOCKER) /build/bin/myst $(EXEC) $(OPTS)
 	@ echo "=== passed test (dotnet-sos)"
 
 tests-without-docker:


### PR DESCRIPTION
This solves the problem with the `dotnet-sos` printing out multiple lines of summary output on failure.