### PR TITLE
Fix ramfs rename directory operation

### DIFF
--- a/kernel/ramfs.c
+++ b/kernel/ramfs.c
@@ -1820,7 +1820,9 @@ static int _fs_rename(myst_fs_t* fs, const char* oldpath, const char* newpath)
 
     /* Add the newpath directory entry */
     {
-        _inode_add_dirent(new_parent, old_inode, DT_REG, locals->new_basename);
+        const uint8_t type = S_ISDIR(old_inode->mode) ? DT_DIR : DT_REG;
+
+        _inode_add_dirent(new_parent, old_inode, type, locals->new_basename);
 
         if (S_ISDIR(old_inode->mode))
             new_parent->nlink++;

--- a/tests/fs/fs.c
+++ b/tests/fs/fs.c
@@ -1055,6 +1055,12 @@ static void test_append(void)
     assert(buf.st_size == sizeof(alpha) + 3 + 3);
 }
 
+void test_rename_dir(void)
+{
+    assert(mkdir("/renamedir1", 0777) == 0);
+    assert(rename("/renamedir1", "/renamedir2") == 0);
+}
+
 int main(int argc, const char* argv[])
 {
     if (argc != 2)
@@ -1110,6 +1116,7 @@ int main(int argc, const char* argv[])
     test_o_tmpfile_not_supp(argv[1]);
     test_sync();
     test_append();
+    test_rename_dir();
 
     printf("=== passed all tests (%s)\n", argv[0]);
 


### PR DESCRIPTION
When renaming a directory, ramfs was adding the directory entry to the new directory with the wrong type tag (``DT_REG`` rather than ``DT_DIR``).