### PR TITLE
Fix CRT corruption caused by (v)fork

### DIFF
--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -933,6 +933,41 @@ index eeae1d0a..7e13faa8 100644
  #endif
  }
 +weak_alias (sendmmsg, __sendmmsg);
+diff --git a/src/process/fork.c b/src/process/fork.c
+index fb42478a..2d0921f8 100644
+--- a/src/process/fork.c
++++ b/src/process/fork.c
+@@ -22,15 +22,28 @@ pid_t fork(void)
+ #else
+ 	ret = __syscall(SYS_clone, SIGCHLD, 0);
+ #endif
+-	if (!ret) {
++
++        if (!ret) {
+ 		pthread_t self = __pthread_self();
+ 		self->tid = __syscall(SYS_gettid);
+ 		self->robust_list.off = 0;
+ 		self->robust_list.pending = 0;
+ 		self->next = self->prev = self;
++
++		// In Linux, the child process can safely modify the libc internal variables as below
++		// since (v)fork creates a new memory space for the child; any changes done by the child
++		// does not affect the parent.
++		// However, in mystikos, after (v)fork, the child still shares the same libc/crt as the parent.
++		// Therefore, it is not safe to modify the libc state. It is only after execve that the child
++		// gets its own crt/libc.
++		// Some LTP tests (e.g /ltp/testcases/kernel/syscalls/fchmod/fchmod05) rely on fork.
++		// Those tests rely on the tid for the thread being set above.
++#if 0
+ 		__thread_list_lock = 0;
+ 		libc.threads_minus_1 = 0;
+-	}
++#endif
++       }
++
+ 	__restore_sigs(&set);
+ 	__fork_handler(!ret);
+ 	return __syscall_ret(ret);
 diff --git a/src/process/x86_64/vfork.s b/src/process/x86_64/vfork.s
 index 91144390..809463a1 100644
 --- a/src/process/x86_64/vfork.s


### PR DESCRIPTION
In MUSL's vfork implementation, the child process clears libc variables.
This is OK since after a (v)fork, the child gets its own memory space and any changes
done by the child does not affect the parent.

In Mystikos, after a (v)fork, the child still uses the parent's libc/CRT. Therefore, any changes done
by the child to CRT is also visible to the parent. A new CRT is created for the child only after
execve call.

The child, immediately after a vfork, goes on to set libc.threds_minus_1 to zero. This causes MUSL
to think that there is only one thread in the program, and subsequently it skips locking.
In Mystikos, this has the effect that the CRT becomes thread-unsafe after a fork. This leads to
various issues. The most common manifestation is strange crashes in malloc's bin/unbin functions.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>