### PR TITLE
Return Linux errnos from myst_buf fucntions

### DIFF
--- a/tests/args/Makefile
+++ b/tests/args/Makefile
@@ -14,8 +14,8 @@ endif
 
 LDFLAGS = $(OEHOST_LDFLAGS)
 
-LIBS = $(LIBDIR)/libmysthost.a
-LIBS = $(LIBDIR)/libmystutils.a
+LIBS += $(LIBDIR)/libmystutils.a
+LIBS += $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/tests/buf/Makefile
+++ b/tests/buf/Makefile
@@ -14,8 +14,9 @@ endif
 
 LDFLAGS = $(OEHOST_LDFLAGS)
 
-LIBS = $(LIBDIR)/libmysthost.a
-LIBS = $(LIBDIR)/libmystutils.a
+LIBS =
+LIBS += $(LIBDIR)/libmystutils.a
+LIBS += $(LIBDIR)/libmysthost.a
 
 REDEFINE_TESTS=1
 

--- a/utils/buf.c
+++ b/utils/buf.c
@@ -10,6 +10,7 @@
 
 #include <myst/round.h>
 #include <myst/strings.h>
+#include <myst/eraise.h>
 
 #define MYST_BUF_CHUNK_SIZE 1024
 
@@ -27,7 +28,7 @@ void myst_buf_release(myst_buf_t* buf)
 int myst_buf_clear(myst_buf_t* buf)
 {
     if (!buf)
-        return -1;
+        return -EINVAL;
 
     buf->size = 0;
 
@@ -37,7 +38,7 @@ int myst_buf_clear(myst_buf_t* buf)
 int myst_buf_reserve(myst_buf_t* buf, size_t cap)
 {
     if (!buf)
-        return -1;
+        return -EINVAL;
 
     /* If capacity is bigger than current capacity */
     if (cap > buf->cap)
@@ -57,7 +58,7 @@ int myst_buf_reserve(myst_buf_t* buf, size_t cap)
 
         /* Expand allocation */
         if (!(new_data = realloc(buf->data, new_cap)))
-            return -1;
+            return -ENOMEM;
 
         buf->data = new_data;
         buf->cap = new_cap;
@@ -69,7 +70,7 @@ int myst_buf_reserve(myst_buf_t* buf, size_t cap)
 int myst_buf_resize(myst_buf_t* buf, size_t new_size)
 {
     if (!buf)
-        return -1;
+        return -EINVAL;
 
     if (new_size == 0)
     {
@@ -79,7 +80,7 @@ int myst_buf_resize(myst_buf_t* buf, size_t new_size)
     }
 
     if (myst_buf_reserve(buf, new_size) != 0)
-        return -1;
+        return -ENOMEM;
 
     if (new_size > buf->size)
         memset(buf->data + buf->size, 0, new_size - buf->size);
@@ -95,7 +96,7 @@ int myst_buf_append(myst_buf_t* buf, const void* data, size_t size)
 
     /* Check arguments */
     if (!buf || !data)
-        return -1;
+        return -EINVAL;
 
     /* If zero-sized, then success */
     if (size == 0)
@@ -122,14 +123,13 @@ int myst_buf_append(myst_buf_t* buf, const void* data, size_t size)
 
 int myst_buf_insert(myst_buf_t* buf, size_t pos, const void* data, size_t size)
 {
-    int ret = -1;
+    int ret = 0;
     size_t rem;
 
     if (!buf || pos > buf->size)
-        goto done;
+        ERAISE(-EINVAL);
 
-    if (myst_buf_reserve(buf, buf->size + size) != 0)
-        return -1;
+    ECHECK(myst_buf_reserve(buf, buf->size + size));
 
     rem = buf->size - pos;
 
@@ -142,7 +142,6 @@ int myst_buf_insert(myst_buf_t* buf, size_t pos, const void* data, size_t size)
         memset(buf->data + pos, 0, size);
 
     buf->size += size;
-    ret = 0;
 
 done:
     return ret;
@@ -153,7 +152,7 @@ int myst_buf_remove(myst_buf_t* buf, size_t pos, size_t size)
     size_t rem;
 
     if (!buf || pos > buf->size || pos + size > buf->size)
-        return -1;
+        return -EINVAL;
 
     rem = buf->size - (pos + size);
 
@@ -167,16 +166,13 @@ int myst_buf_remove(myst_buf_t* buf, size_t pos, size_t size)
 
 int myst_buf_pack_u64(myst_buf_t* buf, uint64_t x)
 {
-    int ret = -1;
+    int ret = 0;
     const size_t n = sizeof(uint64_t);
 
     if (!buf)
-        goto done;
+        ERAISE(-EINVAL);
 
-    if (myst_buf_append(buf, &x, n) != 0)
-        goto done;
-
-    ret = 0;
+    ECHECK(myst_buf_append(buf, &x, n));
 
 done:
     return ret;
@@ -184,22 +180,20 @@ done:
 
 int myst_buf_unpack_u64(myst_buf_t* buf, uint64_t* x)
 {
-    int ret = -1;
+    int ret = 0;
     size_t r;
     const size_t n = sizeof(uint64_t);
 
     if (!buf || !x)
-        goto done;
+        ERAISE(-EINVAL);
 
     r = buf->size - buf->offset;
 
     if (r < n)
-        goto done;
+        ERAISE(-ERANGE);
 
     memcpy(x, buf->data + buf->offset, n);
     buf->offset += n;
-
-    ret = 0;
 
 done:
     return ret;
@@ -207,17 +201,16 @@ done:
 
 int myst_buf_pack_bytes(myst_buf_t* buf, const void* p, size_t size)
 {
-    int ret = -1;
+    int ret = 0;
     size_t n;
     size_t align;
     uint8_t align_buf[sizeof(uint64_t)];
 
     if (!buf || !p)
-        goto done;
+        ERAISE(-EINVAL);
 
     /* total size should be a multiple of 8 to guarantee alignment */
-    if (myst_round_up(size, sizeof(uint64_t), &n) != 0)
-        goto done;
+    ECHECK(myst_round_up(size, sizeof(uint64_t), &n));
 
     /* calculate how many extra alignment bytes are needed */
     align = n - size;
@@ -227,18 +220,15 @@ int myst_buf_pack_bytes(myst_buf_t* buf, const void* p, size_t size)
         memset(align_buf, 0, align);
 
     /* append the size */
-    if (myst_buf_pack_u64(buf, size) != 0)
-        goto done;
+    ECHECK(myst_buf_pack_u64(buf, size));
 
     /* append the bytes */
-    if (size && myst_buf_append(buf, p, size) != 0)
-        goto done;
+    if (size)
+        ECHECK(myst_buf_append(buf, p, size));
 
     /* append the alignment bytes */
-    if (align && myst_buf_append(buf, align_buf, align) != 0)
-        goto done;
-
-    ret = 0;
+    if (align)
+        ECHECK(myst_buf_append(buf, align_buf, align));
 
 done:
     return ret;
@@ -246,35 +236,32 @@ done:
 
 int myst_buf_unpack_bytes(myst_buf_t* buf, const void** p, size_t* size_out)
 {
-    int ret = -1;
+    int ret = 0;
     size_t size;
 
     if (!buf || !p || !size_out)
-        goto done;
+        ERAISE(-EINVAL);
 
     /* unpack the size of the array */
-    if (myst_buf_unpack_u64(buf, &size) != 0)
-        goto done;
+    ECHECK(myst_buf_unpack_u64(buf, &size));
 
     /* unpack the array bytes */
     {
         size_t r;
         size_t n;
 
-        if (myst_round_up(size, sizeof(uint64_t), &n) != 0)
-            goto done;
+        ECHECK(myst_round_up(size, sizeof(uint64_t), &n));
 
         r = buf->size - buf->offset;
 
         if (r < n)
-            goto done;
+            ERAISE(-ERANGE);
 
         *p = buf->data + buf->offset;
         buf->offset += n;
     }
 
     *size_out = size;
-    ret = 0;
 
 done:
     return ret;
@@ -282,19 +269,16 @@ done:
 
 int myst_buf_pack_str(myst_buf_t* buf, const char* str)
 {
-    int ret = -1;
+    int ret = 0;
     size_t len;
 
     if (!buf || !str)
-        goto done;
+        ERAISE(-EINVAL);
 
     len = strlen(str);
 
     /* pack the characters and the null terminator */
-    if (myst_buf_pack_bytes(buf, str, len + 1) != 0)
-        goto done;
-
-    ret = 0;
+    ECHECK(myst_buf_pack_bytes(buf, str, len + 1));
 
 done:
     return ret;
@@ -302,29 +286,26 @@ done:
 
 int myst_buf_unpack_str(myst_buf_t* buf, const char** str, size_t* len)
 {
-    int ret = -1;
+    int ret = 0;
     size_t size;
     const char* p;
 
     if (!buf || !str || !len)
-        goto done;
+        ERAISE(-EINVAL);
 
     /* unpack the array of charaters */
-    if (myst_buf_unpack_bytes(buf, (const void**)&p, &size) != 0)
-        goto done;
+    ECHECK(myst_buf_unpack_bytes(buf, (const void**)&p, &size));
 
     /* a string must have at least one null byte */
     if (size == 0)
-        goto done;
+        ERAISE(-ERANGE);
 
     /* verify that the string is zero-terminated */
     if (p[size - 1] != '\0')
-        goto done;
+        ERAISE(-EINVAL);
 
     *str = p;
     *len = size - 1;
-
-    ret = 0;
 
 done:
     return ret;
@@ -340,26 +321,22 @@ done:
 */
 int myst_buf_pack_strings(myst_buf_t* buf, const char* strings[], size_t count)
 {
-    int ret = -1;
+    int ret = 0;
 
     if (!buf || !strings)
-        goto done;
+        ERAISE(-EINVAL);
 
     /* pack the number of strings */
-    if (myst_buf_pack_u64(buf, count) != 0)
-        goto done;
+    ECHECK(myst_buf_pack_u64(buf, count));
 
     /* pack each of the strings */
     for (size_t i = 0; i < count; i++)
     {
         if (!strings[i])
-            goto done;
+            ERAISE(-EINVAL);
 
-        if (myst_buf_pack_str(buf, strings[i]) != 0)
-            goto done;
+        ECHECK(myst_buf_pack_str(buf, strings[i]));
     }
-
-    ret = 0;
 
 done:
     return ret;
@@ -370,20 +347,19 @@ int myst_buf_unpack_strings(
     const char*** strings_out,
     size_t* count_out)
 {
-    int ret = -1;
+    int ret = 0;
     size_t count;
     const char** strings = NULL;
 
     if (!buf || !strings_out || !count_out)
-        goto done;
+        ERAISE(-EINVAL);
 
     /* unpack the number of strings */
-    if (myst_buf_unpack_u64(buf, &count) != 0)
-        goto done;
+    ECHECK(myst_buf_unpack_u64(buf, &count));
 
     /* allocate array of pointers to strings */
     if (!(strings = calloc(count + 1, sizeof(char*))))
-        goto done;
+        ERAISE(-ENOMEM);
 
     /* unpack each of the strings */
     for (size_t i = 0; i < count; i++)
@@ -391,8 +367,7 @@ int myst_buf_unpack_strings(
         const char* str;
         size_t len;
 
-        if (myst_buf_unpack_str(buf, &str, &len) != 0)
-            goto done;
+        ECHECK(myst_buf_unpack_str(buf, &str, &len));
 
         strings[i] = str;
     }
@@ -400,8 +375,6 @@ int myst_buf_unpack_strings(
     *strings_out = strings;
     *count_out = count;
     strings = NULL;
-
-    ret = 0;
 
 done:
 

--- a/utils/bufu64.c
+++ b/utils/bufu64.c
@@ -3,6 +3,7 @@
 
 #include <myst/buf.h>
 #include <myst/bufu64.h>
+#include <myst/eraise.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,7 +11,7 @@
 int myst_bufu64_init(myst_bufu64_t* buf, uint64_t* data, size_t size)
 {
     if (!buf || (!data && size > 0))
-        return -1;
+        return -EINVAL;
 
     buf->data = data;
     buf->size = size;
@@ -32,6 +33,7 @@ void myst_bufu64_release(myst_bufu64_t* buf)
 
 int myst_bufu64_reserve(myst_bufu64_t* buf, size_t cap)
 {
+    int ret = 0;
     myst_buf_t tmp;
     const size_t n = sizeof(uint64_t);
 
@@ -40,18 +42,19 @@ int myst_bufu64_reserve(myst_bufu64_t* buf, size_t cap)
     tmp.cap = buf->cap * n;
     cap *= n;
 
-    if (myst_buf_reserve(&tmp, cap) != 0)
-        return -1;
+    ECHECK(myst_buf_reserve(&tmp, cap));
 
     buf->data = (uint64_t*)tmp.data;
     buf->size = tmp.size / n;
     buf->cap = tmp.cap / n;
 
-    return 0;
+done:
+    return ret;
 }
 
 int myst_bufu64_resize(myst_bufu64_t* buf, size_t new_size)
 {
+    int ret = 0;
     myst_buf_t tmp;
     const size_t n = sizeof(uint64_t);
 
@@ -60,14 +63,14 @@ int myst_bufu64_resize(myst_bufu64_t* buf, size_t new_size)
     tmp.cap = buf->cap * n;
     new_size *= n;
 
-    if (myst_buf_resize(&tmp, new_size) != 0)
-        return -1;
+    ECHECK(myst_buf_resize(&tmp, new_size));
 
     buf->data = (uint64_t*)tmp.data;
     buf->size = tmp.size / n;
     buf->cap = tmp.cap / n;
 
-    return 0;
+done:
+    return ret;
 }
 
 void myst_bufu64_clear(myst_bufu64_t* buf)
@@ -80,6 +83,7 @@ void myst_bufu64_clear(myst_bufu64_t* buf)
 
 int myst_bufu64_append(myst_bufu64_t* buf, const uint64_t* data, size_t size)
 {
+    int ret = 0;
     myst_buf_t tmp;
     const size_t n = sizeof(uint64_t);
 
@@ -88,14 +92,14 @@ int myst_bufu64_append(myst_bufu64_t* buf, const uint64_t* data, size_t size)
     tmp.cap = buf->cap * n;
     size *= n;
 
-    if (myst_buf_append(&tmp, data, size) != 0)
-        return -1;
+    ECHECK(myst_buf_append(&tmp, data, size));
 
     buf->data = (uint64_t*)tmp.data;
     buf->size = tmp.size / n;
     buf->cap = tmp.cap / n;
 
-    return 0;
+done:
+    return ret;
 }
 
 int myst_bufu64_append1(myst_bufu64_t* buf, uint64_t data)
@@ -109,6 +113,7 @@ int myst_bufu64_insert(
     const uint64_t* data,
     size_t size)
 {
+    int ret = 0;
     myst_buf_t tmp;
     const size_t n = sizeof(uint64_t);
 
@@ -119,18 +124,19 @@ int myst_bufu64_insert(
     pos *= n;
     size *= n;
 
-    if (myst_buf_insert(&tmp, pos, data, size) != 0)
-        return -1;
+    ECHECK(myst_buf_insert(&tmp, pos, data, size));
 
     buf->data = (uint64_t*)tmp.data;
     buf->size = tmp.size / n;
     buf->cap = tmp.cap / n;
 
-    return 0;
+done:
+    return ret;
 }
 
 int myst_bufu64_remove(myst_bufu64_t* buf, size_t pos, size_t size)
 {
+    int ret = 0;
     myst_buf_t tmp;
     const size_t n = sizeof(uint64_t);
 
@@ -141,12 +147,12 @@ int myst_bufu64_remove(myst_bufu64_t* buf, size_t pos, size_t size)
     pos *= n;
     size *= n;
 
-    if (myst_buf_remove(&tmp, pos, size) != 0)
-        return -1;
+    ECHECK(myst_buf_remove(&tmp, pos, size));
 
     buf->data = (uint64_t*)tmp.data;
     buf->size = tmp.size / n;
     buf->cap = tmp.cap / n;
 
-    return 0;
+done:
+    return ret;
 }


### PR DESCRIPTION
This PR modifies ``myst_buf_t`` functions to return Linux error numbers rather than negative one.