### PR TITLE
Enable full 32-bit uid/gid support in ext2fs implementation

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -2657,8 +2657,10 @@ static int _create_inode(
         inode->i_mode = mode;
 
         /* Set the uid and gid to root */
-        inode->i_uid = euid;
-        inode->i_gid = egid;
+        inode->i_uid = euid & 0xFFFF;
+        inode->i_osd2.linux2.i_uid_h = euid >> 16;
+        inode->i_gid = egid & 0xFFFF;
+        inode->i_osd2.linux2.i_gid_h = egid >> 16;
 
         /* Set the size of this file */
         _inode_set_size(inode, size);
@@ -2716,6 +2718,8 @@ static int _create_dir_inode_and_block(
 
     /* Initialize the inode */
     {
+        uid_t uid = myst_syscall_geteuid();
+        gid_t gid = myst_syscall_getegid();
         const uint32_t t = (uint32_t)time(NULL);
 
         memset(&locals->inode, 0, sizeof(ext2_inode_t));
@@ -2724,8 +2728,10 @@ static int _create_dir_inode_and_block(
         locals->inode.i_mode = (S_IFDIR | mode);
 
         /* Set the uid and gid to root */
-        locals->inode.i_uid = myst_syscall_geteuid();
-        locals->inode.i_gid = myst_syscall_getegid();
+        locals->inode.i_uid = uid & 0xFFFF;
+        locals->inode.i_osd2.linux2.i_uid_h = uid >> 16;
+        locals->inode.i_gid = gid & 0xFFFF;
+        locals->inode.i_osd2.linux2.i_gid_h = gid >> 16;
 
         /* Set the size of this file */
         _inode_set_size(&locals->inode, ext2->block_size);
@@ -4428,8 +4434,12 @@ int ext2_fstat(myst_fs_t* fs, myst_file_t* file, struct stat* statbuf)
     statbuf->st_ino = file->shared->ino;
     statbuf->st_mode = file->shared->inode.i_mode;
     statbuf->st_nlink = file->shared->inode.i_links_count;
-    statbuf->st_uid = file->shared->inode.i_uid;
-    statbuf->st_gid = file->shared->inode.i_gid;
+    statbuf->st_uid =
+        file->shared->inode.i_uid |
+        (((uid_t)file->shared->inode.i_osd2.linux2.i_uid_h) << 16);
+    statbuf->st_gid =
+        file->shared->inode.i_gid |
+        (((uid_t)file->shared->inode.i_osd2.linux2.i_gid_h) << 16);
     statbuf->st_rdev = 0; /* only for special files */
     statbuf->st_size = _inode_get_size(&file->shared->inode);
     statbuf->st_blksize = ext2->block_size;
@@ -5540,10 +5550,16 @@ static int _chown(ext2_inode_t* inode, uid_t owner, gid_t group)
         ERAISE(-EINVAL);
 
     if (owner != -1)
-        inode->i_uid = owner;
+    {
+        inode->i_uid = owner & 0xFFFF;
+        inode->i_osd2.linux2.i_uid_h = owner >> 16;
+    }
 
     if (group != -1)
-        inode->i_gid = group;
+    {
+        inode->i_gid = group & 0xFFFF;
+        inode->i_osd2.linux2.i_gid_h = group >> 16;
+    }
 
     /* For executables, clear set-user-ID and set-group-ID bits */
     if (inode->i_mode & (S_IXUSR | S_IXGRP | S_IXOTH))

--- a/ext2/ext2dump.c
+++ b/ext2/ext2dump.c
@@ -273,11 +273,11 @@ static void _dump_inode(const ext2_t* ext2, const ext2_inode_t* inode)
 
     {
         printf("i_osd2[]={");
-        n = sizeof(inode->i_osd2) / sizeof(inode->i_osd2[0]);
+        n = sizeof(inode->i_osd2) / sizeof(inode->i_osd2.buf[0]);
 
         for (i = 0; i < n; i++)
         {
-            printf("%u", inode->i_osd2[i]);
+            printf("%u", inode->i_osd2.buf[i]);
 
             if (i + 1 != n)
                 printf(", ");

--- a/include/myst/ext2.h
+++ b/include/myst/ext2.h
@@ -155,13 +155,13 @@ struct ext2_group_desc
 struct ext2_inode
 {
     uint16_t i_mode;
-    uint16_t i_uid;
+    uint16_t i_uid; /* low 16bit of uid */
     uint32_t i_size;
     uint32_t i_atime;
     uint32_t i_ctime;
     uint32_t i_mtime;
     uint32_t i_dtime;
-    uint16_t i_gid;
+    uint16_t i_gid; /* low 16bit of gid */
     uint16_t i_links_count;
     uint32_t i_blocks;
     uint32_t i_flags;
@@ -177,7 +177,16 @@ struct ext2_inode
     uint32_t i_file_acl;
     uint32_t i_dir_acl;
     uint32_t i_faddr;
-    uint8_t i_osd2[12];
+    union {
+        uint8_t buf[12];
+        struct
+        {
+            uint8_t reserve1[4];
+            uint16_t i_uid_h; /* high 16bit of uid */
+            uint16_t i_gid_h; /* high 16bit of gid */
+            uint8_t reserve2[4];
+        } linux2;
+    } i_osd2;
     uint8_t dummy[128]; /* sometimes the inode is bigger */
 };
 

--- a/kernel/affinity.c
+++ b/kernel/affinity.c
@@ -3,9 +3,11 @@
 
 #define _GNU_SOURCE
 #include <sched.h>
+#include <sys/mman.h>
 
 #include <myst/eraise.h>
 #include <myst/kernel.h>
+#include <myst/mmanutils.h>
 #include <myst/syscall.h>
 #include <myst/thread.h>
 
@@ -16,15 +18,19 @@ long myst_syscall_sched_getaffinity(
 {
     long ret = 0;
 
-    if (pid < 0 || !mask)
-        ERAISE(-EINVAL);
+    if (!mask || myst_is_bad_addr_write(mask, cpusetsize))
+        ERAISE(-EFAULT);
 
-    if (pid != 0)
+    if (pid < 0)
+    {
+        ERAISE(-ESRCH);
+    }
+    else if (pid != 0)
     {
         myst_thread_t* thread = myst_find_thread(pid);
 
         if (!thread)
-            ERAISE(-EINVAL);
+            ERAISE(-ESRCH);
 
         pid = thread->target_tid;
     }
@@ -63,15 +69,19 @@ long myst_syscall_sched_setaffinity(
 {
     long ret = 0;
 
-    if (pid < 0 || !mask)
-        ERAISE(-EINVAL);
+    if (!mask || myst_is_bad_addr_read(mask, cpusetsize))
+        ERAISE(-EFAULT);
 
-    if (pid != 0)
+    if (pid < 0)
+    {
+        ERAISE(-ESRCH);
+    }
+    else if (pid != 0)
     {
         myst_thread_t* thread = myst_find_thread(pid);
 
         if (!thread)
-            ERAISE(-EINVAL);
+            ERAISE(-ESRCH);
 
         pid = thread->target_tid;
     }

--- a/kernel/pipedev.c
+++ b/kernel/pipedev.c
@@ -737,25 +737,39 @@ static int _pd_ioctl(
         arg,
         myst_getppid()));
 
-    if (request == TIOCGWINSZ)
+    switch (request)
     {
-        ERAISE(-EINVAL);
-    }
-    else if (request == FIONBIO)
-    {
-        int* val = (int*)arg;
-
-        if (!val)
+        case TIOCGWINSZ:
+        {
             ERAISE(-EINVAL);
+            break;
+        }
+        case FIONBIO:
+        {
+            int* val = (int*)arg;
 
-        if (*val)
-            pipe->fl_flags |= O_NONBLOCK;
-        else
-            pipe->fl_flags &= ~O_NONBLOCK;
-    }
-    else
-    {
-        ERAISE(-ENOTSUP);
+            if (!val)
+                ERAISE(-EINVAL);
+
+            if (*val)
+                pipe->fl_flags |= O_NONBLOCK;
+            else
+                pipe->fl_flags &= ~O_NONBLOCK;
+
+            break;
+        }
+        case FIOCLEX:
+        {
+            pipe->fd_flags |= FD_CLOEXEC;
+            break;
+        }
+        case FIONCLEX:
+        {
+            pipe->fd_flags &= ~FD_CLOEXEC;
+            break;
+        }
+        default:
+            ERAISE(-ENOTSUP);
     }
 
 done:


### PR DESCRIPTION
Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>

This PR addresses three issues:

1. Existing ext2fs implementation does not support full 32-bit uid/gid in ext2fs inode. The issue was exposed by cpython test suite's test_posix test set. In ext2fs inode definition, an OS specific data structure for Linux holds the high 16 bits of uid/gid. The PR follows the Linux definition to support full 32b-bit uid/gid
2. Existing sched_getaffinity and sched_setaffinity implementation's error code implementation does not match Linux syscall manual specification. The issue was also exposed by cpython test suite's test_posiz test set. The PR changed the error code implementation to match the Linux syscall manual. The PR also add address validity check.
3. Add missing FIOCLEX/FIONCLEX ioctl support for pipe fd.

The cpython test_posix test set is not enabled in this PR, pending resolution to other issues affecting that test set. 