### PR TITLE
Extend timeout to 12 hours

### DIFF
--- a/.jenkins/pipelines/release.Jenkinsfile
+++ b/.jenkins/pipelines/release.Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         label 'Jenkins-Shared-DC2'
     }
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 720, unit: 'MINUTES')
     }
     parameters {
         string(name: "REPOSITORY", defaultValue: "deislabs")


### PR DESCRIPTION
Release builds will trigger the .NET P1 tests, which take > 6 hours to complete successfully. This will extend the timeout to 12 hours so that release builds have the chance to pass.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>