### PR TITLE
Dup no longer inherits FD_CLOEXEC

### DIFF
--- a/include/myst/fs.h
+++ b/include/myst/fs.h
@@ -31,6 +31,7 @@ const char* myst_fstype_name(myst_fstype_t fstype);
 typedef struct myst_fs myst_fs_t;
 
 typedef struct myst_file myst_file_t;
+typedef struct myst_file_shared myst_file_shared_t;
 
 typedef int (*myst_mount_resolve_callback_t)(
     const char* path,

--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -436,40 +436,45 @@ static const char* _inode_target(inode_t* inode)
 
 #define FILE_MAGIC 0xdfe1d5c160064f8e
 
-struct myst_file
+struct myst_file_shared
 {
     uint64_t magic;
     inode_t* inode;
     size_t offset;      /* the current file offset (files) */
     uint32_t access;    /* (O_RDONLY | O_RDWR | O_WRONLY) */
     uint32_t operating; /* (O_APPEND | O_DIRECT | O_NOATIME | O_NONBLOCK) */
-    int fdflags;        /* file descriptor flags: FD_CLOEXEC */
     char realpath[PATH_MAX];
     myst_buf_t vbuf;           /* virtual file buffer */
     myst_spinlock_t vbuf_lock; /* lock for the virtual file buffer */
     _Atomic(size_t) use_count;
 };
 
+struct myst_file
+{
+    struct myst_file_shared* shared;
+    int fdflags; /* file descriptor flags: FD_CLOEXEC */
+};
+
 static bool _file_valid(const myst_file_t* file)
 {
-    return file && file->magic == FILE_MAGIC;
+    return file && file->shared && file->shared->magic == FILE_MAGIC;
 }
 
 static void* _file_data(const myst_file_t* file)
 {
-    return (file->inode->v_cb.open_cb) ? file->vbuf.data
-                                       : file->inode->buf.data;
+    return (file->shared->inode->v_cb.open_cb) ? file->shared->vbuf.data
+                                               : file->shared->inode->buf.data;
 }
 
 static size_t _file_size(const myst_file_t* file)
 {
-    return (file->inode->v_cb.open_cb) ? file->vbuf.size
-                                       : file->inode->buf.size;
+    return (file->shared->inode->v_cb.open_cb) ? file->shared->vbuf.size
+                                               : file->shared->inode->buf.size;
 }
 
 static void* _file_current(myst_file_t* file)
 {
-    return (uint8_t*)_file_data(file) + file->offset;
+    return (uint8_t*)_file_data(file) + file->shared->offset;
 }
 
 static void* _file_at(myst_file_t* file, size_t offset)
@@ -804,6 +809,7 @@ static int _fs_open(
     ramfs_t* ramfs = (ramfs_t*)fs;
     inode_t* inode = NULL;
     myst_file_t* file = NULL;
+    myst_file_shared_t* file_shared = NULL;
     int ret = 0;
     int errnum;
     bool is_i_new = false;
@@ -834,6 +840,11 @@ static int _fs_open(
     /* Create the file object */
     if (!(file = calloc(1, sizeof(myst_file_t))))
         ERAISE(-ENOMEM);
+
+    if (!(file_shared = calloc(1, sizeof(myst_file_shared_t))))
+        ERAISE(-ENOMEM);
+
+    file->shared = file_shared;
 
     errnum = _path_to_inode(
         ramfs, pathname, true, NULL, &inode, locals->suffix, &tfs);
@@ -894,10 +905,11 @@ static int _fs_open(
 
         /* Get the realpath of this file */
         ECHECK(_path_to_inode_realpath(
-            ramfs, pathname, true, NULL, &inode, file->realpath, NULL));
+            ramfs, pathname, true, NULL, &inode, file->shared->realpath, NULL));
 
         if (inode->v_cb.open_cb)
-            ECHECK((*inode->v_cb.open_cb)(file, &file->vbuf, file->realpath));
+            ECHECK((*inode->v_cb.open_cb)(
+                file, &file->shared->vbuf, file->shared->realpath));
     }
     else if (errnum == -ENOENT)
     {
@@ -926,7 +938,7 @@ static int _fs_open(
 
         /* Get the realpath of this file */
         ECHECK(_path_to_inode_realpath(
-            ramfs, pathname, true, NULL, &inode, file->realpath, NULL));
+            ramfs, pathname, true, NULL, &inode, file->shared->realpath, NULL));
     }
     else
     {
@@ -934,17 +946,18 @@ static int _fs_open(
     }
 
     /* Initialize the file */
-    file->magic = FILE_MAGIC;
-    file->inode = inode;
-    file->access = (flags & (O_RDONLY | O_RDWR | O_WRONLY));
-    file->operating = (flags & (O_APPEND | O_NONBLOCK));
-    file->use_count = 1;
+    file->shared->magic = FILE_MAGIC;
+    file->shared->inode = inode;
+    file->shared->access = (flags & (O_RDONLY | O_RDWR | O_WRONLY));
+    file->shared->operating = (flags & (O_APPEND | O_NONBLOCK));
+    file->shared->use_count = 1;
     inode->nopens++;
 
     assert(_file_valid(file));
 
     *file_out = file;
     file = NULL;
+    file_shared = NULL;
     inode = NULL;
 
 done:
@@ -957,6 +970,9 @@ done:
 
     if (file)
         free(file);
+
+    if (file_shared)
+        free(file_shared);
 
     return ret;
 }
