### PR TITLE
Patch musl pathconf

### DIFF
--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -551,6 +551,96 @@ index 02cb1aa2..07e76f19 100644
  	} else if ((name&~4U)!=1 && name-_CS_POSIX_V6_ILP32_OFF32_CFLAGS>33U) {
  		errno = EINVAL;
  		return 0;
+diff --git a/src/conf/fpathconf.c b/src/conf/fpathconf.c
+index e6aca5cf..d7392ced 100644
+--- a/src/conf/fpathconf.c
++++ b/src/conf/fpathconf.c
+@@ -1,6 +1,7 @@
+ #include <unistd.h>
+ #include <limits.h>
+ #include <errno.h>
++#include <sys/stat.h>
+ 
+ long fpathconf(int fd, int name)
+ {
+@@ -31,5 +32,20 @@ long fpathconf(int fd, int name)
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
++
++	// The maximum length of a filename in the directory path or
++	// fd that the process is allowed to create
++	if (name == _PC_NAME_MAX) {
++		struct stat buf;
++		if (fstat(fd, &buf) == -1) {
++			return -1;
++		}
++		// Should be directory
++		if (!S_ISDIR(buf.st_mode)) {
++			errno = EBADF;
++			return -1;
++		}
++	}
++
+ 	return values[name];
+ }
+diff --git a/src/conf/pathconf.c b/src/conf/pathconf.c
+index 01e19c59..30a9e3cb 100644
+--- a/src/conf/pathconf.c
++++ b/src/conf/pathconf.c
+@@ -1,6 +1,51 @@
+ #include <unistd.h>
++#include <limits.h>
++#include <errno.h>
++#include <sys/stat.h>
+ 
+ long pathconf(const char *path, int name)
+ {
+-	return fpathconf(-1, name);
++	static const short values[] = {
++		[_PC_LINK_MAX] = _POSIX_LINK_MAX,
++		[_PC_MAX_CANON] = _POSIX_MAX_CANON,
++		[_PC_MAX_INPUT] = _POSIX_MAX_INPUT,
++		[_PC_NAME_MAX] = NAME_MAX,
++		[_PC_PATH_MAX] = PATH_MAX,
++		[_PC_PIPE_BUF] = PIPE_BUF,
++		[_PC_CHOWN_RESTRICTED] = 1,
++		[_PC_NO_TRUNC] = 1,
++		[_PC_VDISABLE] = 0,
++		[_PC_SYNC_IO] = 1,
++		[_PC_ASYNC_IO] = -1,
++		[_PC_PRIO_IO] = -1,
++		[_PC_SOCK_MAXBUF] = -1,
++		[_PC_FILESIZEBITS] = FILESIZEBITS,
++		[_PC_REC_INCR_XFER_SIZE] = 4096,
++		[_PC_REC_MAX_XFER_SIZE] = 4096,
++		[_PC_REC_MIN_XFER_SIZE] = 4096,
++		[_PC_REC_XFER_ALIGN] = 4096,
++		[_PC_ALLOC_SIZE_MIN] = 4096,
++		[_PC_SYMLINK_MAX] = -1,
++		[_PC_2_SYMLINKS] = 1
++	};
++	if (name >= sizeof(values)/sizeof(values[0])) {
++		errno = EINVAL;
++		return -1;
++	}
++
++	// The maximum length of a filename in the directory path or
++	// fd that the process is allowed to create
++	if (name == _PC_NAME_MAX) {
++		struct stat buf;
++		if (stat(path, &buf) == -1) {
++			return -1;
++		}
++		// Should be directory
++		if (!S_ISDIR(buf.st_mode)) {
++			errno = EBADF;
++			return -1;
++		}
++	}
++
++	return values[name];
+ }
 diff --git a/src/exit/_Exit.c b/src/exit/_Exit.c
 index 7a6115c7..9f715d51 100644
 --- a/src/exit/_Exit.c


### PR DESCRIPTION
For case "PC_NAME_MAX", check if filepath or fd is valid

This patch will enable Cpython 3.10 `test_os.TestInvalidFD.test_fpathconf`