### PR TITLE
Handle nested signals with altstack and no return user handler

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -253,6 +253,9 @@ typedef struct myst_kernel_args
     /* pointer to myst_handle_host_signal(). Set by myst_enter_kernel */
     void (*myst_handle_host_signal)(siginfo_t* siginfo, mcontext_t* context);
 
+    /* pointer to myst_signal_restore_mask(). Set by myst_enter_kernel */
+    void (*myst_signal_restore_mask)(void);
+
     /* boolean indicating whether to terminate on unhandled syscall or return
      * ENOSYS
      */

--- a/include/myst/signal.h
+++ b/include/myst/signal.h
@@ -44,4 +44,6 @@ int myst_signal_altstack(const stack_t* ss, stack_t* old_ss);
 
 const char* myst_signum_to_string(unsigned signum);
 
+void myst_signal_restore_mask(void);
+
 #endif /* _MYST_SIGNAL_H */

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -678,7 +678,10 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     /* myst_handle_host_signal can be called from enclave exception handlers */
     args->myst_handle_host_signal = myst_handle_host_signal;
 
-    /* make a copy of the input kernel aguments and reassign args */
+    /* myst_signal_restore_mask can be called from enclave exception handlers */
+    args->myst_signal_restore_mask = myst_signal_restore_mask;
+
+    /* make a copy of the input kernel arguments and reassign args */
     __myst_kernel_args = *args;
     args = &__myst_kernel_args;
 

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -374,6 +374,13 @@ static uint64_t _vectored_handler(oe_exception_record_t* er)
                 er->context->rsp =
                     *(uint64_t*)(er->context->rsp + IRETFRAME_Rsp);
 
+                /* Always restore signal mask on iretq. For the case of
+                 * returning from signal handling, doing so recovers
+                 * the mask that is temporarily set by _handle_one_signal.
+                 * For other cases, this function does not have any
+                 * effectiveness. */
+                (*_kargs.myst_signal_restore_mask)();
+
                 return OE_EXCEPTION_CONTINUE_EXECUTION;
                 break;
             }


### PR DESCRIPTION
This PR updates the signal handling logic. Details are as follows:

- Update the signal return logic to support nested signals on using altstack
- Make the logic more robust against the case of user handler does not return
  - Update the logic on determining using altstack or not
  - Always restore the signal mask on signal return and iret simulation
- Ensure the user handler does not run on kernel stack

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>