### PR TITLE
cpython 3.10 small changes

### DIFF
--- a/tests/cpython-tests/config-3.10.json
+++ b/tests/cpython-tests/config-3.10.json
@@ -9,7 +9,7 @@
     // Mystikos specific values
 
     // The heap size of the user application. Increase this setting if your app experienced OOM.
-    "MemorySize": "4g",
+    "MemorySize": "8g",
     "ThreadStackSize": "2m",
     // The path to the entry point application in rootfs
     "ApplicationPath": "/cpython/python",

--- a/tests/cpython-tests/test_config_v3.10.2/tests.passed
+++ b/tests/cpython-tests/test_config_v3.10.2/tests.passed
@@ -176,7 +176,6 @@ test_ipaddress
 test_isinstance
 test_iter
 test_iterlen
-test_itertools
 test_json
 test_keyword
 test_keywordonlyarg

--- a/tests/cpython-tests/test_config_v3.10.2/tests.passed.individual
+++ b/tests/cpython-tests/test_config_v3.10.2/tests.passed.individual
@@ -1,4 +1,5 @@
 test_asynchat
 test_interpreters
+test_itertools
 test_repl
 test_zipfile


### PR DESCRIPTION
increase memory for 3.10 tests to 8G
move test_itertools into own test host

Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>