### PR TITLE
Setting process status not atomic and set once

### DIFF
--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -101,6 +101,10 @@ struct myst_process
     /* the process identifier (inherited from main thread) */
     pid_t pid;
 
+    /* To make sure the exit status and terminating signal number is set only
+     * once we use this flag */
+    bool exit_status_signum_set;
+
     /* The exit status passed to SYS_exit */
     int exit_status;
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -3926,6 +3926,7 @@ static long _syscall(void* args_)
             BREAK(_return(n, ret));
         }
         case SYS_exit:
+        case SYS_exit_group:
         {
             const int status = (int)x1;
 
@@ -3944,7 +3945,21 @@ static long _syscall(void* args_)
             if (!thread || thread->magic != MYST_THREAD_MAGIC)
                 myst_panic("unexpected");
 
-            process->exit_status = status;
+            bool process_status_set = false;
+            if (__atomic_compare_exchange_n(
+                    &process->exit_status_signum_set,
+                    &process_status_set,
+                    true,
+                    false,
+                    __ATOMIC_RELEASE,
+                    __ATOMIC_ACQUIRE))
+            {
+                process->exit_status = status;
+                process->terminating_signum = 0;
+            }
+
+            if (n == SYS_exit_group)
+                myst_kill_thread_group();
 
             /* the kstack is freed after the long-jump below */
             thread->exit_kstack = args->kstack;
@@ -5018,14 +5033,6 @@ static long _syscall(void* args_)
         }
         case SYS_clock_nanosleep:
             break;
