### PR TITLE
[sched_getparam] bug fix  - look for pid in caller's threadpool too

### DIFF
--- a/crt/sched.c
+++ b/crt/sched.c
@@ -7,8 +7,5 @@
 
 int sched_getparam(pid_t pid, struct sched_param* param)
 {
-    if (param)
-        memset(param, 0, sizeof(struct sched_param));
-
     return syscall(SYS_sched_getparam, pid, param);
 }

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -665,9 +665,7 @@ long myst_ftruncate_ocall(int fd, off_t length)
 
 long myst_sched_getparam_ocall(pid_t pid, struct myst_sched_param* param)
 {
-    return (syscall(SYS_sched_getparam, pid, (struct sched_param*)param) == 0)
-               ? 0
-               : -errno;
+    return (syscall(SYS_sched_getparam, pid, param) == 0) ? 0 : -errno;
 }
 
 long myst_symlink_ocall(

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -76,11 +76,9 @@ enclave
         long __reserved2;
     };
 
+    /* The expected glibc struct sched_param */
     struct myst_sched_param {
         int sched_priority;
-        int __reserved1;
-        struct myst_sched_param_reserved __reserved2[2];
-        int __reserved3;
     };
 
     trusted


### PR DESCRIPTION
sched_getparam should look in all processes and all threads in caller's threadpool for matching pid, change struct myst_sched_param to match glibc definition, and add memset protection for sched_param in kernel/sched.c

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>