### PR TITLE
Install az cli

### DIFF
--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -79,6 +79,19 @@ pipeline {
                    """
             }
         }
+        stage('Setup AZ CLI') {
+            steps {
+                withCredentials([string(credentialsId: 'Jenkins-ServicePrincipal-ID', variable: 'SERVICE_PRINCIPAL_ID'),
+                                    string(credentialsId: 'Jenkins-ServicePrincipal-Password', variable: 'SERVICE_PRINCIPAL_PASSWORD'),
+                                    string(credentialsId: 'ACC-Prod-Tenant-ID', variable: 'TENANT_ID'),
+                                    string(credentialsId: 'ACC-Prod-Subscription-ID', variable: 'AZURE_SUBSCRIPTION_ID')]) {
+                    sh """
+                        ${JENKINS_SCRIPTS}/azure-sdk/install-azure-cli.sh
+                        ${JENKINS_SCRIPTS}/azure-sdk/login-azure-cli.sh
+                    """
+                }
+            }
+        }
         stage('Build repo source') {
             steps {
                 sh """
@@ -131,6 +144,7 @@ pipeline {
         }
         stage('Cleanup') {
             steps {
+                sh "${JENKINS_SCRIPTS}/azure-sdk/logout-azure-cli.sh"
                 cleanWs()
             }
         }

--- a/.jenkins/scripts/azure-sdk/install-azure-cli.sh
+++ b/.jenkins/scripts/azure-sdk/install-azure-cli.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs | xargs) main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+wget https://packages.microsoft.com/keys/microsoft.asc
+sudo apt-key add microsoft.asc
+sudo apt-get -o DPkg::Lock::Timeout=3 -o APT::Acquire::Retries=3 update
+sudo apt-get -o DPkg::Lock::Timeout=3 -o APT::Acquire::Retries=3 -y install azure-cli

--- a/.jenkins/scripts/azure-sdk/login-azure-cli.sh
+++ b/.jenkins/scripts/azure-sdk/login-azure-cli.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+az login --service-principal -u ${SERVICE_PRINCIPAL_ID} -p ${SERVICE_PRINCIPAL_PASSWORD} --tenant ${TENANT_ID} >> /dev/null
+az account set -s ${AZURE_SUBSCRIPTION_ID}

--- a/.jenkins/scripts/azure-sdk/logout-azure-cli.sh
+++ b/.jenkins/scripts/azure-sdk/logout-azure-cli.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+az logout || true
+az cache purge
+az account clear


### PR DESCRIPTION
Azure SDK tests require Azure CLI to be installed which was erroneously removed in #1062. 
This PR will install `az` as part of the CI setup for the Azure SDK pipeline only.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>