-        case SYS_exit_group:
-        {
-            int status = (int)x1;
-            _strace(n, "status=%d", status);
-
-            myst_kill_thread_group();
-            BREAK(_return(n, 0));
-        }
         case SYS_epoll_wait:
         {
             int epfd = (int)x1;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -539,7 +539,7 @@ long myst_wait(
     myst_process_t* p;
 
     if (rusage)
-        ERAISE(-EINVAL);
+        memset(rusage, 0, sizeof(*rusage));
 
     /* If this is the only process then raise ECHILD */
     if (process->next_process == NULL && process->prev_process == NULL &&

--- a/tests/ltp/README.md
+++ b/tests/ltp/README.md
@@ -197,7 +197,7 @@ FAILING
 | /ltp/testcases/kernel/syscalls/execvp/execvp01_child | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/exit/exit01 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/exit/exit02 | 1 | 1 | 1 |
-| /ltp/testcases/kernel/syscalls/exit_group/exit_group01 | 0 | 0 | 0 |
+| /ltp/testcases/kernel/syscalls/exit_group/exit_group01 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/faccessat/faccessat01 | 1 | 1 | 1 |
 | /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise01 | 0 | 0 | 0 |
 | /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise01_64 | 0 | 0 | 0 |

--- a/tests/ltp/ext2fs_tests_other_errors.txt
+++ b/tests/ltp/ext2fs_tests_other_errors.txt
@@ -94,7 +94,6 @@
 /ltp/testcases/kernel/syscalls/execveat/execveat_errno
 /ltp/testcases/kernel/syscalls/execvp/execvp01
 /ltp/testcases/kernel/syscalls/execvp/execvp01_child
-/ltp/testcases/kernel/syscalls/exit_group/exit_group01
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise01
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise01_64
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise02

--- a/tests/ltp/ext2fs_tests_passed.txt
+++ b/tests/ltp/ext2fs_tests_passed.txt
@@ -40,6 +40,7 @@
 /ltp/testcases/kernel/syscalls/eventfd2/eventfd2_02
 /ltp/testcases/kernel/syscalls/exit/exit01
 /ltp/testcases/kernel/syscalls/exit/exit02
+/ltp/testcases/kernel/syscalls/exit_group/exit_group01
 /ltp/testcases/kernel/syscalls/faccessat/faccessat01
 /ltp/testcases/kernel/syscalls/fallocate/fallocate03
 /ltp/testcases/kernel/syscalls/fchdir/fchdir01

--- a/tests/ltp/hostfs_tests_other_errors.txt
+++ b/tests/ltp/hostfs_tests_other_errors.txt
@@ -92,7 +92,6 @@
 /ltp/testcases/kernel/syscalls/execveat/execveat_errno
 /ltp/testcases/kernel/syscalls/execvp/execvp01
 /ltp/testcases/kernel/syscalls/execvp/execvp01_child
-/ltp/testcases/kernel/syscalls/exit_group/exit_group01
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise01
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise01_64
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise02

--- a/tests/ltp/hostfs_tests_passed.txt
+++ b/tests/ltp/hostfs_tests_passed.txt
@@ -42,6 +42,7 @@
 /ltp/testcases/kernel/syscalls/eventfd2/eventfd2_02
 /ltp/testcases/kernel/syscalls/exit/exit01
 /ltp/testcases/kernel/syscalls/exit/exit02
+/ltp/testcases/kernel/syscalls/exit_group/exit_group01
 /ltp/testcases/kernel/syscalls/faccessat/faccessat01
 /ltp/testcases/kernel/syscalls/fallocate/fallocate03
 /ltp/testcases/kernel/syscalls/fchdir/fchdir01

--- a/tests/ltp/ramfs_tests_other_errors.txt
+++ b/tests/ltp/ramfs_tests_other_errors.txt
@@ -94,7 +94,6 @@
 /ltp/testcases/kernel/syscalls/execveat/execveat_errno
 /ltp/testcases/kernel/syscalls/execvp/execvp01
 /ltp/testcases/kernel/syscalls/execvp/execvp01_child
-/ltp/testcases/kernel/syscalls/exit_group/exit_group01
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise01
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise01_64
 /ltp/testcases/kernel/syscalls/fadvise/posix_fadvise02

--- a/tests/ltp/ramfs_tests_passed.txt
+++ b/tests/ltp/ramfs_tests_passed.txt
@@ -40,6 +40,7 @@
 /ltp/testcases/kernel/syscalls/eventfd2/eventfd2_02
 /ltp/testcases/kernel/syscalls/exit/exit01
 /ltp/testcases/kernel/syscalls/exit/exit02
+/ltp/testcases/kernel/syscalls/exit_group/exit_group01
 /ltp/testcases/kernel/syscalls/faccessat/faccessat01
 /ltp/testcases/kernel/syscalls/fallocate/fallocate03
 /ltp/testcases/kernel/syscalls/fchdir/fchdir01

--- a/tests/pthread/Makefile
+++ b/tests/pthread/Makefile
@@ -8,10 +8,11 @@ all:
 	$(MAKE) myst
 	$(MAKE) rootfs
 
-rootfs: pthread.c
+rootfs: pthread.c exit_status.c
 	mkdir -p appdir/bin
 	$(MUSL_GCC) $(CFLAGS) -o appdir/bin/pthread_musl pthread.c $(LDFLAGS)
 	$(CC) $(CFLAGS) -DATTR_AFFINITY_NP -o appdir/bin/pthread_gcc pthread.c -lpthread $(LDFLAGS)
+	$(MUSL_GCC) $(CFLAGS) -o appdir/bin/exit_status exit_status.c -lpthread $(LDFLAGS)
 	$(MYST) mkcpio appdir rootfs
 
 ifdef STRACE
@@ -33,8 +34,18 @@ MAX_CPUS=--max-cpus=1024
 NPROCS=$(shell nproc)
 
 tests:
+	$(MAKE) test_musl
+	$(MAKE) test_gcc
+	$(MAKE) test_exit_on_thread
+
+test_musl: rootfs
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_musl $(NPROCS) $(COUNT) 
+
+test_gcc: rootfs
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/pthread_gcc $(NPROCS) $(COUNT)
+
+test_exit_on_thread: rootfs
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/exit_status tests
 
 t:
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(MAX_CPUS) rootfs /bin/pthread_gcc $(NPROCS) $(COUNT)

--- a/tests/pthread/exit_status.c
+++ b/tests/pthread/exit_status.c
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <pthread.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#define CHECK(ret) \
+    if (ret != 0)  \
+        exit(-1);
+
+#define TEST1_EXIT_STATUS 0
+#define TEST2_EXIT_STATUS 2
+
+void* thread_exit(void* _args)
+{
+    int* args = (int*)_args;
+    int code = *args;
+    fprintf(stderr, "calling exit(%d) from thread_exit\n", code);
+    exit(code);
+}
+
+int test1_child()
+{
+    pthread_t child;
+    int code = TEST1_EXIT_STATUS;
+    pthread_create(&child, NULL, thread_exit, &code);
+    pthread_join(child, NULL);
+    return -1;
+}
+
+int test1()
+{
+    pid_t pid = 0;
+    int wstatus = 0;
+    char* const argv[] = {"/bin/exit_status", "test1-child", NULL};
+
+    if (posix_spawn(&pid, argv[0], NULL, NULL, argv, NULL) != 0)
+        return -1;
+
+    if (waitpid(pid, &wstatus, 0) != pid)
+        return -1;
+    if (!WIFEXITED(wstatus) || (WEXITSTATUS(wstatus) != TEST1_EXIT_STATUS))
+    {
+        fprintf(stderr, "didnt return the correct exit status\n");
+
+        return -1;
+    }
+
+    return 0;
+}
+
+int test2_child()
+{
+    pthread_t child;
+    int code = TEST2_EXIT_STATUS;
+    pthread_create(&child, NULL, thread_exit, &code);
+    pthread_join(child, NULL);
+    return -1;
+}
+
+int test2()
+{
+    pid_t pid = 0;
+    int wstatus = 0;
+    char* const argv[] = {"/bin/exit_status", "test2-child", NULL};
+
+    if (posix_spawn(&pid, argv[0], NULL, NULL, argv, NULL) != 0)
+        return -1;
+
+    if (waitpid(pid, &wstatus, 0) != pid)
+        return -1;
+    if (WEXITSTATUS(wstatus) != TEST2_EXIT_STATUS)
+    {
+        fprintf(stderr, "didnt return the correct exit status\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int tests()
+{
+    CHECK(test1());
+    CHECK(test2());
+
+    return 0;
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 2)
+        exit(-1);
+
+    if (strcmp(argv[1], "tests") == 0)
+        return tests();
+    else if (strcmp(argv[1], "test1-child") == 0)
+        return test1_child();
+    else if (strcmp(argv[1], "test2-child") == 0)
+        return test2_child();
+    else
+        return -1;
+}


### PR DESCRIPTION
it is set atomically between SYS_exit, SYS_exit_group and a terminating
signal.
On top of this, SYS_exit_group now terminates the current thread in the
same way that SYS_exit does.