### PR TITLE
Fix __fwritex() console write crash

### DIFF
--- a/target/sgx/enclave/tcall.c
+++ b/target/sgx/enclave/tcall.c
@@ -305,21 +305,8 @@ long myst_tcall(long n, long params[6])
             int fd = (int)x1;
             const void* buf = (const void*)x2;
             size_t count = (size_t)x3;
-            FILE* stream = NULL;
 
-            if (fd == STDOUT_FILENO)
-                stream = stdout;
-            else if (fd == STDERR_FILENO)
-                stream = stderr;
-            else
-                return -EINVAL;
-
-            if (fwrite(buf, 1, count, stream) != count)
-                return -EIO;
-
-            fflush(stream);
-
-            return (long)count;
+            return myst_tcall_write_console(fd, buf, count);
         }
         case MYST_TCALL_READ_CONSOLE:
         {

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -957,6 +957,26 @@ long myst_tcall_interrupt_thread(pid_t tid)
     return retval;
 }
 
+long myst_tcall_write_console(int fd, const void* buf, size_t count)
+{
+    long ret = 0;
+    long retval = 0;
+
+    if (fd != STDOUT_FILENO && fd != STDERR_FILENO)
+        ERAISE(-EINVAL);
+
+    if (myst_write_console_ocall(&retval, fd, buf, count) != OE_OK)
+        ERAISE(-EIO);
+
+    if (retval != count)
+        ERAISE(-EIO);
+
+    ret = count;
+
+done:
+    return ret;
+}
+
 OE_SET_ENCLAVE_SGX2(
     ENCLAVE_PRODUCT_ID,
     ENCLAVE_SECURITY_VERSION,

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -770,3 +770,27 @@ long myst_interrupt_thread_ocall(pid_t tid)
 {
     return myst_tcall_interrupt_thread(tid);
 }
+
+long myst_write_console_ocall(int fd, const void* buf, size_t count)
+{
+    long ret = 0;
+    FILE* stream;
+
+    if (!buf)
+        ERAISE(-EINVAL);
+
+    if (fd == STDOUT_FILENO)
+        stream = stdout;
+    else if (fd == STDERR_FILENO)
+        stream = stderr;
+    else
+        ERAISE(-EINVAL);
+
+    if (fwrite(buf, 1, count, stream) != count)
+        ERAISE(-EIO);
+
+    ret = count;
+
+done:
+    return ret;
+}

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -628,5 +628,18 @@ enclave
             [out] uint32_t* rbx,
             [out] uint32_t* rcx,
             [out] uint32_t* rdx);
+
+        /*
+        **======================================================================
+        **
+        ** console I/O
+        **
+        **======================================================================
+        */
+
+        long myst_write_console_ocall(
+            int fd, /* STDOUT_FILENO or STDERR_FILENO */
+            [in, size=count] const void* buf,
+            size_t count);
     };
 };


### PR DESCRIPTION
The ``tests/pthread`` test crashes in OE's **musl libc** ``__fwritex()`` function. This happens when **strace** is enabled. This fix bypasses ``__fwritex()`` by introducing``myst_write_console_ocall()`` as defined below.

```C++
        long myst_write_console_ocall(
            int fd, /* STDOUT_FILENO or STDERR_FILENO */
            [in, size=count] const void* buf,
            size_t count);
```

Since the crash only occurs when ``__fwritex()`` is bombarded by hundreds of threads, we suspect a file-stream locking bug in **OE's musl libc**.

This fix is a better approach for two reasons.
- Mystikos in general rarely relies on OE musl libc.
- The new OCALL consumes less of the kernel stack than **musl libc fwrite()** (which is unpredictable), and since we are trying to optimize the kernel stack, this approach is at least predictable and probably minimal.