### PR TITLE
Update nightly pipeline

### DIFF
--- a/.jenkins/pipelines/nightly.Jenkinsfile
+++ b/.jenkins/pipelines/nightly.Jenkinsfile
@@ -8,12 +8,48 @@ pipeline {
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
-        choice(name: "REGION", choices:['useast', 'canadacentral'], description: "Azure region for the SQL solutions test")
+        string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
+        choice(name: "REGION", choices: ['useast', 'canadacentral'], description: "Azure region for the SQL solutions test")
     }
     environment {
         TEST_CONFIG = 'Nightly'
     }
     stages {
+        stage('Checkout') {
+            when {
+                anyOf {
+                    expression { params.PULL_REQUEST_ID != "" }
+                    expression { params.BRANCH != "" }
+                }
+            }
+            steps {
+                script {
+                    if ( params.PULL_REQUEST_ID ) {
+                        checkout([$class: 'GitSCM',
+                            branches: [[name: "pr/${PULL_REQUEST_ID}"]],
+                            extensions: [],
+                            userRemoteConfigs: [[
+                                url: 'https://github.com/deislabs/mystikos',
+                                refspec: "+refs/pull/${PULL_REQUEST_ID}/merge:refs/remotes/origin/pr/${PULL_REQUEST_ID}"
+                            ]]
+                        ])
+                    } else {
+                        checkout([$class: 'GitSCM',
+                            branches: [[name: params.BRANCH]],
+                            extensions: [],
+                            userRemoteConfigs: [[url: "https://github.com/${REPOSITORY}/mystikos"]]]
+                        )
+                    }
+                    GIT_COMMIT_ID = sh(
+                        returnStdout: true,
+                        script: "git log --max-count=1 --pretty=format:'%H'"
+                    ).trim()
+                    if ( GIT_COMMIT_ID == "" ) {
+                        error("Failed to fetch git commit ID")
+                    }
+                }
+            }
+        }
         stage('Run Nightly Tests') {
             matrix {
                 axes {
@@ -23,7 +59,7 @@ pipeline {
                     }
                     axis {
                         name 'TEST_PIPELINE'
-                        values 'Unit', 'Solutions', 'DotNet', 'Azure-SDK'
+                        values 'Unit', 'Solutions', 'DotNet', 'DotNet-P1', 'Azure-SDK'
                     }
                 }
                 stages {
@@ -32,15 +68,18 @@ pipeline {
                             script {
                                 stage("${OS_VERSION} ${TEST_PIPELINE} (${TEST_CONFIG})") {
                                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                                        build job: "Standalone-Pipelines/${TEST_PIPELINE}-Tests-Pipeline",
-                                        parameters: [
-                                            string(name: "UBUNTU_VERSION", value: OS_VERSION),
-                                            string(name: "REPOSITORY", value: params.REPOSITORY),
-                                            string(name: "BRANCH", value: params.BRANCH),
-                                            string(name: "TEST_CONFIG", value: env.TEST_CONFIG),
-                                            string(name: "REGION", value: params.REGION),
-                                            string(name: "COMMIT_SYNC", value: params.GIT_COMMIT)
-                                        ]
+                                        build(
+                                            job: "../Standalone-Pipelines/${TEST_PIPELINE}-Tests-Pipeline",
+                                            parameters: [
+                                                string(name: "UBUNTU_VERSION", value: OS_VERSION),
+                                                string(name: "REPOSITORY", value: params.REPOSITORY),
+                                                string(name: "BRANCH", value: params.BRANCH),
+                                                string(name: "PULL_REQUEST_ID", value: params.PULL_REQUEST_ID),
+                                                string(name: "TEST_CONFIG", value: env.TEST_CONFIG),
+                                                string(name: "REGION", value: params.REGION),
+                                                string(name: "COMMIT_SYNC", value: GIT_COMMIT_ID)
+                                            ]
+                                        )
                                     }
                                 }
                             }
@@ -48,6 +87,19 @@ pipeline {
                     }
                 }
             }
+        }
+    }
+    post {
+        always {
+            build(
+                job: "../Standalone-Pipelines/Send-Email",
+                parameters: [
+                    string(name: "REPOSITORY", value: params.REPOSITORY),
+                    string(name: "BRANCH", value: params.BRANCH),
+                    string(name: "EMAIL_SUBJECT", value: "[Jenkins] [${env.JOB_NAME}] [${currentBuild.currentResult}] [#${env.BUILD_NUMBER}]"),
+                    string(name: "EMAIL_BODY", value: "See build log for details: ${env.BUILD_URL}")
+                ]
+            )
         }
     }
 }

