### PR TITLE
PyTorch pipeline set correct return code

### DIFF
--- a/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-code-coverage-nightly.yml
@@ -108,7 +108,9 @@ jobs:
     # run PyTorch tests
     - script: |
         make run -C $(Build.SourcesDirectory)/solutions/pytorch_tests
+        RESULT=$?
         make clean -C $(Build.SourcesDirectory)/solutions/pytorch_tests
+        exit ${RESULT}
       displayName: 'run PyTorch tests'
       continueOnError: true
       enabled: true

--- a/.azure_pipelines/ci-pipeline-makefile-nightly.yml
+++ b/.azure_pipelines/ci-pipeline-makefile-nightly.yml
@@ -98,7 +98,9 @@ jobs:
     # run PyTorch tests
     - script: |
         make run -C $(Build.SourcesDirectory)/solutions/pytorch_tests
+        RESULT=$?
         make clean -C $(Build.SourcesDirectory)/solutions/pytorch_tests
+        exit ${RESULT}
       displayName: 'run PyTorch tests'
       continueOnError: true
       enabled: true

--- a/.azure_pipelines/ci-pipeline-release.yml
+++ b/.azure_pipelines/ci-pipeline-release.yml
@@ -134,7 +134,9 @@ jobs:
       - script: |
           export PATH="$PATH:$(pwd)/mystikos/bin"
           make run -C $(Build.SourcesDirectory)/solutions/pytorch_tests
+          RESULT=$?
           make clean -C $(Build.SourcesDirectory)/solutions/pytorch_tests
+          exit ${RESULT}
         displayName: 'run PyTorch tests'
         continueOnError: true
         enabled: true


### PR DESCRIPTION
Because of `continueOnError: true`, the final return code is `make clean`, which is always successful. So cache the result of `make run` to set the correct result code.

I tend not to remove `continueOnError: true` because I want to keep running `make clean` no matter `make run` returns success or fail.