### PR TITLE
Maintain _debug_modules in order of debugger registration

### DIFF
--- a/tools/myst/host/host.c
+++ b/tools/myst/host/host.c
@@ -21,6 +21,7 @@
 #include <myst/getopt.h>
 #include <myst/paths.h>
 #include <myst/round.h>
+#include <myst/spinlock.h>
 #include <myst/strings.h>
 #include <myst/tcall.h>
 #include <myst/trace.h>
@@ -45,10 +46,20 @@ typedef struct debug_module
     oe_debug_module_t base;
     struct debug_module* next;
     char __buf[PATH_MAX];
-    bool loaded;
 } debug_module_t;
 
+/* Modules that have been registered with the debugger. Each time a module is
+   registered, it is added to the front of the list. This list is maintained
+   in the same order that the debugger receives notifications. This allows the
+   debugger to efficiently sync in case _debug_modules and the debugger's own
+   list go out of sync.  */
 static debug_module_t* _debug_modules;
+
+/* List of modules yet to be registered with the debugger. The modules in this
+   list are removed one by one and then registered with the debugger and
+   prepended to the _debug_modules list.  */
+static debug_module_t* _debug_modules_pending;
+static myst_spinlock_t _modules_lock;
 
 long myst_syscall_isatty_ocall(int fd)
 {
@@ -128,6 +139,7 @@ long myst_add_symbol_file_by_path(
     void* data = NULL;
     bool notify = true;
 
+    myst_spin_lock(&_modules_lock);
     if (!path || !text_data || !text_size)
         ERAISE(-EINVAL);
 
@@ -151,17 +163,23 @@ long myst_add_symbol_file_by_path(
         {
             /* notify gdb to load the symbols */
             oe_debug_notify_library_loaded(&di->base);
-            di->loaded = true;
+
+            /* add to the front of the list */
+            di->next = _debug_modules;
+            _debug_modules = di;
+        }
+        else
+        {
+            /* add to the front of the pending list */
+            di->next = _debug_modules_pending;
+            _debug_modules_pending = di;
         }
 
-        /* add to the front of the list */
-        di->next = _debug_modules;
-        _debug_modules = di;
         di = NULL;
     }
 
 done:
-
+    myst_spin_unlock(&_modules_lock);
     if (di)
         free(di);
 
@@ -199,6 +217,7 @@ long myst_tcall_add_symbol_file(
     void* data = NULL;
     bool notify = false;
 
+    myst_spin_lock(&_modules_lock);
     if (!text_data || !text_size || (!file_data && file_size))
         ERAISE(-EINVAL);
 
@@ -284,16 +303,23 @@ long myst_tcall_add_symbol_file(
         {
             /* notify gdb to load the symbols */
             oe_debug_notify_library_loaded(&di->base);
-            di->loaded = true;
+
+            /* add to the front of the list */
+            di->next = _debug_modules;
+            _debug_modules = di;
+        }
+        else
+        {
+            /* add to the front of the pending list */
+            di->next = _debug_modules_pending;
+            _debug_modules_pending = di;
         }
 
-        /* add to the front of the list */
-        di->next = _debug_modules;
-        _debug_modules = di;
         di = NULL;
     }
 
 done:
+    myst_spin_unlock(&_modules_lock);
 
     if (di)
         free(di);
@@ -324,14 +350,21 @@ long myst_tcall_load_symbols(void)
 {
     int ret = 0;
 
-    for (debug_module_t* p = _debug_modules; p; p = p->next)
+    myst_spin_lock(&_modules_lock);
+
+    debug_module_t* next;
+    for (debug_module_t* p = _debug_modules_pending; p; p = next)
     {
-        if (!p->loaded)
-        {
-            oe_debug_notify_library_loaded(&p->base);
-            p->loaded = true;
-        }
+        next = p->next;
+
+        oe_debug_notify_library_loaded(&p->base);
+
+        p->next = _debug_modules;
+        _debug_modules = p;
     }
+    _debug_modules_pending = NULL;
+
+    myst_spin_unlock(&_modules_lock);
 
     return ret;
 }
@@ -344,6 +377,8 @@ int myst_load_symbols_ocall(void)
 long myst_tcall_unload_symbols(void)
 {
     long ret = 0;
+
+    myst_spin_lock(&_modules_lock);
 
     for (debug_module_t* p = _debug_modules; p;)
     {
@@ -360,6 +395,7 @@ long myst_tcall_unload_symbols(void)
         p = next;
     }
 
+    myst_spin_unlock(&_modules_lock);
     return ret;
 }
 


### PR DESCRIPTION
Before this PR, some modules are added to _debug_modules but not registered
with the debugger immediately. They are later registered by traversing the list
looking for modules whose `loaded` field is false. This causes the module
list maintained by the debugger to be different from the list maintained by
Mystikos. This makes it difficult to sync the two lists when they diverge.

Whis this PR, modules that were previously added to _debug_modules list, but
not registered immediately are now added to a _debug_modules_pending list.
Later, the pending list is iterated and the modules are registered and added
to _debug_modules list. This guarantees that the _debug_modules list is
in (reverse) order of registration.

This allows features like `--goto <event>` and `restart <checkpointnum>` to work.
The developer can invoke a myst-gdb command `myst-sync-symbols` (another PR) to
force the debugger to ensure that its own list matches the _debug_modules list,
loading/removing symbols as necessary.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>