### PR TITLE
make cpprestsdk use ext2 by default, disable broken test

### DIFF
--- a/solutions/Makefile
+++ b/solutions/Makefile
@@ -39,7 +39,7 @@ endif
 DIRS += nodejs
 DIRS += numpy_core_tests
 DIRS += redis
-#DIRS += cpprestsdk
+DIRS += cpprestsdk
 
 .PHONY: $(DIRS)
 

--- a/solutions/cpprestsdk/Makefile
+++ b/solutions/cpprestsdk/Makefile
@@ -11,13 +11,14 @@ ifdef STRACE
 OPTS += --strace
 endif
 
-all: package
+all: ext2rootfs
 
 package: $(APPDIR) private.pem
 	$(MYST) package-sgx $(APPDIR) private.pem config.json
 
-run: 
-	myst/bin/$(APP_NAME) $(OPTS)
+run: ext2rootfs
+#	myst/bin/$(APP_NAME) $(OPTS)
+	$(RUNTEST) $(MYST_EXEC) ext2rootfs --app-config-path config.json $(OPTS) /app/casablanca/build.release/Release/Binaries/test_runner
 
 $(APPDIR):
 	$(APPBUILDER) -v -d Dockerfile
@@ -26,7 +27,7 @@ cpio: $(APPDIR)
 	$(MYST) mkcpio $(APPDIR) rootfs
 
 ext2rootfs: $(APPDIR)
-	$(MYST) mkext2 $(APPDIR) ext2rootfs
+	$(MYST) mkext2 -f $(APPDIR) ext2rootfs
 
 # There are 6 test suite come with the CPPRESTSDK, replace the <suite>.so filename to related test suite
 # libhttpclient_test.so
@@ -48,4 +49,4 @@ private.pem:
 	openssl genrsa -out private.pem -3 3072
 
 clean:
-	rm -rf rootfs $(APPDIR) myst private.pem 
+	rm -rf rootfs $(APPDIR) myst private.pem ext2rootfs

--- a/solutions/cpprestsdk/skip-tests.patch
+++ b/solutions/cpprestsdk/skip-tests.patch
@@ -1,3 +1,24 @@
+diff --git a/Release/tests/functional/http/client/outside_tests.cpp b/Release/tests/functional/http/client/outside_tests.cpp
+index 439772c7..bcdad28b 100644
+--- a/Release/tests/functional/http/client/outside_tests.cpp
++++ b/Release/tests/functional/http/client/outside_tests.cpp
+@@ -240,6 +240,7 @@ SUITE(outside_tests)
+ 
+     TEST(server_hostname_mismatch_ignored) { test_ignored_ssl_cert(U("https://wrong.host.badssl.com/")); }
+ 
++#if 0 /* this test fails because an external server is down */
+     TEST(server_hostname_host_override_after_upgrade)
+     {
+         http_client client(U("http://198.35.26.96/"));
+@@ -248,6 +249,8 @@ SUITE(outside_tests)
+         auto response = client.request(req).get();
+         VERIFY_ARE_EQUAL(status_codes::OK, response.status_code());
+     }
++#endif
++
+ #endif // !defined(__cplusplus_winrt) && !defined(CPPREST_FORCE_HTTP_CLIENT_WINHTTPPAL)
+ 
+     TEST(server_cert_expired) { test_failed_ssl_cert(U("https://expired.badssl.com/")); }
 diff --git a/Release/tests/functional/streams/fstreambuf_tests.cpp b/Release/tests/functional/streams/fstreambuf_tests.cpp
 index 190eb66b..39e65559 100644
 --- a/Release/tests/functional/streams/fstreambuf_tests.cpp


### PR DESCRIPTION
Signed-off-by: Paul Allen <paul.c.allen@microsoft.com>