### PR TITLE
Add test to cover issue 1140 (epoll memory error)

### DIFF
--- a/tests/epoll/epoll.c
+++ b/tests/epoll/epoll.c
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/epoll.h>
+#include <sys/mman.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
 #include <time.h>
@@ -77,8 +78,48 @@ static void test_epoll_fcntl()
     printf("=== passed test (%s)\n", __FUNCTION__);
 }
 
+#define PAGE_SIZE 4096
+
+void test_issue1140(void)
+{
+    uint8_t* pages;
+
+    /* allocate two pages */
+    {
+        const size_t length = 2 * PAGE_SIZE;
+        const int prot = PROT_READ | PROT_WRITE;
+        const int flags = MAP_ANONYMOUS | MAP_PRIVATE;
+        pages = mmap(NULL, length, prot, flags, -1, 0);
+        assert(pages != MAP_FAILED);
+    }
+
+    /* protect the second page */
+    {
+        void* addr = pages + PAGE_SIZE;
+        const size_t length = PAGE_SIZE;
+        const int prot = PROT_NONE;
+        assert(mprotect(addr, length, prot) == 0);
+    }
+
+    /* set pointer to epoll events (only first element accessible) */
+    const int maxevents = 1;
+    struct epoll_event* events =
+        (void*)(pages + PAGE_SIZE - (maxevents * sizeof(struct epoll_event)));
+    assert(events != NULL);
+
+    /* create an epoll fd */
+    int epfd = epoll_create1(0);
+    assert(epfd != -1);
+
+    /* call epoll */
+    int ret = epoll_wait(epfd, events, maxevents, 0);
+
+    close(epfd);
+}
+
 int main(int argc, const char* argv[])
 {
+    test_issue1140();
     test_epoll_on_regular_files_unsupp();
     test_epoll_fcntl();
 


### PR DESCRIPTION
This PR adds a test (currently failing) to catch a bug that was introduced into epoll. See issue #1140 for details.

This issue was introduced by https://github.com/deislabs/mystikos/pull/1099.

The new test works fine natively but crashes in Mystikos due to epoll change.

**NOTE: THIS TEST WILL NOT PASSS UNTIL THE ISSUE IS RESOLVED.**