### PR TITLE
Fix minimum required lldb version

### DIFF
--- a/tests/lldb/Makefile
+++ b/tests/lldb/Makefile
@@ -31,7 +31,7 @@ tests:
 	$(RUNTEST) $(MAKE) __tests
 
 __tests:rootfs
-	${MYST_LLDB} ${LLDB_CMDS} -- ${MYST} ${EXEC} rootfs /bin/helloworld ${OPTS} 2>&1 > ${LLDB_LOG_FILE} 2> /dev/null \
+	${MYST_LLDB} ${LLDB_CMDS} -- ${MYST} ${EXEC} rootfs /bin/helloworld ${OPTS} 2>&1 > ${LLDB_LOG_FILE}  \
            || echo "Failure running myst_lldb"
 	@cat ${LLDB_LOG_FILE} | grep -E "$(LLDB_MATCH)" > /dev/null || (cat ${LLDB_LOG_FILE} && exit 1)
 	@ echo "=== passed test (lldb)"

--- a/third_party/openenclave/Makefile
+++ b/third_party/openenclave/Makefile
@@ -96,6 +96,8 @@ endif
 	mkdir -p $(TOP)/build/bin
 	rm -f $(TOP)/build/bin/myst-gdb
 	ln -s $(TOP)/build/openenclave/bin/oegdb $(TOP)/build/bin/myst-gdb
+	# Patch minimum required lldb version from 7 to 8.
+	sed -i 's/-7/-8/g' $(TOP)/build/openenclave/bin/oelldb
 	rm -f $(TOP)/build/bin/myst-lldb
 	ln -s $(TOP)/build/openenclave/bin/oelldb $(TOP)/build/bin/myst-lldb
 


### PR DESCRIPTION
The Python interface has changed since version 8 and that is the
minimum required version. oelldb is patched to fix the version.

Don't silence error output from lldb in the test to help with debugging test failure.

oelldb's minimum required version will be updated separately in the OE repo.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>