### PR TITLE
Enable test_faulthandler for 3.8 and 3.9

### DIFF
--- a/tests/cpython-tests/test_config_v3.8.11/tests.failed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.failed
@@ -10,7 +10,6 @@ test_ctypes
 test_distutils
 test_eintr
 test_embed
-test_faulthandler
 test_fcntl
 test_fileio
 test_fork1

--- a/tests/cpython-tests/test_config_v3.8.11/tests.passed
+++ b/tests/cpython-tests/test_config_v3.8.11/tests.passed
@@ -110,6 +110,7 @@ test_exception_hierarchy
 test_exception_variations
 test_exceptions
 test_extcall
+test_faulthandler
 test_file
 test_file_eintr
 test_filecmp

--- a/tests/cpython-tests/test_config_v3.9.7/tests.failed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.failed
@@ -10,7 +10,6 @@ test_ctypes
 test_distutils
 test_eintr
 test_embed
-test_faulthandler
 test_fcntl
 test_fileio
 test_fork1

--- a/tests/cpython-tests/test_config_v3.9.7/tests.passed
+++ b/tests/cpython-tests/test_config_v3.9.7/tests.passed
@@ -110,6 +110,7 @@ test_exception_hierarchy
 test_exception_variations
 test_exceptions
 test_extcall
+test_faulthandler
 test_file
 test_file_eintr
 test_filecmp


### PR DESCRIPTION
Test was relying on stack overflow handling support, which was added as part GH PR #1177

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>