### PR TITLE
Update expected output for pandas

### DIFF
--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -58,7 +58,7 @@ run: rootfs
 		$(PYTEST_CMD) $(PYTEST_OPTS) 2>&1 > result; true)
 	sed -i '$$d' result
 	tail -n 26 result > test_summary
-	diff test_summary expected-test-summary	
+	diff -B -w test_summary expected-test-summary
 	$(MAKE) run-individual
 	$(MAKE) clean_intermediate
 	$(MAKE) run-passed

--- a/solutions/pandas_tests/expected-test-summary
+++ b/solutions/pandas_tests/expected-test-summary
@@ -1,7 +1,7 @@
 =========================== short test summary info ============================
-FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[\U0001f44d...]
-FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[\u03a9\u0153\u2211\xb4...]
-FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[abcd...]
+FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::TestClipboard::test_raw_roundtrip[\U0001f44d...]
+FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::TestClipboard::test_raw_roundtrip[\u03a9\u0153\u2211\xb4...]
+FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::TestClipboard::test_raw_roundtrip[abcd...]
 ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetPyArrow::test_s3_roundtrip_explicit_fs
 ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetPyArrow::test_s3_roundtrip
 ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_parquet.py::TestParquetFastParquet::test_s3_roundtrip

--- a/solutions/pandas_tests/tests.individual
+++ b/solutions/pandas_tests/tests.individual
@@ -9,4 +9,3 @@
 /usr/local/lib/python3.9/site-packages/pandas/tests/io/test_date_converters.py
 /usr/local/lib/python3.9/site-packages/pandas/tests/io/test_compression.py
 /usr/local/lib/python3.9/site-packages/pandas/tests/internals/test_managers.py
-


### PR DESCRIPTION
Signed-off-by: radhikaj <radhikaj@microsoft.com>

The solutions pipeline failed due to newlines in the output of expected-test-summary and test_summary. I am not certain of this since I cant repro locally, but see this in the nightly run:
https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1862 


[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1858)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1859)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1860)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1861)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1862)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1863)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1864)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1865)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1866)[](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FStandalone-Pipelines%2FSolutions-Tests-Pipeline/detail/Solutions-Tests-Pipeline/2202/pipeline/#step-58-log-1867)[2022-02-13T07:55:53.365Z] 

[2022-02-13T07:56:05.236Z] 2,4c2,4

[2022-02-13T07:56:05.236Z] < FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::TestClipboard::test_raw_roundtrip[\U0001f44d...]

[2022-02-13T07:56:05.236Z] < FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::TestClipboard::test_raw_roundtrip[\u03a9\u0153\u2211\xb4...]

[2022-02-13T07:56:05.236Z] < FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::TestClipboard::test_raw_roundtrip[abcd...]

[2022-02-13T07:56:05.236Z] ---

[2022-02-13T07:56:05.236Z] > FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[\U0001f44d...]

[2022-02-13T07:56:05.236Z] > FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[\u03a9\u0153\u2211\xb4...]

[2022-02-13T07:56:05.236Z] > FAILED ../usr/local/lib/python3.9/site-packages/pandas/tests/io/test_clipboard.py::test_raw_roundtrip[abcd...]

[2022-02-13T07:56:05.236Z] make[2]: *** [Makefile:60: run] Error 1

[2022-02-13T07:56:05.236Z] make[2]: Leaving directory '/home/oeadmin/workspace/Mystikos/Standalone-Pipelines/Solutions-Tests-Pipeline/solutions/pandas_tests'