### PR TITLE
itimer multi-process, update wait and getitimer

### DIFF
--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -283,14 +283,18 @@ long myst_syscall_sethostname(const char* hostname, size_t len);
 
 long myst_syscall_umask(mode_t mask);
 
-long myst_syscall_run_itimer(void);
+long myst_syscall_run_itimer(myst_process_t* process);
 
 long myst_syscall_setitimer(
+    myst_process_t* process,
     int which,
     const struct itimerval* new_value,
     struct itimerval* old_value);
 
-int myst_syscall_getitimer(int which, struct itimerval* curr_value);
+int myst_syscall_getitimer(
+    myst_process_t* process,
+    int which,
+    struct itimerval* curr_value);
 
 long myst_syscall_fsync(int fd);
 

--- a/include/myst/thread.h
+++ b/include/myst/thread.h
@@ -93,6 +93,8 @@ struct siginfo_list_item
     struct siginfo_list_item* next;
 };
 
+typedef struct myst_itimer myst_itimer_t;
+
 struct myst_process
 {
     /* the session id (see getsid() function) */
@@ -192,6 +194,14 @@ struct myst_process
      * is received.
      */
     int sigstop_futex;
+
+    /* itimer thread needs to be initialized by the CRT once. This boolean
+     * returns if it has not been done yet so it can be initiated. */
+    bool itimer_thread_requested;
+
+    /* itimer data. this structure has too many other objects in it that make it
+     * hard to not be a pointer so it gets initialized when there are calls. */
+    myst_itimer_t* itimer;
 };
 
 struct myst_thread

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -907,6 +907,9 @@ int myst_enter_kernel(myst_kernel_args_t* args)
             process->fdtable = NULL;
         }
 
+        if (process->itimer)
+            free(process->itimer);
+
         /* Remove ourself from /proc/<pid> so other processes know we have gone
          * if they check */
         procfs_pid_cleanup(process->pid);

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -3830,7 +3830,7 @@ static long _syscall(void* args_)
         case SYS_myst_run_itimer:
         {
             _strace(n, NULL);
-            BREAK(_return(n, myst_syscall_run_itimer()));
+            BREAK(_return(n, myst_syscall_run_itimer(process)));
         }
         case SYS_myst_start_shell:
         {
@@ -3848,7 +3848,8 @@ static long _syscall(void* args_)
 
             _strace(n, "which=%d curr_value=%p", which, curr_value);
 
-            BREAK(_return(n, myst_syscall_getitimer(which, curr_value)));
+            BREAK(
+                _return(n, myst_syscall_getitimer(process, which, curr_value)));
         }
         case SYS_alarm:
             break;
@@ -3866,7 +3867,8 @@ static long _syscall(void* args_)
                 old_value);
 
             BREAK(_return(
-                n, myst_syscall_setitimer(which, new_value, old_value)));
+                n,
+                myst_syscall_setitimer(process, which, new_value, old_value)));
         }
         case SYS_getpid:
         {

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1061,6 +1061,9 @@ static long _run_thread(void* arg_)
                 process->fdtable = NULL;
             }
 
+            if (process->itimer)
+                free(process->itimer);
+
             /* Only need to zombify the process thread.
             ATTN: referencing "process" after zombification is not safe,
             parent might have cleaned it up */


### PR DESCRIPTION
add multi-process support
getitimer calculates based off of wait start time, more accurate
wait does wait for full amount, not pulsing every millisecond
wait timer does not overrun if got woken with interrupt

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>