### PR TITLE
Change the order of sockperf and cpython tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -96,8 +96,8 @@ endif
 
 ifndef MYST_ENABLE_GCOV
 ifdef MYST_NIGHTLY_TEST
-DIRS += sockperf
 DIRS += cpython-tests
+DIRS += sockperf
 endif
 DIRS += clock
 DIRS += pollpipe2


### PR DESCRIPTION
Signed-off-by: Radhikaj <radhikaj@microsoft.com>
It is probable that a leak in sockperf is causing cypthon tests to fail. Interchanging the order for nightly runs so we have less flakiness.