### PR TITLE
Remove ext2 mkdir mode check

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -2711,7 +2711,7 @@ static int _create_dir_inode_and_block(
     struct locals* locals = NULL;
 
     /* Check parameters */
-    if (!_ext2_valid(ext2) || !mode || !parent_ino || !ino)
+    if (!_ext2_valid(ext2) || !parent_ino || !ino)
         ERAISE(-EINVAL);
 
     if (!(locals = malloc(sizeof(struct locals))))
@@ -4086,8 +4086,8 @@ int ext2_unlink(myst_fs_t* fs, const char* path)
 
     /* remove the directory entry for this file */
     ECHECK(_split_path(path, locals->dirname, locals->filename));
-    ECHECK(_remove_dirent(ext2, dino, &locals->dinode, locals->filename,
-        false));
+    ECHECK(
+        _remove_dirent(ext2, dino, &locals->dinode, locals->filename, false));
 
     /* unlink the inode */
     ECHECK(_inode_unlink(ext2, ino, &locals->inode));
@@ -4789,7 +4789,8 @@ int ext2_rmdir(myst_fs_t* fs, const char* path)
 
     /* remove the directory entry for this file */
     ECHECK(_split_path(path, locals->dirname, locals->filename));
-    ECHECK(_remove_dirent(ext2, dino, &locals->dinode, locals->filename, false));
+    ECHECK(
+        _remove_dirent(ext2, dino, &locals->dinode, locals->filename, false));
 
     /* truncate the file to zero size (to return all the blocks) */
     {


### PR DESCRIPTION
This is to support nonreadable directory in EXT2. CPIO doesn't validate mode so doesn't need change

With this change following test cases would pass

```

▶ make testcase TESTCASE=test_pydoc.PydocImportTest.test_apropos_with_unreadable_dir TARGET=linux
/home/zijiewu/code/fork_mystikos/build/bin/myst exec-linux --app-config-path config.json ext2fs3.9 /cpython/python -m unittest Lib.test.test_pydoc.PydocImportTest.test_apropos_with_unreadable_dir -v
test_apropos_with_unreadable_dir (Lib.test.test_pydoc.PydocImportTest) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.001s

OK

▶ make testcase TESTCASE=test_pkgutil.PkgutilTests.test_unreadable_dir_on_syspath TARGET=linux   
/home/zijiewu/code/fork_mystikos/build/bin/myst exec-linux --app-config-path config.json ext2fs3.9 /cpython/python -m unittest Lib.test.test_pkgutil.PkgutilTests.test_unreadable_dir_on_syspath -v
test_unreadable_dir_on_syspath (Lib.test.test_pkgutil.PkgutilTests) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.009s

OK

▶ make testcase TESTCASE=test_pkgutil.PkgutilTests.test_unreadable_dir_on_syspath             
/home/zijiewu/code/fork_mystikos/build/bin/myst exec-sgx --app-config-path config.json ext2fs3.9 /cpython/python -m unittest Lib.test.test_pkgutil.PkgutilTests.test_unreadable_dir_on_syspath -v
test_unreadable_dir_on_syspath (Lib.test.test_pkgutil.PkgutilTests) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.018s

OK
```