### PR TITLE
[do not merge] Add /proc/sys/kernel/pid_max

### DIFF
--- a/include/myst/bits.h
+++ b/include/myst/bits.h
@@ -29,4 +29,21 @@ MYST_INLINE void myst_clear_bit(uint8_t* data, size_t index)
     data[byte] &= ~(1 << bit);
 }
 
+MYST_INLINE size_t
+myst_find_clear_bit(uint8_t* data, size_t size, size_t start_index)
+{
+    uint8_t i = start_index / 8;
+    uint8_t val = 0;
+
+    while (i < size)
+    {
+        val = data[i];
+        if (val != 0xff)
+        {
+            return (i * 8 + (size_t)__builtin_ctz((int)(~val & (val + 1))));
+        }
+        i++;
+    }
+    return 0;
+}
 #endif /* _MYST_BITS_H */

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -29,6 +29,13 @@
 /* Typical default value in host operating system's /proc/sys/kernel/pid_max */
 #define MYST_PID_MAX 0x8000
 
+/*
+ * Bitmap to track pids in use. If bit 'n' (starting from 0) is set, then pid
+ * 'n' is assigned to an active process or thread. When cycling, we cycling pid
+ * between [104, 32677].
+ */
+extern uint8_t myst_bitmap_pid[4096];
+
 /* this signal is used to interrupt threads blocking on host in syscalls */
 #define MYST_INTERRUPT_THREAD_SIGNAL (SIGRTMIN + 1)
 

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -10,6 +10,7 @@
 
 #include <myst/appenv.h>
 #include <myst/atexit.h>
+#include <myst/bits.h>
 #include <myst/clock.h>
 #include <myst/cpio.h>
 #include <myst/crash.h>
@@ -954,6 +955,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         /* Remove ourself from /proc/<pid> so other processes know we have gone
          * if they check */
         procfs_pid_cleanup(process->pid);
+        myst_set_bit(myst_bitmap_pid, process->pid);
 
         /* Send SIGHUP to all other active processes */
         myst_send_sighup_child_processes(process);


### PR DESCRIPTION
The file /proc/sys/kernel/pid_max is required for ltp tests for syscall sched_getparam, sched_getscheduler and sched_setscheduler to function correctly. 


To cycle pids, introduced a 4096 byte bitmap to track pid/tids in use. The pid/ tid are assigned starting from 100 in increments of 1, and set the bit corresponding to the pid/tid on the bitmap. Concurrently, when a thread has finished execution, the bit corresponding to pid/ tid is unset in bitmap. When pid_max is reached, the bitmap is checked for the first unset bit starting from value 104.

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>