### PR TITLE
epoll maxevents optimization

### DIFF
--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -155,9 +155,10 @@ enclave
 
         long myst_epoll_wait_ocall(
             int epfd,
-            [in, out, count=maxevents] struct epoll_event* events,
+            [out, count=maxevents] struct epoll_event* events,
             size_t maxevents,
-            int timeout);
+            int timeout)
+            transition_using_threads;
 
         long myst_epoll_ctl_ocall(
             int epfd,


### PR DESCRIPTION
This PR makes the following optimizations to ``epoll_wait()``.

- Makes``myst_epoll_wait_ocall()`` switchless
- Removes the ``in`` annotation of the  ``events`` ocall parameter (``events`` is strictly an output parameter)
- Reduces ``maxevents`` to the number of file descriptors registered with ``epoll_ctl(EPOLL_CTL_ADD)`` (since there can never be more events than the number of file descriptors).

The final change was required because Redis passes **10,128** as the ``maxevents`` parameter (the number of elements in the ``events`` output buffer), which incurs a large copy (**121,536** bytes) on every call to ``myst_epoll_wait_ocall()``.