### PR TITLE
Copy /proc/[pid]/exe from parent to child at fork()

### DIFF
--- a/include/myst/procfs.h
+++ b/include/myst/procfs.h
@@ -13,6 +13,9 @@ int create_proc_root_entries();
 /* For callbacks implementing /proc/[pid]/xxx entries */
 myst_process_t* myst_procfs_path_to_process(const char* entrypath);
 
+/* Create the "/proc/<pid>/exe" link */
+int procfs_setup_exe_link(const char* path, pid_t pid);
+
 /*
 **==============================================================================
 **

--- a/tests/procfs/procfs.c
+++ b/tests/procfs/procfs.c
@@ -325,6 +325,23 @@ int test_stat_from_child()
     }
 }
 
+int test_self_exe_in_fork_child(char* pn)
+{
+    pid_t pid = fork();
+    assert(pid >= 0);
+
+    if (pid == 0) // child
+    {
+        test_self_exe(pn);
+        exit(0);
+    }
+    else // parent
+    {
+        int status;
+        wait(&status);
+    }
+}
+
 int main(int argc, const char* argv[])
 {
     test_meminfo();
@@ -335,6 +352,7 @@ int main(int argc, const char* argv[])
     test_fdatasync();
     test_stat();
     test_stat_from_child();
+    test_self_exe_in_fork_child(argv[0]);
 
     printf("\n=== passed test (%s)\n", argv[0]);
     return 0;


### PR DESCRIPTION
Currently the /proc/[pid]/exe symlink is setup for child processes only if they do a `execve`. 
 
Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>