### PR TITLE
Add Ice Lake VMs to CI builds

### DIFF
--- a/.jenkins/pipelines/nightly.Jenkinsfile
+++ b/.jenkins/pipelines/nightly.Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         label 'Jenkins-Shared-DC2'
     }
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 720, unit: 'MINUTES')
         timestamps ()
     }
     parameters {
@@ -11,13 +11,32 @@ pipeline {
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
         string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
         choice(name: "REGION", choices: ['useast', 'canadacentral'], description: "Azure region for the SQL solutions test")
+        // Parameters for toggling optional tests.
+        // Add to the below to if you are adding a new test that needs to be toggled. 
         booleanParam(name: "RUN_DOTNETP1", defaultValue: false, description: "Run .NET P1 tests?")
         booleanParam(name: "RUN_OPENMP_TESTSUITE", defaultValue: false, description: "Run OpenMP Test Suite?")
+        booleanParam(name: "ICELAKE_VM", defaultValue: true, description: "Run tests on Ice Lake VMs?")
+        booleanParam(name: "COFFEELAKE_VM", defaultValue: false, description: "Run tests on Coffee Lake VMs?")
     }
     environment {
         TEST_CONFIG = 'Nightly'
     }
     stages {
+        stage('Parse params') {
+            steps {
+                script {
+                    // This is used to skip any tests that were not enabled in build parameters.
+                    // Add to the below to if you are adding a new test that needs to be toggled. 
+                    IGNORE_TESTS = []
+                    if ( ! params.RUN_DOTNETP1 ) { IGNORE_TESTS.add('DotNet-P1') }
+                    if ( ! params.RUN_OPENMP_TESTSUITE ) { IGNORE_TESTS.add('OpenMP-Testsuite') }
+                    // This is used to test on specific VM generations
+                    IGNORE_VM_GENERATIONS = []
+                    if ( ! params.ICELAKE_VM ) { IGNORE_VM_GENERATIONS.add('v3') }
+                    if ( ! params.COFFEELAKE_VM ) { IGNORE_VM_GENERATIONS.add('v2') }
+                }
+            }
+        }
         stage('Checkout') {
             when {
                 anyOf {
@@ -62,18 +81,26 @@ pipeline {
                     }
                     axis {
                         name 'TEST_PIPELINE'
+                        // Append to the list below to add a new test
                         values 'Unit', 'Solutions', 'DotNet', 'DotNet-P1', 'Azure-SDK', 'PyTorch', 'OpenMP-Testsuite'
+                    }
+                    axis {
+                        name 'VM_GENERATION'
+                        values 'v3', 'v2'
                     }
                 }
                 stages {
                     stage("Matrix") {
                         steps {
                             script {
-                                // Workaround for skipping .NET P1 tests as dynamic matrix axis values are not supported
-                                // https://issues.jenkins.io/browse/JENKINS-62127
-                                if ( ! ( (TEST_PIPELINE == 'DotNet-P1' && ! params.RUN_DOTNETP1)
-                                      || (TEST_PIPELINE == 'OpenMP-Testsuite' && ! params.RUN_OPENMP_TESTSUITE) )) {
-                                    stage("${OS_VERSION} ${TEST_PIPELINE} (${TEST_CONFIG})") {
+                                stage("${TEST_PIPELINE} ${OS_VERSION} ACC-${VM_GENERATION} ${TEST_CONFIG}") {
+                                    // Workaround for skipping optional tests as dynamic matrix axis values are not supported
+                                    // https://issues.jenkins.io/browse/JENKINS-62127
+                                    if ( IGNORE_TESTS.contains(TEST_PIPELINE) || IGNORE_VM_GENERATIONS.contains(VM_GENERATION) ) {
+                                        catchError(buildResult: 'SUCCESS', stageResult: 'NOT_BUILT') {
+                                            error "This test is skipped. You can enable this test in the build parameters."
+                                        }
+                                    } else {
                                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                                             build(
                                                 job: "/Mystikos/Standalone-Pipelines/${TEST_PIPELINE}-Tests-Pipeline",
@@ -84,7 +111,8 @@ pipeline {
                                                     string(name: "PULL_REQUEST_ID", value: params.PULL_REQUEST_ID),
                                                     string(name: "TEST_CONFIG", value: env.TEST_CONFIG),
                                                     string(name: "REGION", value: params.REGION),
-                                                    string(name: "COMMIT_SYNC", value: GIT_COMMIT_ID)
+                                                    string(name: "COMMIT_SYNC", value: GIT_COMMIT_ID),
+                                                    string(name: "VM_GENERATION", value: VM_GENERATION)
                                                 ]
                                             )
                                         }

--- a/.jenkins/pipelines/pr.Jenkinsfile
+++ b/.jenkins/pipelines/pr.Jenkinsfile
@@ -169,7 +169,8 @@ pipeline {
                                             string(name: "PULL_REQUEST_ID", value: params.PULL_REQUEST_ID),
                                             string(name: "TEST_CONFIG", value: env.TEST_CONFIG),
                                             string(name: "REGION", value: params.REGION),
-                                            string(name: "COMMIT_SYNC", value: params.GIT_COMMIT_ID)
+                                            string(name: "COMMIT_SYNC", value: params.GIT_COMMIT_ID),
+                                            string(name: "VM_GENERATION", value: 'v3')
                                         ]
                                     }
                                 }

--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label UBUNTU_VERSION == '20.04' ? 'ACC-2004-DC4' : 'ACC-1804-DC4'
+        label UBUNTU_VERSION == '20.04' ? "ACC-${params.VM_GENERATION}-2004-DC4" : "ACC-${params.VM_GENERATION}-1804-DC4"
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
@@ -12,6 +12,7 @@ pipeline {
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
         string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
         choice(name: "TEST_CONFIG", choices: ['None', 'Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        choice(name: "VM_GENERATION", choices: ['v3', 'v2'], description: "v3 for Ice Lake VMs; v2 for Coffee Lake")
         string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
         string(name: "PACKAGE_NAME", defaultValue: "", description: "optional - release package to install (do not include extension)")
         choice(name: "PACKAGE_EXTENSION", choices:['tar.gz', 'deb'], description: "Extension of package given in PACKAGE_NAME")

--- a/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
@@ -1,9 +1,9 @@
 pipeline {
     agent {
-        label UBUNTU_VERSION == '20.04' ? 'ACC-2004-DC4' : 'ACC-1804-DC4'
+        label UBUNTU_VERSION == '20.04' ? "ACC-${params.VM_GENERATION}-2004-DC4" : "ACC-${params.VM_GENERATION}-1804-DC4"
     }
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 720, unit: 'MINUTES')
         timestamps ()
     }
     parameters {
@@ -12,6 +12,7 @@ pipeline {
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
         string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
         choice(name: "TEST_CONFIG", choices: ['None', 'Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        choice(name: "VM_GENERATION", choices: ['v3', 'v2'], description: "v3 for Ice Lake VMs; v2 for Coffee Lake")
         string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
         string(name: "PACKAGE_NAME", defaultValue: "", description: "optional - release package to install (do not include extension)")
         choice(name: "PACKAGE_EXTENSION", choices:['tar.gz', 'deb'], description: "Extension of package given in PACKAGE_NAME")

--- a/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label UBUNTU_VERSION == '20.04' ? 'ACC-2004-DC4' : 'ACC-1804-DC4'
+        label UBUNTU_VERSION == '20.04' ? "ACC-${params.VM_GENERATION}-2004-DC4" : "ACC-${params.VM_GENERATION}-1804-DC4"
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
@@ -12,6 +12,7 @@ pipeline {
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
         string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
         choice(name: "TEST_CONFIG", choices: ['None', 'Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        choice(name: "VM_GENERATION", choices: ['v3', 'v2'], description: "v3 for Ice Lake VMs; v2 for Coffee Lake")
         string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
         string(name: "PACKAGE_NAME", defaultValue: "", description: "optional - release package to install (do not include extension)")
         choice(name: "PACKAGE_EXTENSION", choices:['tar.gz', 'deb'], description: "Extension of package given in PACKAGE_NAME")

--- a/.jenkins/pipelines/standalone/openmp-testsuite.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/openmp-testsuite.Jenkinsfile
@@ -1,9 +1,9 @@
 pipeline {
     agent {
-        label UBUNTU_VERSION == '20.04' ? 'ACC-2004-DC4' : 'ACC-1804-DC4'
+        label UBUNTU_VERSION == '20.04' ? "ACC-${params.VM_GENERATION}-2004-DC4" : "ACC-${params.VM_GENERATION}-1804-DC4"
     }
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 120, unit: 'MINUTES')
         timestamps ()
     }
     parameters {
@@ -12,6 +12,7 @@ pipeline {
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
         string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
         choice(name: "TEST_CONFIG", choices: ['None', 'Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        choice(name: "VM_GENERATION", choices: ['v3', 'v2'], description: "v3 for Ice Lake VMs; v2 for Coffee Lake")
         string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
     }
     environment {

--- a/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label UBUNTU_VERSION == '20.04' ? 'ACC-2004-DC4' : 'ACC-1804-DC4'
+        label UBUNTU_VERSION == '20.04' ? "ACC-${params.VM_GENERATION}-2004-DC4" : "ACC-${params.VM_GENERATION}-1804-DC4"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -12,6 +12,7 @@ pipeline {
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
         string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
         string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
+        choice(name: "VM_GENERATION", choices: ['v3', 'v2'], description: "v3 for Ice Lake VMs; v2 for Coffee Lake")
     }
     environment {
         MYST_SCRIPTS =      "${WORKSPACE}/scripts"

--- a/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label UBUNTU_VERSION == '20.04' ? 'ACC-2004-DC4' : 'ACC-1804-DC4'
+        label UBUNTU_VERSION == '20.04' ? "ACC-${params.VM_GENERATION}-2004-DC4" : "ACC-${params.VM_GENERATION}-1804-DC4"
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
@@ -13,6 +13,7 @@ pipeline {
         string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
         choice(name: "REGION", choices: ['useast', 'canadacentral'], description: "Azure region for the SQL solution tests")
         choice(name: "TEST_CONFIG", choices: ['None', 'Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        choice(name: "VM_GENERATION", choices: ['v3', 'v2'], description: "v3 for Ice Lake VMs; v2 for Coffee Lake")
         string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
         string(name: "PACKAGE_NAME", defaultValue: "", description: "optional - release package to install (do not include extension)")
         choice(name: "PACKAGE_EXTENSION", choices:['tar.gz', 'deb'], description: "Extension of package given in PACKAGE_NAME")

--- a/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
@@ -1,9 +1,9 @@
 pipeline {
     agent {
-        label UBUNTU_VERSION == '20.04' ? 'ACC-2004-DC4' : 'ACC-1804-DC4'
+        label UBUNTU_VERSION == '20.04' ? "ACC-${params.VM_GENERATION}-2004-DC4" : "ACC-${params.VM_GENERATION}-1804-DC4"
     }
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         timestamps ()
     }
     parameters {
@@ -12,6 +12,7 @@ pipeline {
         string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
         string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you are building a pull request, enter the pull request ID number here. (ex. 789)")
         choice(name: "TEST_CONFIG", choices: ['None', 'Nightly', 'Code Coverage'], description: "Test configuration to execute")
+        choice(name: "VM_GENERATION", choices: ['v3', 'v2'], description: "v3 for Ice Lake VMs; v2 for Coffee Lake")
         string(name: "COMMIT_SYNC", defaultValue: "", description: "optional - used to sync outputs of parallel jobs")
         string(name: "PACKAGE_NAME", defaultValue: "", description: "optional - release package to install (do not include extension)")
         choice(name: "PACKAGE_EXTENSION", choices:['tar.gz', 'deb'], description: "Extension of package given in PACKAGE_NAME")


### PR DESCRIPTION
* PR builds will run on Ice Lake VMs for all tests.
* Manually triggered nightly builds will run all tests on Ice Lake VMs by default, with the option to run Coffee Lake. Scheduled nightly builds will run on both Ice Lake and Coffee Lake VMs.
* Increase timeout for .NET P1 tests to 12 hours as the extended tests on Ice Lake typically takes 7-8 hours to complete.
* Refactor the way we handle optional tests in the nightly pipeline to make it easier to scale, and added comments to help developers.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>