### PR TITLE
run-gdb target to detect problems when run under gdb.

### DIFF
--- a/tests/aspnetcore/Makefile
+++ b/tests/aspnetcore/Makefile
@@ -42,6 +42,11 @@ one:
 	$(MYST_EXEC) ext2fs --roothash=roothash $(OPTS) \
 	/aspnetcore/.dotnet/dotnet test $(TEST)
 
+one-gdb:
+	$(MYST_GDB) --batch -ex "source ./commands.gdb" --args \
+        $(MYST_EXEC) ext2fs --roothash=roothash $(OPTS) \
+	/aspnetcore/.dotnet/dotnet test $(TEST)
+
 #################################
 #			dev targets			#
 #################################

--- a/tests/aspnetcore/commands.gdb
+++ b/tests/aspnetcore/commands.gdb
@@ -1,0 +1,28 @@
+# Pass certain signals to program
+handle SIGILL nostop noprint
+handle SIGUSR1 nostop noprint
+handle SIGUSR2 nostop noprint
+handle SIG35 nostop noprint
+handle SIGABRT nostop noprint
+
+# Demangle C++ identifiers
+set print asm-demangle on
+
+# Don't prompt for pagination
+set pagination off
+
+# Don't prompt for pending breakpoints
+set breakpoint pending on
+
+# In general, don't wait for confirmation
+set confirm off
+
+# Set exit code to default value
+set $_exitcode = -1
+
+# Run the program
+run
+
+# Return exit code to shell
+printf "Exit code is %d\n", $_exitcode
+quit $_exitcode


### PR DESCRIPTION
aspnetcore tests that pass normally fail frequently enough when run under myst-gdb.
The `run-gdb` target makes it easy to reproduce such failures.

For example, running `make run-gdb` multiple times will trigger SEGV or hang.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>