### PR TITLE
Patch glibc test runner

### DIFF
--- a/tests/glibc/Dockerfile
+++ b/tests/glibc/Dockerfile
@@ -4,9 +4,12 @@ RUN apt-get update && apt-get install -y \
     build-essential bison git gawk python3
 
 # checkout glibc
+WORKDIR /
 RUN git clone https://sourceware.org/git/glibc.git
-RUN cd glibc && git checkout release/2.34/master && \
-    mkdir build && cd build
+WORKDIR /glibc
+RUN git checkout release/2.34/master
+COPY patch.diff .
+RUN git apply patch.diff
 
 # configure the build
 WORKDIR /glibc/build
@@ -15,7 +18,7 @@ RUN ../configure --prefix=/usr \
                  --enable-static-pie
 
 # build glibc
-RUN make
+RUN make -j
 
 # Future enhancement after confirming stability
 # FROM ubuntu:18.04

--- a/tests/glibc/Makefile
+++ b/tests/glibc/Makefile
@@ -41,7 +41,9 @@ build: glibc
 PWD=$(shell pwd)
 
 $(APPDIR):
-	$(APPBUILDER) -i mystikos/glibc-test:0.1
+	# $(APPBUILDER) -i mystikos/glibc-test:0.1
+	# todo: replace with pre-built image
+	$(APPBUILDER) -i hullcritical/glibc-test:0.1
 	cp $(CURDIR)/tests.passed $(APPDIR)
 
 $(APPDIR)/bin/run: run.c
@@ -67,3 +69,6 @@ myst:
 clean:
 	rm -rf $(APPDIR) $(ROOTFS)
 
+TEST=/glibc/build/math/test-tgmath3-asin
+gdb:
+	$(MYST_GDB) --args $(MYST_EXEC) $(OPTS) $(ROOTFS) $(TEST) $(NL)

--- a/tests/glibc/patch.diff
+++ b/tests/glibc/patch.diff
@@ -1,0 +1,33 @@
+diff --git a/support/support_test_main.c b/support/support_test_main.c
+index 07e3cdd173..2c399dd72a 100644
+--- a/support/support_test_main.c
++++ b/support/support_test_main.c
+@@ -407,8 +407,9 @@ support_test_main (int argc, char **argv, const struct test_config *config)
+      - set up the timer
+      - fork and execute the function.  */
+ 
+-  test_pid = fork ();
+-  if (test_pid == 0)
++  pid_t local_pid = fork ();
++
++  if (local_pid == 0)
+     {
+       /* This is the child.  */
+       if (disable_coredumps)
+@@ -430,12 +431,15 @@ support_test_main (int argc, char **argv, const struct test_config *config)
+       /* Execute the test function and exit with the return value.   */
+       exit (run_test_function (argc, argv, config));
+     }
+-  else if (test_pid < 0)
++  else if (local_pid < 0)
+     {
+       printf ("Cannot fork test program: %m\n");
+       exit (1);
+     }
+ 
++  /* Store child pid */
++  test_pid = local_pid;
++
+   /* Set timeout.  */
+   signal (SIGALRM, signal_handler);
+   alarm (timeout * timeoutfactor);


### PR DESCRIPTION
Store pid returned from fork in a local variable instead of global one. This would reduce the flakiness of glibc tests