### PR TITLE
pgid of main process should be same as pid

### DIFF
--- a/include/myst/process.h
+++ b/include/myst/process.h
@@ -9,7 +9,6 @@
 #include <unistd.h>
 
 #define MYST_DEFAULT_UMASK (S_IWGRP | S_IWOTH)
-#define MYST_DEFAULT_PGID (pid_t)100
 
 // ATTN: Small stack size for the primary thread of a process might not work
 // for certain apps, especially when on-demand stack growth is not supported

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -486,7 +486,7 @@ static int _init_main_thread(
     process->thread_group_lock = MYST_SPINLOCK_INITIALIZER;
     thread->thread_lock = &process->thread_group_lock;
     process->umask = MYST_DEFAULT_UMASK;
-    process->pgid = MYST_DEFAULT_PGID;
+    process->pgid = pid;
 
     process->cwd_lock = MYST_SPINLOCK_INITIALIZER;
     process->cwd = strdup(cwd);


### PR DESCRIPTION
We were setting it to an arbitrary value where it should be the pid of the same process

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>