--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -6,11 +6,12 @@ pipeline {
         timeout(time: 300, unit: 'MINUTES')
     }
     parameters {
-        choice(name: "UBUNTU_VERSION", choices:["18.04","20.04"])
+        choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])
         string(name: "REPOSITORY", defaultValue: "deislabs")
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
-        choice(name: "TEST_CONFIG", choices:['None','Nightly', 'Code Coverage'], description: "Test configuration to execute")
-        string(name: "COMMIT_SYNC", description: "optional - used to sync outputs of parallel jobs")
+        string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
+        choice(name: "TEST_CONFIG", choices: ['None', 'Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
     }
     environment {
         MYST_SCRIPTS =      "${WORKSPACE}/scripts"
@@ -27,20 +28,41 @@ pipeline {
     stages {
         stage("Cleanup files") {
             steps {
-                sh """
-                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
-                   """
+                sh "${JENKINS_SCRIPTS}/global/clean-temp.sh"
+            }
+        }
+        stage("Checkout Pull Request") {
+            when {
+                expression { params.PULL_REQUEST_ID != "" }
+            }
+            steps {
+                cleanWs()
+                checkout([$class: 'GitSCM',
+                    branches: [[name: "pr/${PULL_REQUEST_ID}"]],
+                    extensions: [],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/deislabs/mystikos',
+                        refspec: "+refs/pull/${PULL_REQUEST_ID}/merge:refs/remotes/origin/pr/${PULL_REQUEST_ID}"
+                    ]]
+                ])
             }
         }
         stage('Verify commit sync') {
-            when { allOf {
+            when {
                 expression { params.COMMIT_SYNC != "" }
-                expression { params.COMMIT_SYNC != GIT_COMMIT }
-            }}
+            }
             steps {
+                // Check if the checked out commit is the same across all parallel builds
                 script {
-                    currentBuild.result = 'ABORTED'
-                    error("Aborting build: mismatched commit - commit($GIT_COMMIT), expected(${COMMIT_SYNC})")
+                    def GIT_COMMIT_ID = sh(
+                        returnStdout: true,
+                        script: "git log --max-count=1 --pretty=format:'%H'"
+                    ).trim()
+                    if ( GIT_COMMIT_ID != params.COMMIT_SYNC ) {
+                        error("Checked out commit (${GIT_COMMIT_ID}) does not match commit from upstream job (${params.COMMIT_SYNC})")
+                    } else {
+                        println("Checked out commit (${GIT_COMMIT_ID}) matches upstream job (${params.COMMIT_SYNC}). Continuing with build.")
+                    }
                 }
             }
         }

--- a/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
@@ -6,12 +6,13 @@ pipeline {
         timeout(time: 300, unit: 'MINUTES')
     }
     parameters {
-        choice(name: "UBUNTU_VERSION", choices:["18.04","20.04"])
+        choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])
         string(name: "REPOSITORY", defaultValue: "deislabs")
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
-        choice(name: "REGION", choices:['useast', 'canadacentral'], description: "Azure region for the SQL solution tests")
-        choice(name: "TEST_CONFIG", choices:['None','Nightly', 'Code Coverage'], description: "Test configuration to execute")
-        string(name: "COMMIT_SYNC", description: "optional - used to sync outputs of parallel jobs")
+        string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
+        choice(name: "REGION", choices: ['useast', 'canadacentral'], description: "Azure region for the SQL solution tests")
+        choice(name: "TEST_CONFIG", choices: ['None', 'Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
     }
     environment {
         MYST_SCRIPTS =      "${WORKSPACE}/scripts"
@@ -28,29 +29,46 @@ pipeline {
     stages {
         stage("Cleanup files") {
             steps {
-                sh """
-                   ${JENKINS_SCRIPTS}/global/clean-temp.sh
-                   """
+                sh "${JENKINS_SCRIPTS}/global/clean-temp.sh"
+            }
+        }
+        stage("Checkout Pull Request") {
+            when {
+                expression { params.PULL_REQUEST_ID != "" }
+            }
+            steps {
+                cleanWs()
+                checkout([$class: 'GitSCM',
+                    branches: [[name: "pr/${PULL_REQUEST_ID}"]],
+                    extensions: [],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/deislabs/mystikos',
+                        refspec: "+refs/pull/${PULL_REQUEST_ID}/merge:refs/remotes/origin/pr/${PULL_REQUEST_ID}"
+                    ]]
+                ])
             }
         }
         stage('Verify commit sync') {
-            when { allOf {
+            when {
                 expression { params.COMMIT_SYNC != "" }
-                expression { params.COMMIT_SYNC != GIT_COMMIT }
-            }}
+            }
             steps {
+                // Check if the checked out commit is the same across all parallel builds
                 script {
-                    currentBuild.result = 'ABORTED'
-                    error("Aborting build: mismatched commit - commit($GIT_COMMIT), expected(${COMMIT_SYNC})")
+                    def GIT_COMMIT_ID = sh(
+                        returnStdout: true,
+                        script: "git log --max-count=1 --pretty=format:'%H'"
+                    ).trim()
+                    if ( GIT_COMMIT_ID != params.COMMIT_SYNC ) {
+                        error("Checked out commit (${GIT_COMMIT_ID}) does not match commit from upstream job (${params.COMMIT_SYNC})")
+                    } else {
+                        println("Checked out commit (${GIT_COMMIT_ID}) matches upstream job (${params.COMMIT_SYNC}). Continuing with build.")
+                    }
                 }
             }
         }
         stage('Init Config') {
             steps {
-                checkout([$class: 'GitSCM',
-                    branches: [[name: BRANCH]],
-                    extensions: [],
-                    userRemoteConfigs: [[url: 'https://github.com/${REPOSITORY}/mystikos']]])
                 sh """
                    # Initialize dependencies repo
                    ${JENKINS_SCRIPTS}/global/wait-dpkg.sh


### PR DESCRIPTION
This updates the parallelized nightly pipeline to include the updates made to the original pipeline

* Add option to run builds for PRs
* Email notifications
* Include .NET P1 tests (to run every time. This does not extend the total test time)

This also makes some changes to standalone pipelines to support checking out PRs from GitHub. The git commit verification stage is now merged into a git checkout stage, where a PR merge reference will be checked out and then verified with the git commit id passed in from the upstream parent build.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>