### PR TITLE
Update pandas tests to run certain tests  individually (these tests hang when run in sequence)

### DIFF
--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -14,14 +14,15 @@ PYTEST_CMD = $(PYTHON3) -m pytest
 PYTEST_INI_FILE = pytest.ini
 PYTEST_OPTS = -s -q --no-header --skip-slow --skip-db --skip-network
 TEST_ROOT = /usr/local/lib/python3.9/site-packages/
-TEST = pandas/tests/arrays/string_/test_string.py
+TEST = appdir/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_fsspec.py 
 # The following tests used to pass in mystikos, but currently hang indefinitely.
 # Removing these tests currently, and will be added back after investigating
 # these failures.
 REMOVE_TESTS_TEMPORARILY= \
-appdir/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_stata.py \
-appdir/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_sql.py \
-appdir/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_pickle.py 
+appdir/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_user_agent.py \
+
+#the folllowing tests hang when run sequentially, but pass when run individually
+TEST_RUN_INDIVIDUAL=$(shell cat tests.individual)
 
 OPTS = --max-affinity-cpus=4 --app-config-path config.json
 ifdef STRACE
@@ -41,12 +42,16 @@ rootfs-passed: appdir
 	# remove test files that are known to fail partially. These are tested in target 'run'
 	# for expected failures/ errors.
 	cat tests.partially_passed | while read line; do rm -f appdir/"$$line"; done
-	# This file is temporarily being disabled from pandas_tests, to investigate handling
-	rm -f $(REMOVE_TESTS_TEMPORARILY)
+	# This file is temporarily being disabled from pandas_tests, to investigate handling	
+	@ $(foreach i, $(TEST_RUN_INDIVIDUAL),  rm  -rf appdir/$(i) )
+	@ $(foreach i, $(REMOVE_TESTS_TEMPORARILY),  rm  -rf appdir/$(i) )
 	$(MYST) mkext2 appdir rootfs-passed
 
 run-passed: rootfs-passed
 	$(MYST_EXEC) rootfs-passed $(OPTS) $(PYTHON3) /app/app.py
+
+run-individual: rootfs
+	$(foreach i, $(TEST_RUN_INDIVIDUAL), echo $i; $(MAKE) run-one TEST=$(i) $(NL) )
 
 run: rootfs
 	-(cat tests.partially_passed | xargs -P 8 $(MYST_EXEC) rootfs $(OPTS) \
@@ -55,14 +60,11 @@ run: rootfs
 	tail -n 26 result > test_summary
 	diff test_summary expected-test-summary
 	$(MAKE) clean_intermediate
+	$(MAKE) run-individual
 	$(MAKE) run-passed
 
 run-one: rootfs
-	# NOTE: This target is provided for debugging purposes only. It could fail
-	# unexpectedly for few test files.
-	# (e.g., pandas/tests/extension/arrow/arrays.py fails with
-	# ModuleNotFoundError).
-	$(MYST_EXEC) rootfs $(OPTS) $(PYTEST_CMD) $(PYTEST_OPTS) $(TEST_ROOT)/$(TEST)
+	$(MYST_EXEC) rootfs $(OPTS) $(PYTEST_CMD) $(TEST)
 
 clean_intermediate:
 	rm -rf rootfs .pytest_cache result test_summary

--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -34,7 +34,7 @@ all: rootfs
 appdir:
 	$(APPBUILDER) Dockerfile
 	cp $(PYTEST_INI_FILE) appdir/
-	@ $(foreach i, $(TEST_RUN_INDIVIDUAL),  rm  -rf appdir/$(i) )
+	@ $(foreach i, $(REMOVE_TESTS_TEMPORARILY),  rm  -rf appdir/$(i) )
 
 rootfs: appdir
 	$(MYST) mkext2 appdir rootfs
@@ -44,7 +44,7 @@ rootfs-passed: appdir
 	# for expected failures/ errors.
 	cat tests.partially_passed | while read line; do rm -f appdir/"$$line"; done
 	# This file is temporarily being disabled from pandas_tests, to investigate handling
-	@ $(foreach i, $(REMOVE_TESTS_TEMPORARILY),  rm  -rf appdir/$(i) )
+	@ $(foreach i, $(TEST_RUN_INDIVIDUAL),  rm  -rf appdir/$(i) )
 	$(MYST) mkext2 appdir rootfs-passed
 
 run-passed: rootfs-passed

--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -14,12 +14,12 @@ PYTEST_CMD = $(PYTHON3) -m pytest
 PYTEST_INI_FILE = pytest.ini
 PYTEST_OPTS = -s -q --no-header --skip-slow --skip-db --skip-network
 TEST_ROOT = /usr/local/lib/python3.9/site-packages/
-TEST = appdir/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_fsspec.py 
+TEST = /usr/local/lib/python3.9/site-packages/pandas/tests/io/test_fsspec.py 
 # The following tests used to pass in mystikos, but currently hang indefinitely.
 # Removing these tests currently, and will be added back after investigating
 # these failures.
 REMOVE_TESTS_TEMPORARILY= \
-appdir/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_user_agent.py \
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_user_agent.py \
 
 #the folllowing tests hang when run sequentially, but pass when run individually
 TEST_RUN_INDIVIDUAL=$(shell cat tests.individual)

--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -34,6 +34,7 @@ all: rootfs
 appdir:
 	$(APPBUILDER) Dockerfile
 	cp $(PYTEST_INI_FILE) appdir/
+	@ $(foreach i, $(TEST_RUN_INDIVIDUAL),  rm  -rf appdir/$(i) )
 
 rootfs: appdir
 	$(MYST) mkext2 appdir rootfs
@@ -42,8 +43,7 @@ rootfs-passed: appdir
 	# remove test files that are known to fail partially. These are tested in target 'run'
 	# for expected failures/ errors.
 	cat tests.partially_passed | while read line; do rm -f appdir/"$$line"; done
-	# This file is temporarily being disabled from pandas_tests, to investigate handling	
-	@ $(foreach i, $(TEST_RUN_INDIVIDUAL),  rm  -rf appdir/$(i) )
+	# This file is temporarily being disabled from pandas_tests, to investigate handling
 	@ $(foreach i, $(REMOVE_TESTS_TEMPORARILY),  rm  -rf appdir/$(i) )
 	$(MYST) mkext2 appdir rootfs-passed
 

--- a/solutions/pandas_tests/tests.individual
+++ b/solutions/pandas_tests/tests.individual
@@ -1,0 +1,12 @@
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_stata.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_sql.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_pickle.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_html.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_s3.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_common.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_gcs.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_fsspec.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_date_converters.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/io/test_compression.py
+/usr/local/lib/python3.9/site-packages/pandas/tests/internals/test_managers.py
+


### PR DESCRIPTION
With pandas updates, some tests are hanging when run in sequence but passing when run individually. Separating those tests and running individually. One test is hanging in both cases and removing that test, Opened #1197 to investigate further. 

Signed-off-by: radhikaj <radhikaj@microsoft.com>