### PR TITLE
Add /proc/stat and fix /proc/[pid]/stat:starttime

### DIFF
--- a/tests/dotnet-ubuntu/hello/Program.cs
+++ b/tests/dotnet-ubuntu/hello/Program.cs
@@ -23,6 +23,13 @@ namespace hello
                 Console.WriteLine("Exception caught: {0}", e);
             }
         }
+
+        static void test_process_starttime()
+        {
+            DateTime startTime = Process.GetCurrentProcess().StartTime;
+            Console.WriteLine("process startTime: {0}", startTime);
+        }
+
         static void Main(string[] args)
         {
             // test handling multiple SIGFPEs.
@@ -33,6 +40,7 @@ namespace hello
             test_null_str_op();
             test_null_str_op();
 
+            test_process_starttime();
         }  
     }
 }

--- a/tests/procfs/procfs.c
+++ b/tests/procfs/procfs.c
@@ -266,8 +266,12 @@ int parse_proc_stat_file(pid_t pid, proc_pid_stat_t* statptr)
         &statptr->state,
         &statptr->starttime);
 
-    // printf("%d %s %c %llu\n", statptr->pid, statptr->name, statptr->state,
-    // statptr->starttime);
+    printf(
+        "%d %s %c %llu\n",
+        statptr->pid,
+        statptr->name,
+        statptr->state,
+        statptr->starttime);
     fclose(fp);
 }
 
@@ -285,11 +289,14 @@ int test_stat()
     assert(stat.state == 'R');
 }
 
+#define SLEEP_DUR 3
 int test_stat_from_child()
 {
     struct timespec tp;
     assert(clock_gettime(CLOCK_MONOTONIC, &tp) == 0);
 
+    // sleep so that child's start time is further away from kernel boot time
+    sleep(SLEEP_DUR);
     pid_t pid = fork();
     assert(pid >= 0);
 
@@ -307,7 +314,7 @@ int test_stat_from_child()
         parse_proc_stat_file(getpid(), &self_stat);
 
         assert(self_stat.pid = getpid());
-        assert(self_stat.starttime >= TIMESPEC_TO_NANOS(tp));
+        assert(self_stat.starttime >= SLEEP_DUR * sysconf(_SC_CLK_TCK));
 
         exit(0);
     }


### PR DESCRIPTION
procfs fixes to unblock dotnet test runner.

Changes -
- Rudimentary implementation for /proc/stat added. Only `btime` - seconds since epoch till system was booted, and `procs_running` fields are supported. Other fields are related to cpu and interrupts, which could be copied over from the host.
- Fix `starttime` field in `/proc/[pid]/starttime`, supposed to return number of ticks between system boot and process start. 