### PR TITLE
when tests fail some abort the pipeline

### DIFF
--- a/tests/libcxx/Makefile
+++ b/tests/libcxx/Makefile
@@ -56,7 +56,7 @@ $(ROOTFS): run.c
 OPTS += --memory-size=64m
 
 tests: $(ROOTFS)
-	$(MYST_EXEC) $(OPTS) $(ROOTFS) /bin/run /tests.passed
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /bin/run /tests.passed
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst

--- a/tests/sockperf/Makefile
+++ b/tests/sockperf/Makefile
@@ -25,13 +25,13 @@ $(ROOTFS): $(APPDIR)
 
 tests:
 	./kill.sh
-	docker run --network="host" temp-image-for-server /app/sockperf server &
+	-docker run --network="host" temp-image-for-server /app/sockperf server &
 	./wait.sh
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf ping-pong
 	# $(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf under-load
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf throughput --msg-size=1472
 	./kill.sh
-	docker run --network="host" temp-image-for-server /app/sockperf server --tcp &
+	-docker run --network="host" temp-image-for-server /app/sockperf server --tcp &
 	./wait.sh
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf ping-pong --tcp
 	# $(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) /app/sockperf under-load --tcp


### PR DESCRIPTION
sometimes we can just prepend $(RUNTEST) before the actual test which is
what was done for libcxx. For sockperf it was specificly the docker
command that failed. For sockperf I ignored the return from docker as
the test is going to fail if the docker run command did not work anyway.

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>