### PR TITLE
[pandas_tests] Remove tests that pass now from failed list

### DIFF
--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -43,7 +43,7 @@ run: rootfs
 	-(cat tests.partially_passed | xargs -P 8 $(MYST_EXEC) rootfs $(OPTS) \
 		$(PYTEST_CMD) $(PYTEST_OPTS) 2>&1 > result; true)
 	sed -i '$$d' result
-	tail -n 28 result > test_summary
+	tail -n 26 result > test_summary
 	diff test_summary expected-test-summary
 	$(MAKE) clean_intermediate
 	$(MAKE) run-passed

--- a/solutions/pandas_tests/expected-test-summary
+++ b/solutions/pandas_tests/expected-test-summary
@@ -2,8 +2,6 @@
 FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[\U0001f44d...]
 FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[\u03a9\u0153\u2211\xb4...]
 FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[abcd...]
-FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/xml/test_xml.py::test_empty_string_etree[0]
-FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/parser/test_quoting.py::test_bad_quote_char[python-kwargs2-"quotechar" must be string, not int]
 ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetPyArrow::test_s3_roundtrip_explicit_fs
 ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetPyArrow::test_s3_roundtrip
 ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetFastParquet::test_s3_roundtrip


### PR DESCRIPTION
The tests test_xml.py::test_empty_string_etree and test_quoting.py:test_bad_quote_char from the expected-test-summary, that holds the failed tests, now pass. Hence, removed out of expected failure list.

solutions-pipeline passed - https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/Mystikos/job/Standalone-Pipelines/job/Solutions-Tests-Pipeline/1419

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>