### PR TITLE
Docker build retries

### DIFF
--- a/scripts/appbuilder
+++ b/scripts/appbuilder
@@ -171,8 +171,8 @@ docker_network_remove()
                 for CONTAINER in $(docker network inspect --format '{{range $k, $v := .Containers}}{{print $k}}{{end}}' $NETWORK_NAME)
                 do
                     echo "Force removing $CONTAINER from $NETWORK_NAME"
-                    docker network disconnect -f $NETWORK_NAME $CONTAINER;
-                done;
+                    docker network disconnect -f $NETWORK_NAME $CONTAINER || true
+                done
             fi
             echo "Docker network retry $i: sleeping $i seconds..."
             sleep $i
@@ -192,6 +192,7 @@ get_image()
         # to be changed to include more ip addresses.
         docker network create $NETWORK_NAME
         docker build $DOCKER_BUILD_MODE --iidfile $TEMP_IMAGE_IIDFILE -f $DOCKER_FILE --network $NETWORK_NAME $EXTRA_ARGS .
+        $(dirname $0)/retry_with_backoff docker build ${DOCKER_BUILD_MODE} --iidfile ${TEMP_IMAGE_IIDFILE} -f ${DOCKER_FILE} --network ${NETWORK_NAME} ${EXTRA_ARGS} .
         docker_network_remove
         if [ ! -f "$TEMP_IMAGE_IIDFILE" ]; then
             echo "failed to build from Docker Image file $TEMP_IMAGE_IIDFILE";


### PR DESCRIPTION
Retrying the docker build failures is evidently effective in moving past the endpoint creation failures / docker network timeouts.

``` 
[2022-03-08T20:20:45.691Z] driver failed programming external connectivity on endpoint optimistic_ishizaka (7f071b807c2979c04a996d1d0dfffc3c45caede6190653f7953489c71c40d231): failed to update bridge endpoint 7f071b8 to store: failed to update bridge store for object type *bridge.bridgeEndpoint: timeout
[2022-03-08T20:20:45.691Z] Failed to build dotnet-lib-6 Docker Image from Dockerfile Dockerfile.glibc.runner
[2022-03-08T20:20:45.691Z] Docker build dotnet-lib-6 retry 1: sleeping 1 seconds...
<truncated for brevity>
[2022-03-08T20:36:42.313Z] Success! Application dotnet-lib-6 built at appdir.
```
From https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/Mystikos/job/Standalone-Pipelines/job/Solutions-Tests-Pipeline/2908/consoleText

Signed-off-by: Chris Yan <chrisyan@microsoft.com>