### PR TITLE
[merge after #1013] Add sys_sched_setscheduler tcall and relevant ltp tests

### DIFF
--- a/crt/sched.c
+++ b/crt/sched.c
@@ -9,3 +9,8 @@ int sched_getparam(pid_t pid, struct sched_param* param)
 {
     return syscall(SYS_sched_getparam, pid, param);
 }
+
+int sched_setscheduler(pid_t pid, int sched, const struct sched_param* param)
+{
+    return syscall(SYS_sched_setscheduler, pid, sched, param);
+}

--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -227,6 +227,10 @@ long myst_syscall_futex(
     int val3);
 
 long myst_syscall_sched_getparam(pid_t pid, struct sched_param* param);
+long myst_syscall_sched_setscheduler(
+    pid_t pid,
+    int policy,
+    struct sched_param* param);
 long myst_syscall_getrandom(void* buf, size_t buflen, unsigned int flags);
 
 struct rusage;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -4663,7 +4663,12 @@ static long _syscall(void* args_)
             // ATTN: support different schedules, FIFO, RR, BATCH, etc.
             // The more control we have on threads inside the kernel, the more
             // schedulers we could support.
-            BREAK(_return(n, 0));
+            pid_t pid = (pid_t)x1;
+            int policy = (int)x2;
+            struct sched_param* param = (struct sched_param*)x3;
+
+            BREAK(_return(
+                n, myst_syscall_sched_setscheduler(pid, policy, param)));
         }
         case SYS_sched_getscheduler:
         {

--- a/target/linux/tcall.c
+++ b/target/linux/tcall.c
@@ -668,6 +668,7 @@ long myst_tcall(long n, long params[6])
         }
         case SYS_sched_yield:
         case SYS_sched_getparam:
+        case SYS_sched_setscheduler:
         case SYS_fstat:
         case SYS_close:
         case SYS_readv:

--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -600,6 +600,7 @@ long myst_tcall(long n, long params[6])
         case SYS_fstat:
         case SYS_sched_yield:
         case SYS_sched_getparam:
+        case SYS_sched_setscheduler:
         case SYS_fchmod:
         case SYS_poll:
         case SYS_open:

--- a/tests/ltp/ext2fs_tests_other_errors.txt
+++ b/tests/ltp/ext2fs_tests_other_errors.txt
@@ -555,8 +555,6 @@
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam03
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam04
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam05
-/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler01
-/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler02
 /ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler03
 /ltp/testcases/kernel/syscalls/select/select01
 /ltp/testcases/kernel/syscalls/select/select02

--- a/tests/ltp/ext2fs_tests_passed.txt
+++ b/tests/ltp/ext2fs_tests_passed.txt
@@ -236,6 +236,8 @@
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
+/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler01
+/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler02
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/tests/ltp/hostfs_tests_other_errors.txt
+++ b/tests/ltp/hostfs_tests_other_errors.txt
@@ -543,8 +543,6 @@
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam03
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam04
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam05
-/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler01
-/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler02
 /ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler03
 /ltp/testcases/kernel/syscalls/select/select01
 /ltp/testcases/kernel/syscalls/select/select02

--- a/tests/ltp/hostfs_tests_passed.txt
+++ b/tests/ltp/hostfs_tests_passed.txt
@@ -246,6 +246,8 @@
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
+/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler01
+/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler02
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/tests/ltp/ramfs_tests_other_errors.txt
+++ b/tests/ltp/ramfs_tests_other_errors.txt
@@ -570,8 +570,6 @@
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam03
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam04
 /ltp/testcases/kernel/syscalls/sched_setparam/sched_setparam05
-/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler01
-/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler02
 /ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler03
 /ltp/testcases/kernel/syscalls/select/select01
 /ltp/testcases/kernel/syscalls/select/select02

--- a/tests/ltp/ramfs_tests_passed.txt
+++ b/tests/ltp/ramfs_tests_passed.txt
@@ -221,6 +221,8 @@
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
 /ltp/testcases/kernel/syscalls/sched_getparam/sched_getparam01
