### PR TITLE
UAMI enabled agents

### DIFF
--- a/.jenkins/nightly.Jenkinsfile
+++ b/.jenkins/nightly.Jenkinsfile
@@ -62,36 +62,6 @@ pipeline {
                         }
                     }
                 }
-                /* This sets up the service principal and managed service identity used by the VM,
-                *  which are required for the solution, SQL solution, and Azure SDK tests.
-                */
-                stage('Setup access') {
-                    steps {
-                        sh """#!/bin/bash
-                            if [[ ! -f /etc/apt/sources.list.d/azure-cli.list ]]; then
-                                echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-                                wget https://packages.microsoft.com/keys/microsoft.asc
-                                sudo apt-key add microsoft.asc
-                                sudo apt-get update
-                            fi
-                            ${helpers.WaitForAptLock()}
-                            sudo apt-get install -y azure-cli
-                        """
-                        withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
-                                         string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
-                                         string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
-                                         string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
-                                         string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
-                                         string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
-                            sh '''
-                                az login --service-principal -u ${SERVICE_PRINCIPAL_ID} -p ${SERVICE_PRINCIPAL_PASSWORD} --tenant ${TENANT_ID} >> /dev/null
-                                az account set -s ${AZURE_SUBSCRIPTION_ID}
-                                az vm identity assign -g ${JENKINS_RESOURCE_GROUP} -n \$(hostname) --identities ${MYSTIKOS_MANAGED_ID} >> /dev/null
-                                az vm update -g ${JENKINS_RESOURCE_GROUP} -n \$(hostname) --set identity.type='UserAssigned' >> /dev/null
-                            '''
-                        }
-                    }
-                }
                 stage('Minimum init config') {
                     steps {
                         sh """

--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -79,24 +79,6 @@ pipeline {
                    """
             }
         }
-        stage('Setup Solutions Access') {
-            steps {
-                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
-                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
-                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
-                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
-                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
-                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
-                    sh """
-                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
-
-                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
-                       """
-                }
-            }
-        }
         stage('Build repo source') {
             steps {
                 sh """

--- a/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
@@ -79,24 +79,6 @@ pipeline {
                    """
             }
         }
-        stage('Setup Solutions Access') {
-            steps {
-                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
-                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
-                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
-                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
-                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
-                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
-                    sh """
-                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
-
-                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
-                       """
-                }
-            }
-        }
         stage('Build repo source') {
             steps {
                 sh """

--- a/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
@@ -80,24 +80,6 @@ pipeline {
                    """
             }
         }
-        stage('Setup Solutions Access') {
-            steps {
-                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
-                                 string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
-                                 string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
-                                 string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
-                                 string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
-                                 string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
-                    sh """
-                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                       ${JENKINS_SCRIPTS}/solutions/init-config.sh
-
-                       ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                       ${JENKINS_SCRIPTS}/solutions/azure-config.sh
-                       """
-                }
-            }
-        }
         stage('Build repo source') {
             steps {
                 sh """

--- a/.jenkins/release.Jenkinsfile
+++ b/.jenkins/release.Jenkinsfile
@@ -84,29 +84,6 @@ pipeline {
                 }
             }
         }
-        stage('Setup access') {
-            steps {
-                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
-                                    string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
-                                    string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
-                                    string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
-                                    string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
-                                    string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
-                    sh '''
-                        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-                        wget https://packages.microsoft.com/keys/microsoft.asc
-                        sudo apt-key add microsoft.asc
-                        sudo apt-get update
-                        while sudo lsof /var/lib/dpkg/lock-frontend | grep dpkg; do sleep 3; done
-                        sudo apt-get install -y azure-cli
-                        az login --service-principal -u ${SERVICE_PRINCIPAL_ID} -p ${SERVICE_PRINCIPAL_PASSWORD} --tenant ${TENANT_ID} >> /dev/null
-                        az account set -s ${AZURE_SUBSCRIPTION_ID}
-                        az vm identity assign -g ${JENKINS_RESOURCE_GROUP} -n \$(hostname) --identities ${MYSTIKOS_MANAGED_ID} >> /dev/null
-                        az vm update -g ${JENKINS_RESOURCE_GROUP} -n \$(hostname) --set identity.type='UserAssigned' >> /dev/null
-                    '''
-                }
-            }
-        }
         stage('Run solution tests') {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {

--- a/.jenkins/scripts/solutions/azure-config.sh
+++ b/.jenkins/scripts/solutions/azure-config.sh
@@ -1,5 +1,0 @@
-sudo apt-get install -y azure-cli
-az login --service-principal -u $SERVICE_PRINCIPAL_ID -p $SERVICE_PRINCIPAL_PASSWORD --tenant $TENANT_ID >> /dev/null
-az account set -s $AZURE_SUBSCRIPTION_ID
-az vm identity assign -g $JENKINS_RESOURCE_GROUP -n $(hostname) --identities $MYSTIKOS_MANAGED_ID >> /dev/null
-az vm update -g $JENKINS_RESOURCE_GROUP -n $(hostname) --set identity.type='UserAssigned' >> /dev/null

--- a/.jenkins/scripts/solutions/init-config.sh
+++ b/.jenkins/scripts/solutions/init-config.sh
@@ -1,4 +1,0 @@
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs | xargs) main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-wget https://packages.microsoft.com/keys/microsoft.asc
-sudo apt-key add microsoft.asc
-sudo apt-get update

--- a/.jenkins/tests.Jenkinsfile
+++ b/.jenkins/tests.Jenkinsfile
@@ -179,32 +179,6 @@ pipeline {
                         }
                     }
                 }
-                /* This sets up the service principal and managed service identity used by the VM,
-                *  which are required for the solution, SQL solution, and Azure SDK tests.
-                */
-                stage('Setup access') {
-                    steps {
-                        withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
-                                        string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
-                                        string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
-                                        string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID'),
-                                        string(credentialsId: 'oe-jenkins-dev-rg', variable: 'JENKINS_RESOURCE_GROUP'),
-                                        string(credentialsId: 'mystikos-managed-identity', variable: "MYSTIKOS_MANAGED_ID")]) {
-                            sh '''
-                                echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-                                wget https://packages.microsoft.com/keys/microsoft.asc
-                                sudo apt-key add microsoft.asc
-                                sudo apt-get update
-                                while sudo lsof /var/lib/dpkg/lock-frontend | grep dpkg; do sleep 3; done
-                                sudo apt-get install -y azure-cli
-                                az login --service-principal -u ${SERVICE_PRINCIPAL_ID} -p ${SERVICE_PRINCIPAL_PASSWORD} --tenant ${TENANT_ID} >> /dev/null
-                                az account set -s ${AZURE_SUBSCRIPTION_ID}
-                                az vm identity assign -g ${JENKINS_RESOURCE_GROUP} -n \$(hostname) --identities ${MYSTIKOS_MANAGED_ID} >> /dev/null
-                                az vm update -g ${JENKINS_RESOURCE_GROUP} -n \$(hostname) --set identity.type='UserAssigned' >> /dev/null
-                            '''
-                        }
-                    }
-                }
                 stage('Run solution tests') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {


### PR DESCRIPTION
This removes an unecessary build stage as we're now using an alternative method of using user assigned manage identities on Jenkins agents

Signed-off-by: Chris Yan <chrisyan@microsoft.com>