### PR TITLE
Fix glibc test failures related to AF_LOCAL/AF_NETLINK

### DIFF
--- a/kernel/udsdev.c
+++ b/kernel/udsdev.c
@@ -1528,6 +1528,16 @@ static int _udsdev_ioctl(
             _obj(sock)->nonblock = (bool)*val;
             break;
         }
+        case FIONREAD:
+        {
+            int* val = (int*)arg;
+
+            if (!val)
+                ERAISE(-EINVAL);
+
+            *((int*)val) = _obj(sock)->buf.size;
+            break;
+        }
         default:
         {
             ERAISE(-ENOTSUP);

--- a/tests/glibc/tests.failed
+++ b/tests/glibc/tests.failed
@@ -1,3 +1,4 @@
 /glibc/build/gmon/tst-gmon-static ldso: /glibc/build/gmon/tst-gmon-static: Not a valid dynamic program 
+/glibc/build/inet/test-ifaddrs: creates a socket with AF_NETLINK
 /glibc/build/io/tst-ftw-lnk.d/link2-tgt ldso: /glibc/build/io/tst-ftw-lnk.d/link2-tgt: Not a valid dynamic program 
 /glibc/build/nptl/test-mutexattr-printers Makefile:57: recipe for target 'one' failed ****Runs without error in GDB****

--- a/tests/glibc/tests.passed
+++ b/tests/glibc/tests.passed
@@ -72,7 +72,6 @@
 /glibc/build/iconvdata/tst-iconv6
 /glibc/build/inet/htontest
 /glibc/build/inet/test-hnto-types
-/glibc/build/inet/test-ifaddrs
 /glibc/build/inet/tst-checks
 /glibc/build/inet/tst-checks-posix
 /glibc/build/inet/tst-ntoa

--- a/tests/sockets/sockets.c
+++ b/tests/sockets/sockets.c
@@ -286,6 +286,12 @@ static void test_socketpair(void)
 
     assert(socketpair(AF_LOCAL, SOCK_STREAM, 0, sv) == 0);
     assert(write(sv[0], alpha, sizeof(alpha)) == sizeof(alpha));
+
+    int nread = -1;
+    assert(ioctl(sv[1], FIONREAD, (unsigned long*)&nread) == 0);
+    assert(nread > 0);
+    assert(nread == sizeof(alpha));
+
     assert(read(sv[1], buf, sizeof(buf)) == sizeof(buf));
     assert(memcmp(buf, alpha, sizeof(buf)) == 0);
 


### PR DESCRIPTION
Fix for glibc AF_LOCAL test failures.
- Disable AF_NETLINK test (not supported by Mystikos)
- Add support for ioctl() with FIONREAD for AF_LOCAL/AF_UNIX.