### PR TITLE
Add tcall sched_getparam

### DIFF
--- a/crt/sched.c
+++ b/crt/sched.c
@@ -1,0 +1,14 @@
+#include <myst/syscallext.h>
+#include <sched.h>
+#include <stdio.h>
+#include <string.h>
+#include <syscall.h>
+#include <unistd.h>
+
+int sched_getparam(pid_t pid, struct sched_param* param)
+{
+    if (param)
+        memset(param, 0, sizeof(struct sched_param));
+
+    return syscall(SYS_sched_getparam, pid, param);
+}

--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -226,6 +226,7 @@ long myst_syscall_futex(
     int* uaddr2,
     int val3);
 
+long myst_syscall_sched_getparam(pid_t pid, struct sched_param* param);
 long myst_syscall_getrandom(void* buf, size_t buflen, unsigned int flags);
 
 struct rusage;

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -25,6 +25,9 @@
 #define MYST_THREAD_MAGIC 0xc79c53d9ad134ad4
 #define MYST_MAX_MUNNAP_ON_EXIT 5
 
+/* Typical default value in host operating system's /proc/sys/kernel/pid_max */
+#define MYST_PID_MAX 0x8000
+
 /* this signal is used to interrupt threads blocking on host in syscalls */
 #define MYST_INTERRUPT_THREAD_SIGNAL (SIGRTMIN + 1)
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <errno.h>
+#include <sched.h>
+#include <string.h>
+#include <syscall.h>
+#include <unistd.h>
+
+#include <myst/eraise.h>
+#include <myst/errno.h>
+#include <myst/kernel.h>
+#include <myst/thread.h>
+
+long myst_syscall_sched_getparam(pid_t pid, struct sched_param* param)
+{
+    long ret = 0;
+    long params[6] = {0};
+
+    if (pid < 0)
+        ERAISE(-EINVAL);
+    else if (pid >= MYST_PID_MAX)
+        ERAISE(-ESRCH);
+
+    if (!param || !myst_is_addr_within_kernel(param))
+    {
+        ERAISE(-EFAULT);
+    }
+
+    memset(param, 0, sizeof(struct sched_param));
+
+    if (pid == 0)
+        params[0] = (long)pid;
+    else
+    {
+        /* We need to send the target pid to the tcall */
+        myst_process_t* process = myst_find_process_from_pid(pid, true);
+        if (process)
+            params[0] = (long)process->main_process_thread->target_tid;
+        else
+            ERAISE(-ESRCH);
+    }
+    params[1] = (long)param;
+
+    ret = myst_tcall(SYS_sched_getparam, params);
+
+done:
+    return ret;
+}

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -4641,15 +4641,7 @@ static long _syscall(void* args_)
 
             _strace(n, "pid=%d param=%p", pid, param);
 
-            // ATTN: Return the priority from SYS_sched_setparam.
-            if (param != NULL)
-            {
-                // Only memset the non reserved part of the structure
-                // This is to be defensive against different sizes of this
-                // struct in musl and glibc.
-                memset(param, 0, sizeof(*param) - 40);
-            }
-            BREAK(_return(n, 0));
+            BREAK(_return(n, myst_syscall_sched_getparam(pid, param)));
         }
         case SYS_sched_setscheduler:
         {

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -667,6 +667,7 @@ long myst_tcall(long n, long params[6])
             return myst_tcall_poll(fds, nfds, timeout);
         }
         case SYS_sched_yield:
+        case SYS_sched_getparam:
         case SYS_fstat:
         case SYS_close:
         case SYS_readv:

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -599,6 +599,7 @@ long myst_tcall(long n, long params[6])
         case SYS_ioctl:
         case SYS_fstat:
         case SYS_sched_yield:
+        case SYS_sched_getparam:
         case SYS_fchmod:
         case SYS_poll:
         case SYS_open:

--- a/tests/ltp/ext2fs_tests_other_errors.txt
+++ b/tests/ltp/ext2fs_tests_other_errors.txt
@@ -543,7 +543,6 @@
 /ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
 /ltp/testcases/kernel/syscalls/sched_getaffinity/sched_getaffinity01
 /ltp/testcases/kernel/syscalls/sched_getattr/sched_getattr02
-/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam03
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler01
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler02