@@ -975,7 +991,7 @@ static off_t _fs_lseek(
         ERAISE(-EINVAL);
 
     /* NOP for read and write callbacks based virtual files */
-    if (_is_virtual_inode(file->inode))
+    if (_is_virtual_inode(file->shared->inode))
         goto done;
 
     switch (whence)
@@ -987,7 +1003,7 @@ static off_t _fs_lseek(
         }
         case SEEK_CUR:
         {
-            new_offset = (off_t)file->offset + offset;
+            new_offset = (off_t)file->shared->offset + offset;
             break;
         }
         case SEEK_END:
@@ -1008,9 +1024,9 @@ static off_t _fs_lseek(
     if (new_offset < 0 || new_offset > (off_t)_file_size(file))
         ERAISE(-EINVAL);
 
-    file->offset = (size_t)new_offset;
+    file->shared->offset = (size_t)new_offset;
 
-    _update_timestamps(file->inode, ACCESS);
+    _update_timestamps(file->shared->inode, ACCESS);
 
     ret = new_offset;
 
@@ -1038,7 +1054,7 @@ static ssize_t _fs_read(
         ERAISE(-EINVAL);
 
     /* fail if file has been opened for write only */
-    if (file->access == O_WRONLY)
+    if (file->shared->access == O_WRONLY)
         ERAISE(-EBADF);
 
     /* reading zero bytes is okay */
@@ -1046,19 +1062,19 @@ static ssize_t _fs_read(
         goto done;
 
     /* If read-time virtual file, populate buf via callback */
-    if (file->inode->v_cb.read_cb)
+    if (file->shared->inode->v_cb.read_cb)
     {
-        ret = file->inode->v_cb.read_cb(file, buf, count);
+        ret = file->shared->inode->v_cb.read_cb(file, buf, count);
         goto done;
     }
 
     /* If offset is beyond end of file, return 0 */
-    if (file->offset >= _file_size(file))
+    if (file->shared->offset >= _file_size(file))
         goto done;
 
     /* Read count bytes from the file or directory */
     {
-        size_t remaining = _file_size(file) - file->offset;
+        size_t remaining = _file_size(file) - file->shared->offset;
 
         if (remaining == 0)
         {
@@ -1068,10 +1084,10 @@ static ssize_t _fs_read(
 
         n = (count < remaining) ? count : remaining;
         memcpy(buf, _file_current(file), n);
-        file->offset += n;
+        file->shared->offset += n;
     }
 
-    _update_timestamps(file->inode, ACCESS);
+    _update_timestamps(file->shared->inode, ACCESS);
 
     ret = (ssize_t)n;
 
@@ -1102,39 +1118,39 @@ static ssize_t _fs_write(
         goto done;
 
     /* fail if file has been opened for read only */
-    if (file->access == O_RDONLY)
+    if (file->shared->access == O_RDONLY)
         ERAISE(-EBADF);
 
     /* If write-time virtual file, write to buf via callback */
-    if (file->inode->v_cb.write_cb)
+    if (file->shared->inode->v_cb.write_cb)
     {
-        ret = file->inode->v_cb.write_cb(file, buf, count);
+        ret = file->shared->inode->v_cb.write_cb(file, buf, count);
         goto done;
     }
 
     /* append always writes to the end of the file */
-    if ((file->operating & O_APPEND))
-        file->offset = _file_size(file);
+    if ((file->shared->operating & O_APPEND))
+        file->shared->offset = _file_size(file);
 
     /* Verify that the offset is in bounds */
-    if (file->offset > _file_size(file))
+    if (file->shared->offset > _file_size(file))
         ERAISE(-EINVAL);
 
     /* Write count bytes to the file or directory */
     {
-        size_t new_offset = file->offset + count;
+        size_t new_offset = file->shared->offset + count;
 
         if (new_offset > _file_size(file))
         {
-            if (myst_buf_resize(&file->inode->buf, new_offset) != 0)
+            if (myst_buf_resize(&file->shared->inode->buf, new_offset) != 0)
                 ERAISE(-ENOMEM);
         }
 
         memcpy(_file_current(file), buf, count);
-        file->offset = new_offset;
+        file->shared->offset = new_offset;
     }
 
-    _update_timestamps(file->inode, MODIFY | CHANGE);
+    _update_timestamps(file->shared->inode, MODIFY | CHANGE);
 
     ret = (ssize_t)count;
 
@@ -1170,9 +1186,9 @@ static ssize_t _fs_pread(
         goto done;
 
     /* If read-time virtual file, populate buf via callback */
-    if (file->inode->v_cb.read_cb)
+    if (file->shared->inode->v_cb.read_cb)
     {
-        ret = file->inode->v_cb.read_cb(file, buf, count);
+        ret = file->shared->inode->v_cb.read_cb(file, buf, count);
         goto done;
     }
 
@@ -1194,7 +1210,7 @@ static ssize_t _fs_pread(
         memcpy(buf, _file_at(file, (size_t)offset), n);
     }
 
-    _update_timestamps(file->inode, ACCESS);
+    _update_timestamps(file->shared->inode, ACCESS);
 
     ret = (ssize_t)n;
 
@@ -1229,9 +1245,9 @@ static ssize_t _fs_pwrite(
         goto done;
 
     /* If write-time virtual file, write to buf via callback */
-    if (file->inode->v_cb.write_cb)
+    if (file->shared->inode->v_cb.write_cb)
     {
-        ret = file->inode->v_cb.write_cb(file, buf, count);
+        ret = file->shared->inode->v_cb.write_cb(file, buf, count);
         goto done;
     }
 
@@ -1239,21 +1255,21 @@ static ssize_t _fs_pwrite(
     {
         // When opened for append, Linux pwrite() appends data to the end of
         // file regadless of the offset.
-        if ((file->operating & O_APPEND))
+        if ((file->shared->operating & O_APPEND))
             offset = _file_size(file);
 
         size_t new_offset = (size_t)offset + count;
 
         if (new_offset > _file_size(file))
         {
-            if (myst_buf_resize(&file->inode->buf, new_offset) != 0)
+            if (myst_buf_resize(&file->shared->inode->buf, new_offset) != 0)
                 ERAISE(-ENOMEM);
         }
 
         memcpy(_file_at(file, (size_t)offset), buf, count);
     }
 
-    _update_timestamps(file->inode, CHANGE | MODIFY);
+    _update_timestamps(file->shared->inode, CHANGE | MODIFY);
 
     ret = (ssize_t)count;
 
@@ -1335,36 +1351,40 @@ static int _fs_close(myst_fs_t* fs, myst_file_t* file)
     if (!_ramfs_valid(ramfs) || !_file_valid(file))
         ERAISE(-EINVAL);
 
-    assert(file->inode);
-    assert(_inode_valid(file->inode));
-    assert(file->inode->nopens > 0);
+    assert(file->shared->inode);
+    assert(_inode_valid(file->shared->inode));
+    assert(file->shared->inode->nopens > 0);
 
-    if (--file->use_count == 0)
+    if (--file->shared->use_count == 0)
     {
         /* If a virtual file has a close-callback, call it */
-        if (file->inode->v_cb.close_cb)
-            file->inode->v_cb.close_cb(file);
+        if (file->shared->inode->v_cb.close_cb)
+            file->shared->inode->v_cb.close_cb(file);
 
         /* For open-time virtual files, release the virtual file
         data on close */
-        if (file->inode->v_cb.open_cb)
-            myst_buf_release(&file->vbuf);
+        if (file->shared->inode->v_cb.open_cb)
+            myst_buf_release(&file->shared->vbuf);
 
-        file->inode->nopens--;
+        file->shared->inode->nopens--;
 
         /* handle case where file was deleted while open */
-        if (file->inode->nopens == 0 && file->inode->nlink == 0)
+        if (file->shared->inode->nopens == 0 && file->shared->inode->nlink == 0)
         {
-            _inode_free(ramfs, file->inode);
+            _inode_free(ramfs, file->shared->inode);
         }
         else
         {
-            _update_timestamps(file->inode, ACCESS);
+            _update_timestamps(file->shared->inode, ACCESS);
         }
 
-        memset(file, 0xdd, sizeof(myst_file_t));
-        free(file);
+        memset(file->shared, 0xdd, sizeof(myst_file_t));
+        free(file->shared);
     }
+
+    /* free file descriptor level object */
+    memset(file, 0xdd, sizeof(myst_file_t));
+    free(file);
 done:
     return ret;
 }
@@ -1545,8 +1565,8 @@ static int _fs_fstat(myst_fs_t* fs, myst_file_t* file, struct stat* statbuf)
     if (!_ramfs_valid(ramfs) || !_file_valid(file) || !statbuf)
         ERAISE(-EINVAL);
 
-    assert(_inode_valid(file->inode));
-    ERAISE(_stat(file->inode, statbuf));
+    assert(_inode_valid(file->shared->inode));
+    ERAISE(_stat(file->shared->inode, statbuf));
 
 done:
     return ret;
@@ -1852,17 +1872,17 @@ static int _fs_ftruncate(myst_fs_t* fs, myst_file_t* file, off_t length)
     if (!_ramfs_valid(ramfs) || !_file_valid(file) || length < 0)
         ERAISE(-EINVAL);
 
-    if (S_ISDIR(file->inode->mode))
+    if (S_ISDIR(file->shared->inode->mode))
         ERAISE(-EISDIR);
 
     /* truncate does not apply to virtual files */
-    if (_is_virtual_inode(file->inode))
+    if (_is_virtual_inode(file->shared->inode))
         ERAISE(-EINVAL);
 
-    if (myst_buf_resize(&file->inode->buf, (size_t)length) != 0)
+    if (myst_buf_resize(&file->shared->inode->buf, (size_t)length) != 0)
         ERAISE(-ENOMEM);
 
-    _update_timestamps(file->inode, CHANGE | MODIFY);
+    _update_timestamps(file->shared->inode, CHANGE | MODIFY);
 
 done:
     return ret;
@@ -2018,8 +2038,8 @@ static int _fs_getdents64(
         goto done;
 
     /* in case an entry was deleted (by unlink) during this iteration */
-    if (file->offset >= file->inode->buf.size)
-        file->offset = file->inode->buf.size;
+    if (file->shared->offset >= file->shared->inode->buf.size)
+        file->shared->offset = file->shared->inode->buf.size;
 
     for (size_t i = 0; i < n; i++)
     {
@@ -2181,7 +2201,7 @@ static int _fs_realpath(
 
     if (strcmp(ramfs->target, "/") == 0)
     {
-        if (myst_strlcpy(buf, file->realpath, size) >= size)
+        if (myst_strlcpy(buf, file->shared->realpath, size) >= size)
             ERAISE(-ENAMETOOLONG);
     }
     else
@@ -2189,7 +2209,7 @@ static int _fs_realpath(
         if (myst_strlcpy(buf, ramfs->target, size) >= size)
             ERAISE(-ENAMETOOLONG);
 
-        if (myst_strlcat(buf, file->realpath, size) >= size)
+        if (myst_strlcat(buf, file->shared->realpath, size) >= size)
             ERAISE(-ENAMETOOLONG);
     }
 
@@ -2207,7 +2227,7 @@ static void _set_fd_flag(myst_file_t* file, long arg)
     else
         file->fdflags = 0;
 
-    _update_timestamps(file->inode, CHANGE);
+    _update_timestamps(file->shared->inode, CHANGE);
 }
 
 static int _fs_fcntl(myst_fs_t* fs, myst_file_t* file, int cmd, long arg)
@@ -2232,21 +2252,21 @@ static int _fs_fcntl(myst_fs_t* fs, myst_file_t* file, int cmd, long arg)
         }
         case F_GETFL:
         {
-            ret = (int)(file->access | file->operating);
+            ret = (int)(file->shared->access | file->shared->operating);
             goto done;
         }
         case F_SETFL:
         {
             if (arg & O_APPEND)
-                file->operating |= O_APPEND;
+                file->shared->operating |= O_APPEND;
             if (arg & O_NONBLOCK)
-                file->operating |= O_NONBLOCK;
+                file->shared->operating |= O_NONBLOCK;
             if (arg & O_DIRECT)
                 // ATTN: implement O_DIRECT for files
-                file->operating |= O_DIRECT;
+                file->shared->operating |= O_DIRECT;
             if (arg & O_NOATIME)
                 // ATTN: implement O_NOATIME for files
-                file->operating |= O_NOATIME;
+                file->shared->operating |= O_NOATIME;
             goto done;
         }
         case F_SETLK:
@@ -2305,9 +2325,9 @@ static int _fs_ioctl(
                 ERAISE(-EINVAL);
 
             if (*val)
-                file->operating |= O_NONBLOCK;
+                file->shared->operating |= O_NONBLOCK;
             else
-                file->operating &= ~O_NONBLOCK;
+                file->shared->operating &= ~O_NONBLOCK;
 
             break;
         }
@@ -2355,8 +2375,12 @@ static int _fs_dup(
     if (!_ramfs_valid(ramfs) || !_file_valid(file) || !file_out)
         ERAISE(-EINVAL);
 
-    (*file_out) = (myst_file_t*)file;
-    (*file_out)->use_count++;
+    if (!((*file_out) = calloc(1, sizeof(myst_file_t))))
+        ERAISE(-ENOMEM);
+
+    (*file_out)->shared = ((myst_file_t*)file)->shared;
+    (*file_out)->fdflags = 0;
+    (*file_out)->shared->use_count++;
 
 done:
 
@@ -2477,10 +2501,10 @@ static int _fs_futimens(
             case UTIME_OMIT:
                 break;
             case UTIME_NOW:
-                _update_timestamps(file->inode, ACCESS);
+                _update_timestamps(file->shared->inode, ACCESS);
                 break;
             default:
-                file->inode->atime = times[0];
+                file->shared->inode->atime = times[0];
                 break;
         }
 
@@ -2489,17 +2513,17 @@ static int _fs_futimens(
             case UTIME_OMIT:
                 break;
             case UTIME_NOW:
-                _update_timestamps(file->inode, MODIFY);
+                _update_timestamps(file->shared->inode, MODIFY);
                 break;
             default:
-                file->inode->atime = times[1];
+                file->shared->inode->atime = times[1];
                 break;
         }
     }
     else
     {
         /* set to current time */
-        _update_timestamps(file->inode, ACCESS | MODIFY);
+        _update_timestamps(file->shared->inode, ACCESS | MODIFY);
     }
 
 done:
@@ -2586,8 +2610,8 @@ int _fs_fchown(myst_fs_t* fs, myst_file_t* file, uid_t owner, gid_t group)
     if (!_ramfs_valid(ramfs) || !file)
         ERAISE(-EINVAL);
 
-    assert(_inode_valid(file->inode));
-    ECHECK(_chown(file->inode, owner, group));
+    assert(_inode_valid(file->shared->inode));
+    ECHECK(_chown(file->shared->inode, owner, group));
 
 done:
     return ret;
@@ -2709,8 +2733,8 @@ static int _fs_fchmod(myst_fs_t* fs, myst_file_t* file, mode_t mode)
     if (!_ramfs_valid(ramfs) || !file)
         ERAISE(-EINVAL);
 
-    assert(_inode_valid(file->inode));
-    ECHECK(_chmod(file->inode, mode));
+    assert(_inode_valid(file->shared->inode));
+    ECHECK(_chmod(file->shared->inode, mode));
 
 done:
     return ret;
@@ -3013,17 +3037,17 @@ int myst_read_stateful_virtual_file(
     int ret = 0;
     size_t len = buf_size;
 
-    myst_spin_lock(&file->vbuf_lock);
-    if (file->vbuf.size < len)
-        len = file->vbuf.size;
+    myst_spin_lock(&file->shared->vbuf_lock);
+    if (file->shared->vbuf.size < len)
+        len = file->shared->vbuf.size;
 
-    memcpy(buf, file->vbuf.data, len);
+    memcpy(buf, file->shared->vbuf.data, len);
 
-    myst_buf_remove(&file->vbuf, 0, len);
+    myst_buf_remove(&file->shared->vbuf, 0, len);
 
     ret = len;
 
-    myst_spin_unlock(&file->vbuf_lock);
+    myst_spin_unlock(&file->shared->vbuf_lock);
     return ret;
 }
 
@@ -3033,9 +3057,9 @@ int myst_write_stateful_virtual_file(
     size_t buf_size)
 {
     int ret = 0;
-    myst_spin_lock(&file->vbuf_lock);
-    ret = myst_buf_append(&file->vbuf, buf, buf_size);
-    myst_spin_unlock(&file->vbuf_lock);
+    myst_spin_lock(&file->shared->vbuf_lock);
+    ret = myst_buf_append(&file->shared->vbuf, buf, buf_size);
+    myst_spin_unlock(&file->shared->vbuf_lock);
     return ret;
 }
 

--- a/tests/dup/Makefile
+++ b/tests/dup/Makefile
@@ -12,7 +12,10 @@ all:
 rootfs: dup.c
 	mkdir -p $(APPDIR)/bin
 	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/dup dup.c $(LDFLAGS)
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/exec_prog exec_prog.c $(LDFLAGS)
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/dup_cloexec dup_cloexec.c $(LDFLAGS)
 	$(MYST) mkcpio $(APPDIR) rootfs
+	$(MYST) mkext2 --force $(APPDIR) ext2fs
 
 ifdef STRACE
 OPTS = --strace
@@ -20,10 +23,16 @@ endif
 
 tests: all
 	$(RUNTEST) $(MYST_EXEC) rootfs /bin/dup $(OPTS)
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/dup_cloexec $(OPTS)
+	$(RUNTEST) $(MYST_EXEC) ext2fs /bin/dup $(OPTS)
+	$(RUNTEST) $(MYST_EXEC) ext2fs /bin/dup_cloexec $(OPTS)
 
 tests2:
-	gcc dup.c
-	./a.out
+	gcc dup.c -o dup 
+	gcc exec_prog.c -o exec_prog
+	gcc dup_cloexec.c -o dup_cloexec
+	./dup
+	./dup_cloexec
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/dup/dup_cloexec.c
+++ b/tests/dup/dup_cloexec.c
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int test_dup_cloexec()
+{
+    int fd1, fd2;
+    FILE* out;
+
+    if (!(out = fopen("/tmp/file", "w")))
+    {
+        printf("fopen error: %i\n", errno);
+        assert(false);
+    }
+
+    fd1 = fileno(out);
+    assert(fd1 > 0);
+
+    assert(fcntl(fd1, F_SETFD, FD_CLOEXEC) == 0);
+
+    int fdflags = fcntl(fd1, F_GETFD);
+    assert(fdflags == FD_CLOEXEC);
+
+    fd2 = dup(fd1);
+
+    // FD_CLOEXEC is not inherited on dup
+    fdflags = fcntl(fd2, F_GETFD);
+    assert(fdflags == 0);
+
+    char fd1_char[5];
+    char fd2_char[5];
+    sprintf(fd1_char, "%d", fd1);
+    sprintf(fd2_char, "%d", fd2);
+
+    printf("Calling exec\n");
+    char* args[] = {"./exec_prog", fd1_char, fd2_char, NULL};
+    int execret = execvp(args[0], args);
+    printf("errono %i", errno);
+
+    printf("Test failed execvp returned %i\n", execret);
+    close(fd1);
+    close(fd2);
+    assert(execret == 0);
+}
+
+int main(int argc, const char* argv[])
+{
+    printf("test_dup_cloexec exec\n");
+    test_dup_cloexec();
+
+    return 0;
+}

--- a/tests/dup/exec_prog.c
+++ b/tests/dup/exec_prog.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[])
+{
+    printf("This program is called by exec\n");
+
+    int fd1 = atoi(argv[1]);
+    int fd2 = atoi(argv[2]);
+    printf("fd1 %i\n", fd1);
+    printf("fd2 %i\n", fd2);
+
+    // fd1 is closed (FD_CLOEXEC set)
+    assert(lseek(fd1, 0, SEEK_CUR) == -1);
+
+    // fd2 is not closed
+    assert(lseek(fd2, 0, SEEK_CUR) == 0);
+
+    assert(close(fd1) != 0);
+    assert(close(fd2) == 0);
+    printf("=== passed test test_dup_cloexec\n");
+    return 0;
+}

--- a/tests/ltp/README.md
+++ b/tests/ltp/README.md
@@ -157,7 +157,7 @@ FAILING
 | /ltp/testcases/kernel/syscalls/dup/dup07 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/dup2/dup201 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/dup2/dup202 | 1 | 1 | 1 |
-| /ltp/testcases/kernel/syscalls/dup2/dup203 | 0 | 1 | 0 |
+| /ltp/testcases/kernel/syscalls/dup2/dup203 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/dup2/dup204 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/dup2/dup205 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/dup3/dup3_01 | 1 | 1 | 1 |

--- a/tests/ltp/ext2fs_fs_tests_passed.txt
+++ b/tests/ltp/ext2fs_fs_tests_passed.txt
@@ -21,6 +21,7 @@
 /ltp/testcases/kernel/syscalls/dup/dup06
 /ltp/testcases/kernel/syscalls/dup/dup07
 /ltp/testcases/kernel/syscalls/dup2/dup202
+/ltp/testcases/kernel/syscalls/dup2/dup203
 /ltp/testcases/kernel/syscalls/dup2/dup204
 /ltp/testcases/kernel/syscalls/dup2/dup205
 /ltp/testcases/kernel/syscalls/dup3/dup3_01

--- a/tests/ltp/ext2fs_tests_other_errors.txt
+++ b/tests/ltp/ext2fs_tests_other_errors.txt
@@ -66,7 +66,6 @@
 /ltp/testcases/kernel/syscalls/dup/dup02
 /ltp/testcases/kernel/syscalls/dup/dup05
 /ltp/testcases/kernel/syscalls/dup2/dup201
-/ltp/testcases/kernel/syscalls/dup2/dup203
 /ltp/testcases/kernel/syscalls/epoll_pwait/epoll_pwait01
 /ltp/testcases/kernel/syscalls/epoll_wait/epoll_wait02
 /ltp/testcases/kernel/syscalls/epoll_wait/epoll_wait03

--- a/tests/ltp/ext2fs_tests_passed.txt
+++ b/tests/ltp/ext2fs_tests_passed.txt
@@ -28,6 +28,7 @@
 /ltp/testcases/kernel/syscalls/dup/dup06
 /ltp/testcases/kernel/syscalls/dup/dup07
 /ltp/testcases/kernel/syscalls/dup2/dup202
+/ltp/testcases/kernel/syscalls/dup2/dup203
 /ltp/testcases/kernel/syscalls/dup2/dup204
 /ltp/testcases/kernel/syscalls/dup2/dup205
 /ltp/testcases/kernel/syscalls/dup3/dup3_01

--- a/tests/ltp/ramfs_fs_tests_passed.txt
+++ b/tests/ltp/ramfs_fs_tests_passed.txt
@@ -21,6 +21,7 @@
 /ltp/testcases/kernel/syscalls/dup/dup06
 /ltp/testcases/kernel/syscalls/dup/dup07
 /ltp/testcases/kernel/syscalls/dup2/dup202
+/ltp/testcases/kernel/syscalls/dup2/dup203
 /ltp/testcases/kernel/syscalls/dup2/dup204
 /ltp/testcases/kernel/syscalls/dup2/dup205
 /ltp/testcases/kernel/syscalls/dup3/dup3_01

--- a/tests/ltp/ramfs_tests_other_errors.txt
+++ b/tests/ltp/ramfs_tests_other_errors.txt
@@ -66,7 +66,6 @@
 /ltp/testcases/kernel/syscalls/dup/dup02
 /ltp/testcases/kernel/syscalls/dup/dup05
 /ltp/testcases/kernel/syscalls/dup2/dup201
-/ltp/testcases/kernel/syscalls/dup2/dup203
 /ltp/testcases/kernel/syscalls/epoll_pwait/epoll_pwait01
 /ltp/testcases/kernel/syscalls/epoll_wait/epoll_wait02
 /ltp/testcases/kernel/syscalls/epoll_wait/epoll_wait03

--- a/tests/ltp/ramfs_tests_passed.txt
+++ b/tests/ltp/ramfs_tests_passed.txt
@@ -28,6 +28,7 @@
 /ltp/testcases/kernel/syscalls/dup/dup06
 /ltp/testcases/kernel/syscalls/dup/dup07
 /ltp/testcases/kernel/syscalls/dup2/dup202
+/ltp/testcases/kernel/syscalls/dup2/dup203
 /ltp/testcases/kernel/syscalls/dup2/dup204
 /ltp/testcases/kernel/syscalls/dup2/dup205
 /ltp/testcases/kernel/syscalls/dup3/dup3_01


### PR DESCRIPTION
closes #503 

Moved shared file objects to `myst_file_shared` in ramfs and ext2fs. `myst_file` is now a file descriptor level object, allowing each dup'd file descriptor to have its own file descriptor flag (currently only FD_CLOEXEC).