### PR TITLE
Add timestamps

### DIFF
--- a/.jenkins/pipelines/code-coverage.Jenkinsfile
+++ b/.jenkins/pipelines/code-coverage.Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")

--- a/.jenkins/pipelines/nightly.Jenkinsfile
+++ b/.jenkins/pipelines/nightly.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")

--- a/.jenkins/pipelines/pr.Jenkinsfile
+++ b/.jenkins/pipelines/pr.Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")

--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])

--- a/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])

--- a/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])

--- a/.jenkins/pipelines/standalone/measure-code-coverage.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/measure-code-coverage.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")

--- a/.jenkins/pipelines/standalone/openmp-testsuite.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/openmp-testsuite.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])

--- a/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])

--- a/.jenkins/pipelines/standalone/report-code-coverage.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/report-code-coverage.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")

--- a/.jenkins/pipelines/standalone/send-email.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/send-email.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")

--- a/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])

--- a/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     options {
         timeout(time: 300, unit: 'MINUTES')
+        timestamps ()
     }
     parameters {
         choice(name: "UBUNTU_VERSION", choices: ["18.04", "20.04"])


### PR DESCRIPTION
This adds configurable timestamps to build logs, and is visible both in classic view and blue ocean.

When viewing timestamps, classic view is recommended as you can enable/disable, or use system/user timezones, or elapsed time.
![image](https://user-images.githubusercontent.com/22492275/148277253-eccd1054-3482-4ea8-ac9b-d020c6a61fd4.png)

In blue ocean it will only show system time as the timestamp.
![image](https://user-images.githubusercontent.com/22492275/148277364-9199c413-d209-4214-b44d-83c737439db9.png)

Signed-off-by: Chris Yan <chrisyan@microsoft.com>

