### PR TITLE
Add --trace-times feature

### DIFF
--- a/crt/enter.c
+++ b/crt/enter.c
@@ -50,6 +50,13 @@ int myst_pre_launch_hook()
 {
     int ret = 0;
     myst_retrieve_wanted_secrets();
+
+    /* notify the kernel that main() is about to be called */
+    {
+        long params[6] = {0};
+        return myst_syscall(SYS_myst_pre_launch_hook, params);
+    }
+
     return ret;
 }
 

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -191,6 +191,7 @@ typedef struct myst_kernel_args
     /* Tracing options */
     bool trace_errors;
     myst_strace_config_t strace_config;
+    bool trace_times;
 
     /* Whether the target supports the SYSCALL instruction */
     bool have_syscall_instruction;

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -16,6 +16,7 @@ typedef struct myst_options
     bool have_syscall_instruction;
     bool have_fsgsbase_instructions;
     bool trace_errors;
+    bool trace_times;
     bool shell_mode;
     bool debug_symbols;
     bool memcheck;

--- a/include/myst/syscallext.h
+++ b/include/myst/syscallext.h
@@ -29,7 +29,8 @@ typedef enum
     SYS_myst_get_process_thread_stack = 2016,
     SYS_myst_fork_wait_exec_exit = 2017,
     SYS_myst_get_exec_stack_option = 2018,
-    SYS_myst_interrupt_thread = 2019
+    SYS_myst_interrupt_thread = 2019,
+    SYS_myst_pre_launch_hook = 2020
 } myst_syscall_t;
 
 #define MYST_MAX_SYSCALLS 3000

--- a/include/myst/times.h
+++ b/include/myst/times.h
@@ -109,4 +109,8 @@ a clock id is per-thread or per-process.
     (((clock) & (clockid_t)DYN_CLOCK_FD_MASK) == DYN_CLOCK_FD)
 
 long myst_times_get_cpu_clock_time(clockid_t clk_id, struct timespec* tp);
+
+/* boot time */
+extern struct timespec __myst_boot_time;
+
 #endif /* _MYST_TIMES_H */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -644,11 +644,12 @@ static void _print_boottime(void)
         start.tv_nsec = __myst_kernel_args.start_time_nsec;
 
         long nsec = myst_lapsed_nsecs(&start, &now);
+        __myst_boot_time = now;
 
         double secs = (double)nsec / (double)NANO_IN_SECOND;
 
         myst_eprintf("%s", yellow);
-        myst_eprintf("=== boot time: %.4lfsec", secs);
+        myst_eprintf("kernel: boot time: %.4lf seconds", secs);
         myst_eprintf("%s\n", reset);
     }
 }
