### PR TITLE
Adding python azure sdk to the pipeline

### DIFF
--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
         stage('Build repo source') {
             steps {
                 sh """
-                   ${JENKINS_SCRIPTS}/global/make-world.sh
+                   ${JENKINS_SCRIPTS}/global/make-sdk-tests.sh
                    """
             }
         }

--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -153,7 +153,8 @@ pipeline {
                         sh """
                            ${JENKINS_SCRIPTS}/global/run-azure-tests.sh \
                              ${WORKSPACE}/tests/azure-sdk-for-cpp  \
-                             ${WORKSPACE}/solutions/dotnet_azure_sdk
+                             ${WORKSPACE}/solutions/dotnet_azure_sdk \
+                             ${WORKSPACE}/solutions/python_azure_sdk
                            """
                     }
                 }

--- a/.jenkins/scripts/global/make-sdk-tests.sh
+++ b/.jenkins/scripts/global/make-sdk-tests.sh
@@ -1,0 +1,3 @@
+sudo rm -rf $(git ls-files --others --directory)
+make distclean
+make -j

--- a/solutions/python_azure_sdk/Makefile
+++ b/solutions/python_azure_sdk/Makefile
@@ -40,7 +40,7 @@ test-storage: rootfs-storage
 test-storage-blob: rootfs-storage-blob
 	./test-all-packages.sh "$(MYST_EXEC)" storage-blob/rootfs "$(OPTS)" storage-blob/packages.txt
 
-tests: test-keyvault_identity test-storage test-storage-blob
+tests: all test-keyvault_identity test-storage test-storage-blob
 
 clean:
 	rm -rf keyvault_identity/rootfs keyvault_identity/appdir storage/rootfs storage/appdir storage-blob/rootfs storage-blob/appdir


### PR DESCRIPTION
Adding the python sdk test suite which was left out 
Changing the build process for the sdk pipeline to only build mystikos, saving ~29 minutes in the pipeline by reducing build time from ~31 minutes to ~2 minutes