### PR TITLE
Fix realpath given empty path

### DIFF
--- a/kernel/realpath.c
+++ b/kernel/realpath.c
@@ -30,6 +30,9 @@ int myst_realpath(const char* path, myst_path_t* resolved_path)
     if (!path || !resolved_path)
         ERAISE(-EINVAL);
 
+    if (*path == 0)
+        ERAISE(-ENOENT);
+
     if (!(locals = malloc(sizeof(struct locals))))
         ERAISE(-ENOMEM);
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1223,8 +1223,12 @@ static const char* _trim_trailing_slashes(
     if (len >= size)
         return NULL;
 
+    /* if empty pathname or equal to "/" */
+    if (len == 0 || (pathname[0] == '/' && pathname[1] == '\0'))
+        return pathname;
+
     /* remove trailing slashes from the pathname if any */
-    if ((len = strlen(pathname)) && pathname[len - 1] == '/')
+    if (pathname[len - 1] == '/')
     {
         memcpy(buf, pathname, len + 1);
 


### PR DESCRIPTION
Fix an issue that `myst_realpath("")` would return `/`