### PR TITLE
Fix musl pathconf

### DIFF
--- a/third_party/musl/crt/Makefile
+++ b/third_party/musl/crt/Makefile
@@ -85,6 +85,7 @@ NEWFILES += src/stdio/__vfprintf_chk.c
 NEWFILES += src/unistd/preadv2.c
 NEWFILES += src/unistd/pwritev2.c
 NEWFILES += src/stdio/register_printf.c
+NEWFILES += src/conf/confval.h
 
 musl:
 	mkdir -p $(BUILDDIR)

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -519,6 +519,101 @@ index 02cb1aa2..07e76f19 100644
  	} else if ((name&~4U)!=1 && name-_CS_POSIX_V6_ILP32_OFF32_CFLAGS>33U) {
  		errno = EINVAL;
  		return 0;
+diff --git a/src/conf/fpathconf.c b/src/conf/fpathconf.c
+index e6aca5cf..039b7453 100644
+--- a/src/conf/fpathconf.c
++++ b/src/conf/fpathconf.c
+@@ -1,35 +1,28 @@
+-#include <unistd.h>
+-#include <limits.h>
+ #include <errno.h>
++#include <sys/statvfs.h>
++#include "confval.h"
+ 
+ long fpathconf(int fd, int name)
+ {
+-	static const short values[] = {
+-		[_PC_LINK_MAX] = _POSIX_LINK_MAX,
+-		[_PC_MAX_CANON] = _POSIX_MAX_CANON,
+-		[_PC_MAX_INPUT] = _POSIX_MAX_INPUT,
+-		[_PC_NAME_MAX] = NAME_MAX,
+-		[_PC_PATH_MAX] = PATH_MAX,
+-		[_PC_PIPE_BUF] = PIPE_BUF,
+-		[_PC_CHOWN_RESTRICTED] = 1,
+-		[_PC_NO_TRUNC] = 1,
+-		[_PC_VDISABLE] = 0,
+-		[_PC_SYNC_IO] = 1,
+-		[_PC_ASYNC_IO] = -1,
+-		[_PC_PRIO_IO] = -1,
+-		[_PC_SOCK_MAXBUF] = -1,
+-		[_PC_FILESIZEBITS] = FILESIZEBITS,
+-		[_PC_REC_INCR_XFER_SIZE] = 4096,
+-		[_PC_REC_MAX_XFER_SIZE] = 4096,
+-		[_PC_REC_MIN_XFER_SIZE] = 4096,
+-		[_PC_REC_XFER_ALIGN] = 4096,
+-		[_PC_ALLOC_SIZE_MIN] = 4096,
+-		[_PC_SYMLINK_MAX] = -1,
+-		[_PC_2_SYMLINKS] = 1
+-	};
+-	if (name >= sizeof(values)/sizeof(values[0])) {
++	if (name >= sizeof(pathconf_values) / sizeof(pathconf_values[0]))
++	{
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
+-	return values[name];
++
++	switch (name)
++	{
++	case _PC_NAME_MAX:
++	{
++		struct statvfs buf;
++		if (fstatvfs(fd, &buf) < 0)
++			return -1;
++	}
++	break;
++
++	default:
++		break;
++	}
++
++	return pathconf_values[name];
+ }
+diff --git a/src/conf/pathconf.c b/src/conf/pathconf.c
+index 01e19c59..22853a0f 100644
+--- a/src/conf/pathconf.c
++++ b/src/conf/pathconf.c
+@@ -1,6 +1,28 @@
+-#include <unistd.h>
++#include <errno.h>
++#include <sys/statvfs.h>
++#include "confval.h"
+ 
+ long pathconf(const char *path, int name)
+ {
+-	return fpathconf(-1, name);
++	if (name >= sizeof(pathconf_values) / sizeof(pathconf_values[0]))
++	{
++		errno = EINVAL;
++		return -1;
++	}
++
++	switch (name)
++	{
++	case _PC_NAME_MAX:
++	{
++		struct statvfs buf;
++		if (statvfs(path, &buf) < 0)
++			return -1;
++	}
++	break;
++
++	default:
++		break;
++	}
++
++	return pathconf_values[name];
+ }
 diff --git a/src/exit/_Exit.c b/src/exit/_Exit.c
 index 7a6115c7..9f715d51 100644
 --- a/src/exit/_Exit.c
@@ -1631,6 +1726,37 @@ index 8fd5bc5c..38bfbbd8 100644
  	return syscall_cp(SYS_write, fd, buf, count);
  }
 +weak_alias(write, __write_nocancel);
+diff --git a/src/conf/confval.h b/src/conf/confval.h
+new file mode 100644
+index 00000000..041e4282
+--- /dev/null
++++ b/src/conf/confval.h
+@@ -0,0 +1,25 @@
++#include <unistd.h>
++#include <limits.h>
++
++static const short pathconf_values[] = {
++	[_PC_LINK_MAX] = _POSIX_LINK_MAX,
++	[_PC_MAX_CANON] = _POSIX_MAX_CANON,
++	[_PC_MAX_INPUT] = _POSIX_MAX_INPUT,
++	[_PC_NAME_MAX] = NAME_MAX,
++	[_PC_PATH_MAX] = PATH_MAX,
++	[_PC_PIPE_BUF] = PIPE_BUF,
++	[_PC_CHOWN_RESTRICTED] = 1,
++	[_PC_NO_TRUNC] = 1,
++	[_PC_VDISABLE] = 0,
++	[_PC_SYNC_IO] = 1,
++	[_PC_ASYNC_IO] = -1,
++	[_PC_PRIO_IO] = -1,
++	[_PC_SOCK_MAXBUF] = -1,
++	[_PC_FILESIZEBITS] = FILESIZEBITS,
++	[_PC_REC_INCR_XFER_SIZE] = 4096,
++	[_PC_REC_MAX_XFER_SIZE] = 4096,
++	[_PC_REC_MIN_XFER_SIZE] = 4096,
++	[_PC_REC_XFER_ALIGN] = 4096,
++	[_PC_ALLOC_SIZE_MIN] = 4096,
++	[_PC_SYMLINK_MAX] = -1,
++	[_PC_2_SYMLINKS] = 1};
 diff --git a/src/internal/__popcountdi2.c b/src/internal/__popcountdi2.c
 new file mode 100644
 index 00000000..b4b374a1


### PR DESCRIPTION
Adding Validation on input. fd for fpathconf, and path for pathconf

This will make cpython test `test_os.TestInvalidFD.test_fpathconf` pass