### PR TITLE
Test --thread-stack-size option

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -137,6 +137,7 @@ DIRS += glibc
 endif
 
 DIRS += appenv
+DIRS += pthread_stacksize
 
 .PHONY: $(DIRS)
 

--- a/tests/pthread_stacksize/Makefile
+++ b/tests/pthread_stacksize/Makefile
@@ -1,0 +1,42 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+CFLAGS = -fPIC
+
+OPTS =
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+OPTS = --memory-size=8m
+
+APP = /bin/pthread_stacksize
+
+all:
+	$(MAKE) rootfs
+
+rootfs: pthread_stacksize.c
+	mkdir -p appdir/bin
+	$(CC) $(CFLAGS) -o appdir/$(APP) pthread_stacksize.c -lpthread
+	$(MYST) mkcpio appdir rootfs
+
+test = $(RUNTEST) $(MYST_EXEC) rootfs $(APP) $(1) $(OPTS) --thread-stack-size=$(1)
+
+TEST1 = $$((4096 * 32))
+TEST2 = $$((4096 * 64))
+TEST3 = $$((4096 * 128))
+TEST4 = $$((4096 * 256))
+TEST5 = $$((4096 * 300))
+TEST6 = $$((4096 * 1024))
+
+tests: all
+	$(call test,$(TEST1))
+	$(call test,$(TEST2))
+	$(call test,$(TEST3))
+	$(call test,$(TEST4))
+	$(call test,$(TEST5))
+	$(call test,$(TEST6))
+
+clean:
+	rm -rf appdir rootfs export ramfs

--- a/tests/pthread_stacksize/pthread_stacksize.c
+++ b/tests/pthread_stacksize/pthread_stacksize.c
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+static void test1(size_t stacksize_opt)
+{
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    size_t stacksize;
+    pthread_attr_getstacksize(&attr, &stacksize);
+    // printf("stacksize=%zu\n", stacksize);
+    assert(stacksize == stacksize_opt);
+
+    printf("=== passed test (%s)\n", __FUNCTION__);
+}
+
+int main(int argc, const char* argv[])
+{
+    /* check the number of command line arguments */
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s <stacksize>\n", argv[0]);
+        exit(1);
+    }
+
+    /* get the stacksize option */
+    size_t stacksize_opt;
+    {
+        char* end = NULL;
+        stacksize_opt = strtoul(argv[1], &end, 0);
+        assert(end && *end == '\0');
+        assert(stacksize_opt > 0);
+    }
+
+    /* run tests */
+    test1(stacksize_opt);
+
+    printf("=== passed all tests (%s)\n", argv[0]);
+    return 0;
+}


### PR DESCRIPTION
This test verifies that the ``--thread-stack-size`` option actually affects the ``pthread stack size``.