@@ -693,6 +694,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     if (!args->tee_debug_mode)
     {
         args->trace_errors = false;
+        args->trace_times = false;
         memset(&args->strace_config, 0, sizeof(args->strace_config));
         args->shell_mode = false;
         args->memcheck = false;
@@ -828,7 +830,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
         myst_start_shell("\nMystikos shell (enter)\n");
 
     /* print how long it took to boot */
-    if (__myst_kernel_args.perf)
+    if (__myst_kernel_args.perf || __myst_kernel_args.trace_times)
         _print_boottime();
 
     if ((create_appenv_ret = myst_create_appenv(args)) < 0 &&

--- a/kernel/times.c
+++ b/kernel/times.c
@@ -13,6 +13,8 @@
 #include <myst/thread.h>
 #include <myst/times.h>
 
+struct timespec __myst_boot_time;
+
 /* Time spent by the main thread and its children */
 struct tms process_times;
 

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -620,6 +620,7 @@ static long _enter(void* arg_)
                 enclave_image_size, /* image_size */
                 _get_num_tcs(),     /* max threads */
                 final_options.base.trace_errors,
+                final_options.base.trace_times,
                 &final_options.base.strace_config,
                 false, /* have_syscall_instruction */
                 tee_debug_mode,

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -426,6 +426,13 @@ int exec_action(int argc, const char* argv[], const char* envp[])
             options.trace_errors = true;
         }
 
+        /* Get --trace-times option */
+        if (cli_getopt(&argc, argv, "--trace-times", NULL) == 0 ||
+            cli_getopt(&argc, argv, "--ttrace", NULL) == 0)
+        {
+            options.trace_times = true;
+        }
+
         /* Get --shell option */
         if (cli_getopt(&argc, argv, "--shell", NULL) == 0)
             options.shell_mode = true;

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -126,6 +126,13 @@ static void _get_options(
         opts->trace_errors = true;
     }
 
+    /* Get --trace-times option */
+    if (cli_getopt(argc, argv, "--trace-times", NULL) == 0 ||
+        cli_getopt(argc, argv, "--ttrace", NULL) == 0)
+    {
+        opts->trace_times = true;
+    }
+
     /* Get --shell option */
     if (cli_getopt(argc, argv, "--shell", NULL) == 0)
         opts->shell_mode = true;
@@ -469,6 +476,7 @@ static int _enter_kernel(
                 image_size,
                 max_threads,
                 final_options.base.trace_errors,
+                final_options.base.trace_times,
                 &final_options.base.strace_config,
                 have_syscall_instruction,
                 tee_debug_mode,

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -630,6 +630,13 @@ int _exec_package(
         options.trace_errors = true;
     }
 
+    /* Get --trace-times option */
+    if (cli_getopt(&argc, argv, "--trace-times", NULL) == 0 ||
+        cli_getopt(&argc, argv, "--ttrace", NULL) == 0)
+    {
+        options.trace_times = true;
+    }
+
     /* Get --shell option */
     if (cli_getopt(&argc, argv, "--shell", NULL) == 0)
         options.shell_mode = true;

--- a/tools/myst/kargs.c
+++ b/tools/myst/kargs.c
@@ -53,6 +53,7 @@ int init_kernel_args(
     size_t image_size,
     size_t max_threads,
     bool trace_errors,
+    bool trace_times,
     const myst_strace_config_t* strace_config,
     bool have_syscall_instruction,
     bool tee_debug_mode,
@@ -288,6 +289,7 @@ int init_kernel_args(
     args->envp = env.data;
     args->max_threads = max_threads;
     args->trace_errors = trace_errors;
+    args->trace_times = trace_times;
     args->strace_config = *strace_config;
     args->have_syscall_instruction = have_syscall_instruction;
     args->event = thread_event;

--- a/tools/myst/kargs.h
+++ b/tools/myst/kargs.h
@@ -20,6 +20,7 @@ int init_kernel_args(
     size_t image_size,
     size_t max_threads,
     bool trace_errors,
+    bool trace_times,
     const myst_strace_config_t* strace_config,
     bool have_syscall_instruction,
     bool tee_debug_mode,

--- a/tools/myst/options.c
+++ b/tools/myst/options.c
@@ -77,6 +77,7 @@ long determine_final_options(
         {
             final_opts->base.strace_config = cmdline_opts->strace_config;
             final_opts->base.trace_errors = cmdline_opts->trace_errors;
+            final_opts->base.trace_times = cmdline_opts->trace_times;
             final_opts->base.shell_mode = cmdline_opts->shell_mode;
             final_opts->base.debug_symbols = cmdline_opts->debug_symbols;
             final_opts->base.memcheck = cmdline_opts->memcheck;
@@ -91,6 +92,7 @@ long determine_final_options(
                 0,
                 sizeof(final_opts->base.strace_config));
             final_opts->base.trace_errors = false;
+            final_opts->base.trace_times = false;
             final_opts->base.shell_mode = false;
             final_opts->base.debug_symbols = false;
             final_opts->base.memcheck = false;

--- a/utils/syscall.c
+++ b/utils/syscall.c
@@ -381,6 +381,7 @@ static const myst_syscall_pair_t _pairs[] = {
     PAIR(SYS_myst_fork_wait_exec_exit),
     PAIR(SYS_myst_get_exec_stack_option),
     PAIR(SYS_myst_interrupt_thread),
+    PAIR(SYS_myst_pre_launch_hook),
     /* add new entries here! */
     {0, NULL},
 };
@@ -412,6 +413,7 @@ __attribute__((__unused__)) static void _check_myst_syscalls(void)
         case SYS_myst_fork_wait_exec_exit:
         case SYS_myst_get_exec_stack_option:
         case SYS_myst_interrupt_thread:
+        case SYS_myst_pre_launch_hook:
             break;
     }
 }


### PR DESCRIPTION
Add ``--trace-times`` (or ``--ttrace``) to print out the **kernel boot time** and **application load time**.

For example:

```
myst exec-sgx rootfs /bin/getcwd --ttrace
kernel: boot time: 1.0798 seconds
kernel: app load time: 0.0220 seconds
=== passed test (/bin/getcwd)
```