### PR TITLE
fix poll and ppoll RLIMIT_NOFILE limit check

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -218,8 +218,12 @@ long myst_syscall_poll(
 {
     long ret = 0;
     long r;
+    struct rlimit rlimit;
 
-    if (nfds > RLIMIT_NOFILE)
+    ECHECK(myst_limit_get_rlimit(
+        myst_process_self()->pid, RLIMIT_NOFILE, &rlimit));
+
+    if (nfds > rlimit.rlim_max)
         ERAISE(-EINVAL);
     else if (
         nfds && fds && myst_is_bad_addr_read_write(fds, sizeof(*fds) * nfds))


### PR DESCRIPTION
need to use the actual rlimit value, not the index

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>