### PR TITLE
exit() vs SYS_exit different. status was set wrong

### DIFF
--- a/tests/signal/Makefile
+++ b/tests/signal/Makefile
@@ -5,7 +5,16 @@ APPDIR = appdir
 CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 
-#OPTS = --strace
+ifdef TRACE
+	OPTS += --strace --etrace
+else
+	ifdef STRACE
+		OPTS += --strace
+	endif
+	ifdef ETRACE
+		OPTS += --etrace
+	endif
+endif
 
 all:
 	$(MAKE) myst


### PR DESCRIPTION
exit() can be called to shut down each thread. It should not set the
process status unless it is the last thread of the process.
SYS_exit_group on the other hand always tries to set the exit status of
the process because it kills all the process threads including its own

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>