--- a/tests/ltp/ext2fs_tests_passed.txt
+++ b/tests/ltp/ext2fs_tests_passed.txt
@@ -234,6 +234,7 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
+/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/tests/ltp/hostfs_tests_other_errors.txt
+++ b/tests/ltp/hostfs_tests_other_errors.txt
@@ -531,7 +531,6 @@
 /ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
 /ltp/testcases/kernel/syscalls/sched_getaffinity/sched_getaffinity01
 /ltp/testcases/kernel/syscalls/sched_getattr/sched_getattr02
-/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam03
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler01
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler02

--- a/tests/ltp/hostfs_tests_passed.txt
+++ b/tests/ltp/hostfs_tests_passed.txt
@@ -244,6 +244,7 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
+/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/tests/ltp/ramfs_tests_other_errors.txt
+++ b/tests/ltp/ramfs_tests_other_errors.txt
@@ -558,7 +558,6 @@
 /ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02
 /ltp/testcases/kernel/syscalls/sched_getaffinity/sched_getaffinity01
 /ltp/testcases/kernel/syscalls/sched_getattr/sched_getattr02
-/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam03
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler01
 /ltp/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler02

--- a/tests/ltp/ramfs_tests_passed.txt
+++ b/tests/ltp/ramfs_tests_passed.txt
@@ -219,6 +219,7 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
+/ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -997,6 +997,21 @@ index 948ece41..fd7e7801 100644
 +	return 0;
 +}
 \ No newline at end of file
+diff --git a/src/sched/sched_getparam.c b/src/sched/sched_getparam.c
+index 76f10e49..c055a47f 100644
+--- a/src/sched/sched_getparam.c
++++ b/src/sched/sched_getparam.c
+@@ -2,7 +2,9 @@
+ #include <errno.h>
+ #include "syscall.h"
+ 
+-int sched_getparam(pid_t pid, struct sched_param *param)
++int do_sched_getparam(pid_t pid, struct sched_param *param)
+ {
+ 	return __syscall_ret(-ENOSYS);
+ }
++
++_Noreturn weak_alias(do_sched_getparam, sched_getparam);
 diff --git a/src/select/poll.c b/src/select/poll.c
 index c84c8a99..a5f561bd 100644
 --- a/src/select/poll.c

--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -865,6 +865,23 @@ done:
     return ret;
 }
 
+static long _sched_getparam(pid_t pid, struct myst_sched_param* param)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_sched_getparam_ocall(&retval, pid, param) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+
 static long _fchmod(int fd, mode_t mode, uid_t host_euid, gid_t host_egid)
 {
     long ret = 0;
@@ -2048,6 +2065,10 @@ long myst_handle_tcall(long n, long params[6])
         case SYS_sched_yield:
         {
             return _sched_yield();
+        }
+        case SYS_sched_getparam:
+        {
+            return _sched_getparam((pid_t)a, (struct myst_sched_param*)b);
         }
         case SYS_fchmod:
         {

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -663,6 +663,13 @@ long myst_ftruncate_ocall(int fd, off_t length)
     RETURN(ftruncate(fd, length));
 }
 
+long myst_sched_getparam_ocall(pid_t pid, struct myst_sched_param* param)
+{
+    return (syscall(SYS_sched_getparam, pid, (struct sched_param*)param) == 0)
+               ? 0
+               : -errno;
+}
+
 long myst_symlink_ocall(
     const char* target,
     const char* linkpath,

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -71,6 +71,18 @@ enclave
         char d_name[1];
     };
 
+    struct myst_sched_param_reserved {
+        time_t __reserved1;
+        long __reserved2;
+    };
+
+    struct myst_sched_param {
+        int sched_priority;
+        int __reserved1;
+        struct myst_sched_param_reserved __reserved2[2];
+        int __reserved3;
+    };
+
     trusted
     {
         public int myst_enter_ecall(
@@ -123,7 +135,13 @@ enclave
             uint64_t self_event,
             [in] const struct myst_timespec* timeout);
 
-        long myst_sched_yield_ocall();
+        long myst_sched_yield_ocall()
+            transition_using_threads;
+
+        long myst_sched_getparam_ocall(
+            pid_t pid,
+            [out] struct myst_sched_param* param)
+            transition_using_threads;
 
         long myst_poll_ocall(
             [in, out, count=nfds] struct pollfd* fds,


### PR DESCRIPTION
To test /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam03 passes with,the file /proc/sys/kernel/pid_max, when added. But that introduces pid/tid cycling and the requirements/need has to be clarified - tracked by #1013

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>