### PR TITLE
Populate /etc/hosts and /etc/hostname: Fix intermittent EAI_AGAIN cpy…

### DIFF
--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -105,22 +105,21 @@ done:
     return ret;
 }
 
-static int _copy_host_etc_files()
+static int _copy_host_etc_file(const char* path)
 {
     int ret = 0;
     int fd = -1;
-    const char* resolv_file = "/etc/resolv.conf";
     void* buf = NULL;
     size_t buf_size;
     struct stat statbuf;
 
-    ECHECK(myst_load_host_file(resolv_file, &buf, &buf_size));
+    ECHECK(myst_load_host_file(path, &buf, &buf_size));
 
-    if (stat(resolv_file, &statbuf) == 0)
+    if (stat(path, &statbuf) == 0)
     {
-        if ((myst_syscall_unlink(resolv_file)) < 0)
+        if ((myst_syscall_unlink(path)) < 0)
         {
-            myst_eprintf("kernel: failed to unlink file %s\n", resolv_file);
+            myst_eprintf("kernel: failed to unlink file %s\n", path);
             ERAISE(-EINVAL);
         }
     }
@@ -148,14 +147,14 @@ static int _copy_host_etc_files()
             }
         }
     }
-    if ((fd = creat(resolv_file, 0644)) < 0)
+    if ((fd = creat(path, 0644)) < 0)
     {
-        myst_eprintf("kernel: failed to open file %s\n", resolv_file);
+        myst_eprintf("kernel: failed to open file %s\n", path);
         ERAISE(-EINVAL);
     }
     if ((myst_write_file_fd(fd, buf, buf_size)) < 0)
     {
-        myst_eprintf("kernel: failed to write to file %s\n", resolv_file);
+        myst_eprintf("kernel: failed to write to file %s\n", path);
         ERAISE(-EINVAL);
     }
 
@@ -167,6 +166,15 @@ done:
     if (buf)
         free(buf);
 
+    return ret;
+}
+
+static int _copy_host_etc_files()
+{
+    int ret = 0;
+    ECHECK(_copy_host_etc_file("/etc/resolv.conf"));
+    ECHECK(_copy_host_etc_file("/etc/hosts"));
+done:
     return ret;
 }
 


### PR DESCRIPTION
…thon failures.

MUSL's getaddrinfo has the following logic for a given name:
1) if name exists in /etc/hosts:
     \# Super fast. local host typically is resolved thus.
     return ip address from /etc/hosts for the name

2) for each search-domain in /etc/resolv.conf:
     \# Requires network connection. Slow. Timing-sensitive.
     if dns-server successfully resolves "name.search-domain":
        return ip address returned by dns-server for "name.search-domain"

   \# Fast for a local server (127.0.0.53) since value is returned  from cache.
   \# Could be slow for a remote dns server
3) ask dns-server to resolve "localhost" and return ip address

cpython tests require resolving "localhost".

Prior to this PR, /etc/hosts is empty and resolving "localhost" required (2) or (3) above.
If search-domains were specified in /etc/resolv.conf (as is done in typical Azure VM/CI node),
then this resulted in network access and occassional timeout failures.

This PR propagates /etc/hosts and /etc/hostname from the host system, just like /etc/resolv.conf
is done currently. This ensures that, on a typical host, resolving localhost is done from
the /etc/hosts.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>