### PR TITLE
Disable tst-cancel8 glibc testcase

### DIFF
--- a/tests/glibc/tests.failed
+++ b/tests/glibc/tests.failed
@@ -2,3 +2,4 @@
 /glibc/build/inet/test-ifaddrs: creates a socket with AF_NETLINK
 /glibc/build/io/tst-ftw-lnk.d/link2-tgt ldso: /glibc/build/io/tst-ftw-lnk.d/link2-tgt: Not a valid dynamic program 
 /glibc/build/nptl/test-mutexattr-printers Makefile:57: recipe for target 'one' failed ****Runs without error in GDB****
+/glibc/build/nptl/tst-cancel8: Requires support of deferred cancel type for pthread_cancel

--- a/tests/glibc/tests.passed
+++ b/tests/glibc/tests.passed
@@ -333,7 +333,6 @@
 /glibc/build/nptl/tst-cancel26
 /glibc/build/nptl/tst-cancel27
 /glibc/build/nptl/tst-cancel3
-/glibc/build/nptl/tst-cancel8
 /glibc/build/nptl/tst-cancelx10
 /glibc/build/nptl/tst-cancelx12
 /glibc/build/nptl/tst-cancelx13

--- a/tests/glibc/tests.remove
+++ b/tests/glibc/tests.remove
@@ -27,3 +27,4 @@
 /glibc/build/rt/tst-aio7
 /glibc/build/stdlib/tst-getrandom
 /glibc/build/time/tst-clock2
+/glibc/build/nptl/tst-cancel8: Requires support of deferred cancel type for pthread_cancel


### PR DESCRIPTION
Test relies on deferred cancellation of a thread. Mystikos currently delivers pthread_cancel asynchronously to other threads, irrespective of their cancel type.