### PR TITLE
Fix double sending of SIGCHLD to parent

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1023,9 +1023,6 @@ static long _run_thread(void* arg_)
 
             procfs_pid_cleanup(process->pid);
 
-            /* Send a SIGCHLD to the parent process */
-            myst_syscall_kill(process->ppid, SIGCHLD);
-
             /* Wait for any children to go away before proceeding */
             myst_wait_on_child_processes(process);
 


### PR DESCRIPTION
SIGCHLD is again sent to parent later in the exit sequence via `myst_send_sigchld_and_zombify_process`.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>