### PR TITLE
solutions/pandas_tests ignore errorcode for partial passed tests

### DIFF
--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -40,8 +40,8 @@ run-passed: rootfs-passed
 	$(MYST_EXEC) rootfs-passed $(OPTS) $(PYTHON3) /app/app.py
 
 run: rootfs
-	(cat tests.partially_passed | xargs -P 8 $(MYST_EXEC) rootfs $(OPTS) \
-		$(PYTEST_CMD) $(PYTEST_OPTS) 2>&1 > result;)
+	-(cat tests.partially_passed | xargs -P 8 $(MYST_EXEC) rootfs $(OPTS) \
+		$(PYTEST_CMD) $(PYTEST_OPTS) 2>&1 > result; true)
 	sed -i '$$d' result
 	tail -n 28 result > test_summary
 	diff test_summary expected-test-summary


### PR DESCRIPTION
The return code returned to the makefile does not have to be verified for partially passing tests since the final list of failing test is validated against the expected list of failures.
Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>