### PR TITLE
Email requestor only and clean up unnecessary parts for manual PR pipeline

### DIFF
--- a/.jenkins/pipelines/manual-pr.Jenkinsfile
+++ b/.jenkins/pipelines/manual-pr.Jenkinsfile
@@ -7,27 +7,16 @@ pipeline {
         timestamps ()
     }
     parameters {
-        string(name: "REPOSITORY", defaultValue: "deislabs")
-        string(name: "BRANCH", defaultValue: "main", description: "Branch to build")
-        string(name: "PULL_REQUEST_ID", defaultValue: "", description: "If you want to build a pull request, enter the pull request ID number here. Will override branch builds.")
-        choice(name: "REGION", choices: ['useast', 'canadacentral'], description: "Azure region for the SQL solutions test")
+        string(name: "REPOSITORY", defaultValue: "deislabs", description: "Required parameter. This should be the GitHub repository owner (e.g. your GitHub username).")
+        string(name: "BRANCH", defaultValue: "main", description: "Required parameter. This should be your Github branch to build.")
+        string(name: "PULL_REQUEST_ID", defaultValue: "", description: "Optional parameter. If you want to build a pull request, enter the pull request ID number here.")
+        choice(name: "REGION", choices: ['useast', 'canadacentral'], description: "Choose an Azure region for the SQL solutions test")
     }
     environment {
         TEST_CONFIG = 'None'
     }
     stages {
-        /* This stage is used in conjunction with APPROVED_AUTHORS list above
-           to determine whether a build is authorized to run in CI or not.
-           This stage is ran only for Jenkins multibranch pipeline builds
-        */
         stage('Checkout') {
-            when {
-                // This is only necessary for manual PR builds or manual branch builds
-                anyOf {
-                    expression { params.PULL_REQUEST_ID != "" }
-                    expression { params.BRANCH != "main" }
-                }
-            }
             steps {
                 script {
                     if ( params.PULL_REQUEST_ID ) {
@@ -55,41 +44,7 @@ pipeline {
                 }
             }
         }
-        stage('Determine committers') {
-            steps {
-                script {
-                    if ( params.PULL_REQUEST_ID ) {
-                        // This is the git ref for a manual PR build
-                        SOURCE_BRANCH = "origin/pr/${params.PULL_REQUEST_ID}"
-                    } else if ( params.BRANCH ) {
-                        // This is the git ref for a manual branch build
-                        SOURCE_BRANCH = "origin/${params.BRANCH}"
-                    } else {
-                        // This is the git ref in a Jenkins multibranch pipeline build
-                        SOURCE_BRANCH = "origin/PR-${env.CHANGE_ID}"
-                    }
-                    dir("${WORKSPACE}") {
-                        COMMITTER_EMAILS = sh(
-                            returnStdout: true,
-                            script: "git log --pretty='%ae' origin/main..${SOURCE_BRANCH} | sort -u"
-                        )
-                    }
-                }
-            }
-        }
         stage('Run PR Tests') {
-            when {
-                /* Jobs must meet any of the situations below in order to build:
-                    1. Started manually
-                    2. Started by a scheduler
-                    2. Triggered by a GitHub pull request to main
-                */
-                anyOf {
-                    triggeredBy 'UserIdCause'
-                    triggeredBy 'TimerTrigger'
-                    changeRequest target: 'main'
-                }
-            }
             matrix {
                 axes {
                     axis {
@@ -132,15 +87,11 @@ pipeline {
             script {
                 // Bug: Post stage does not show up on Blue Ocean here
                 // https://issues.jenkins.io/browse/JENKINS-58850
-                if ( binding.hasVariable('COMMITTER_EMAILS') ) {
-                    COMMITTER_EMAILS.tokenize('\n').each {
-                        emailext(
-                            subject: "[Jenkins] [${currentBuild.currentResult}] [${env.JOB_NAME}] [#${env.BUILD_NUMBER}]",
-                            body: "See build log for details: ${env.BUILD_URL}",
-                            to: "${it}"
-                        )
-                    }
-                }
+                emailext(
+                    subject: "[Jenkins] [${currentBuild.currentResult}] [${env.JOB_NAME}] [#${env.BUILD_NUMBER}]",
+                    body: "See build log for details: ${env.BUILD_URL}",
+                    recipientProviders: [requestor()]
+                )
             }
         }
     }


### PR DESCRIPTION
For manually triggered PR pipeline:
* Emails will only be sent to requestor (rather than any commits made that's not in main)
* Removed unnecessary `Determine Committers` stage
* Updated comments and descriptions
* Remove when conditions for running the parallel stage left over from original pr.Jenkinsfile

Signed-off-by: Chris Yan <chrisyan@microsoft.com>