### PR TITLE
Prevent concurrent PR builds

### DIFF
--- a/.jenkins/pipelines/pr.Jenkinsfile
+++ b/.jenkins/pipelines/pr.Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
     options {
         timeout(time: 300, unit: 'MINUTES')
         timestamps ()
+        disableConcurrentBuilds(abortPrevious: true)
     }
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")


### PR DESCRIPTION
The given change will only stop the PR build prior to the current one. For example, if the current PR build is build 148, it will only stop build 147 from the same branch. If, for some reason, build 145 was still running, that will not be aborted by build 148. This should not be a problem, as long as all the builds use the Jenkinsfile.