### PR TITLE
Bump up UDP sendto packet limit to 75k

### DIFF
--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -22,7 +22,7 @@
 #include <myst/defs.h>
 #include <myst/thread.h>
 
-#define UDP_PACKET_MAX_LENGTH 65000
+#define UDP_PACKET_MAX_LENGTH (75 * 1024)
 
 MYST_INLINE long myst_syscall0(long n)
 {


### PR DESCRIPTION
was 65000 to fix LTP test but was not large enough for cpython test

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>