### PR TITLE
Initialize locals

### DIFF
--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -323,7 +323,7 @@ static int _status_vcallback(
 
     myst_spin_lock(&myst_process_list_lock);
 
-    if (!(locals = malloc(sizeof(struct locals))))
+    if (!(locals = calloc(1, sizeof(struct locals))))
         ERAISE(-ENOMEM);
 
     if (!vbuf || !entrypath)


### PR DESCRIPTION
Fixes occassional crash that happens when run under gdb.

free(locals->_host_status_buf) leads to memory corruption due to uninitialized
_host_status_buf in case of early return.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>