### PR TITLE
Shrink the cpython-test rootfs

### DIFF
--- a/tests/cpython-tests/Dockerfile
+++ b/tests/cpython-tests/Dockerfile
@@ -27,3 +27,5 @@ RUN ln -sf /cpython/python /usr/bin/python3
 
 # Copy Mystikos pdb
 COPY ./mpdb.py /cpython/mpdb.py
+
+RUN rm -rf /cpython/.git /usr/lib/gcc /usr/lib/x86_64-linux-gnu/perl /usr/lib/x86_64-linux-gnu/nss /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/guile /usr/lib/git-core /usr/lib/x86_64-linux-gnu/gconv /usr/lib/x86_64-linux-gnu/ldscripts /usr/share/perl /usr/lib/python2.7 /usr/lib/python3.6


### PR DESCRIPTION
This change reduces the **cpython-test rootfs** from **1,742mb** to **817mb** or by **53%**.

It also makes the build twice as fast.