### PR TITLE
let child process of fork() have a little more time

### DIFF
--- a/crt/fork.c
+++ b/crt/fork.c
@@ -456,7 +456,18 @@ __attribute__((__returns_twice__)) pid_t myst_fork(void)
             /* Wait if fork mode requires it */
             if (fork_mode == myst_fork_pseudo_wait_for_exit_exec)
             {
+                /* wait for the child process to shutdown */
                 syscall(SYS_myst_fork_wait_exec_exit);
+            }
+            else
+            {
+                /* Sleep enough to allow the child to return first. If an
+                 * application assigns the return of fork() to a global variable
+                 * then there is contention and the child or parent may win.
+                 * This can cause the parent to not know the child pid and all
+                 * sorts can fail. This sleep should be enough to let the child
+                 * finish first. */
+                syscall(SYS_sched_yield);
             }
         }
     }


### PR DESCRIPTION
Sometimes the return of fork() is assigned to a global.
For a child this is zero and is checked directly after the fork is run.
The parent gets the child pid so knows it is the parent.
This causes a race condition between the child and parent as to who
changes this global first.
In most test cases we have seen that do this the parent is sometimes
needing this value after the if() statement itself, where the child is
only doing the initial check before not using it again.
As a result of this observation, and to make fork() more predictable,
this change adds a sched_yield() to the parent before returning in a
hope to let the child hit the first if statement first before
continuing.

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>