### PR TITLE
Wait for passwd lock

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -50,6 +50,12 @@ UPPERDIR=$(CURDIR)/upper
 WORKDIR=$(CURDIR)/work
 HOSTFS=$(CURDIR)/hostfs
 
+# Bash functions
+GROUPADD = while sudo lsof /etc/group; do sleep 3; done; \
+			sudo groupadd
+USERADD = while sudo lsof /etc/passwd; do sleep 3; done; \
+			sudo useradd
+
 all: ext2fs
 
 ext2fs: appdir
@@ -125,18 +131,14 @@ group-file:
 	echo "grp1000:x:1000:" >> appdir/etc/group
 
 add_host_users_and_groups:
-	while sudo lsof /etc/group; do sleep 3; done
-	sudo groupadd -f -g 100701 grp701
-	while sudo lsof /etc/group; do sleep 3; done
-	sudo groupadd -f -g 100704 grp704
-	while sudo lsof /etc/group; do sleep 3; done
-	sudo groupadd -f -g 100705 grp705
-	while sudo lsof /etc/group; do sleep 3; done
-	sudo groupadd -f -g 101000 grp1000
-	id -u user700 >/dev/null 2>&1 || sudo useradd -g grp701 -u 100700 user700
-	id -u user702 >/dev/null 2>&1 || sudo useradd -g grp701 -u 100702 user702
-	id -u user703 >/dev/null 2>&1 || sudo useradd -g grp701 -u 100703 user703
-	id -u user1000 >/dev/null 2>&1 || sudo useradd -g grp1000 -u 101000 user1000
+	$(GROUPADD) -f -g 100701 grp701
+	$(GROUPADD) -f -g 100704 grp704
+	$(GROUPADD) -f -g 100705 grp705
+	$(GROUPADD) -f -g 101000 grp1000
+	id -u user700 >/dev/null 2>&1 || $(USERADD) -g grp701 -u 100700 user700
+	id -u user702 >/dev/null 2>&1 || $(USERADD) -g grp701 -u 100702 user702
+	id -u user703 >/dev/null 2>&1 || $(USERADD) -g grp701 -u 100703 user703
+	id -u user1000 >/dev/null 2>&1 || $(USERADD) -g grp1000 -u 101000 user1000
 
 del_host_users_and_groups:
 	sudo userdel user700 || true


### PR DESCRIPTION
This prevents the issue where /etc/passwd is still locked from previous useradd commands seen in some builds

```
id -u user702 >/dev/null 2>&1 || sudo useradd -g grp701 -u 100702 user702
id -u user703 >/dev/null 2>&1 || sudo useradd -g grp701 -u 100703 user703
useradd: cannot lock /etc/passwd; try again later.
make[6]: *** [Makefile:138: add_host_users_and_groups] Error 1
```

Signed-off-by: Chris Yan <chrisyan@microsoft.com>