### PR TITLE
Update gcov flags for fsflags test

### DIFF
--- a/tests/fsflags/Makefile
+++ b/tests/fsflags/Makefile
@@ -13,7 +13,7 @@ OPTS = --strace
 endif
 
 ifdef MYST_ENABLE_GCOV
-OPTS += --export-ramfs
+CFLAGS += $(GCOV_CFLAGS)
 endif
 
 tests_ext2fs: all


### PR DESCRIPTION
--export-ramfs is no longer used. 