### PR TITLE
Serialize callback invocations from dl_iterate_phdr

### DIFF
--- a/tests/aspnetcore5/Makefile
+++ b/tests/aspnetcore5/Makefile
@@ -54,6 +54,11 @@ test-single: ext2fs
 	$(MYST_EXEC) ext2fs $(OPTS) \
 	/runner/bin/Debug/net5.0/runner /tests/unit-tests.runner.$(ID) ""
 
+test-single-lldb:
+	$(MYST_LLDB) -- $(MYST_EXEC) ext2fs $(OPTS) \
+	--report-native-tids \
+	/runner/bin/Debug/net5.0/runner /tests/unit-tests.runner.$(ID) "/"
+
 one: ext2fs
 	$(MYST_EXEC) ext2fs --roothash=roothash $(OPTS) \
 	/aspnetcore/.dotnet/dotnet test $(TEST)

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -261,7 +261,7 @@ index 20d50f2c..17cd6ac3 100644
 +{
 +}
 diff --git a/ldso/dynlink.c b/ldso/dynlink.c
-index afec985a..acf447c4 100644
+index afec985a..9f9b618d 100644
 --- a/ldso/dynlink.c
 +++ b/ldso/dynlink.c
 @@ -3,6 +3,7 @@
@@ -497,7 +497,39 @@ index afec985a..acf447c4 100644
  	return p;
  }
  
-@@ -2302,7 +2356,7 @@ static void error(const char *fmt, ...)
+@@ -2272,11 +2326,16 @@ no_redir:
+ 	return __dlsym(p, s, ra);
+ }
+ 
++/* Lock to keep calls to callbacks thread-safe. 
++ * Passed callbacks may have static members. */
++static pthread_mutex_t dl_iterate_cb_lock;
+ int dl_iterate_phdr(int(*callback)(struct dl_phdr_info *info, size_t size, void *data), void *data)
+ {
+ 	struct dso *current;
+ 	struct dl_phdr_info info;
+ 	int ret = 0;
++
++	pthread_rwlock_wrlock(&lock);
+ 	for(current = head; current;) {
+ 		info.dlpi_addr      = (uintptr_t)current->base;
+ 		info.dlpi_name      = current->name;
+@@ -2289,12 +2348,11 @@ int dl_iterate_phdr(int(*callback)(struct dl_phdr_info *info, size_t size, void
+ 
+ 		ret = (callback)(&info, sizeof (info), data);
+ 
+-		if (ret != 0) break;
++		if (ret != 0) break; 
+ 
+-		pthread_rwlock_rdlock(&lock);
+ 		current = current->next;
+-		pthread_rwlock_unlock(&lock);
+ 	}
++	pthread_rwlock_unlock(&lock);
+ 	return ret;
+ }
+ 
+@@ -2302,7 +2360,7 @@ static void error(const char *fmt, ...)
  {
  	va_list ap;
  	va_start(ap, fmt);


### PR DESCRIPTION
### Summary
During C++ exception stack unwinding, `int dl_iterate_phdr(
          int (*callback) (struct dl_phdr_info *info,
                           size_t size, void *data),
          void *data)` is called to find frame information. `dl_iterate_phdr` iterates over the list of loaded modules, and calls the callback on each one of them until the callback returns a non-zero code.
Calling of the callback is not protected by any locks. If the callback is not thread safe, and multiple threads are throwing exceptions(as in dotnet's case), then it might lead to undefined behavior.

The callback in for C++ stack unwinding `_Unwind_IteratePhdrCallback` does have a static data member [adds](https://github.com/gcc-mirror/gcc/blob/master/libgcc/unwind-dw2-fde-dip.c#L222) .

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>