+/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler01
+/ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler02
 /ltp/testcases/kernel/syscalls/sched_yield/sched_yield01
 /ltp/testcases/kernel/syscalls/send/send02
 /ltp/testcases/kernel/syscalls/sendfile/sendfile02

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -1012,6 +1012,21 @@ index 76f10e49..c055a47f 100644
  }
 +
 +_Noreturn weak_alias(do_sched_getparam, sched_getparam);
+diff --git a/src/sched/sched_setscheduler.c b/src/sched/sched_setscheduler.c
+index 4435f216..0252845b 100644
+--- a/src/sched/sched_setscheduler.c
++++ b/src/sched/sched_setscheduler.c
+@@ -2,7 +2,9 @@
+ #include <errno.h>
+ #include "syscall.h"
+ 
+-int sched_setscheduler(pid_t pid, int sched, const struct sched_param *param)
++int do_sched_setscheduler(pid_t pid, int sched, const struct sched_param *param)
+ {
+ 	return __syscall_ret(-ENOSYS);
+ }
++
++_Noreturn weak_alias(do_sched_setscheduler, sched_setscheduler);
 diff --git a/src/select/poll.c b/src/select/poll.c
 index c84c8a99..a5f561bd 100644
 --- a/src/select/poll.c

--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -882,6 +882,26 @@ done:
     return ret;
 }
 
+static long _sched_setscheduler(
+    pid_t pid,
+    int policy,
+    struct myst_sched_param* param)
+{
+    long ret = 0;
+    long retval;
+
+    if (myst_sched_setscheduler_ocall(&retval, pid, policy, param) != OE_OK)
+    {
+        ret = -EINVAL;
+        goto done;
+    }
+
+    ret = retval;
+
+done:
+    return ret;
+}
+
 static long _fchmod(int fd, mode_t mode, uid_t host_euid, gid_t host_egid)
 {
     long ret = 0;
@@ -2069,6 +2089,11 @@ long myst_handle_tcall(long n, long params[6])
         case SYS_sched_getparam:
         {
             return _sched_getparam((pid_t)a, (struct myst_sched_param*)b);
+        }
+        case SYS_sched_setscheduler:
+        {
+            return _sched_setscheduler(
+                (pid_t)a, (int)b, (struct myst_sched_param*)c);
         }
         case SYS_fchmod:
         {

--- a/tools/myst/host/syscall.c
+++ b/tools/myst/host/syscall.c
@@ -668,6 +668,15 @@ long myst_sched_getparam_ocall(pid_t pid, struct myst_sched_param* param)
     return (syscall(SYS_sched_getparam, pid, param) == 0) ? 0 : -errno;
 }
 
+long myst_sched_setscheduler_ocall(
+    pid_t pid,
+    int policy,
+    struct myst_sched_param* param)
+{
+    return (syscall(SYS_sched_setscheduler, pid, policy, param) == 0) ? 0
+                                                                      : -errno;
+}
+
 long myst_symlink_ocall(
     const char* target,
     const char* linkpath,

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -141,6 +141,12 @@ enclave
             [out] struct myst_sched_param* param)
             transition_using_threads;
 
+        long myst_sched_setscheduler_ocall(
+            pid_t pid,
+            int policy,
+            [in, out] struct myst_sched_param* param)
+            transition_using_threads;
+
         long myst_poll_ocall(
             [in, out, count=nfds] struct pollfd* fds,
             unsigned long nfds,


### PR DESCRIPTION
Added sys_sched_setscheduler syscall through tcalls and relevant ltp tests. Need /proc/sys/kernel/pid_max file for the tests to work as expected (wait for PR #1013)

The test /ltp/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler03 could not be added due to rlimit limitation - needs further investigation (https://github.com/paulcallen/ltp/blob/master/testcases/kernel/syscalls/sched_setscheduler/sched_setscheduler03.c#L87)

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>