### PR TITLE
Fix double unlock bug in waitpid (myst_wait)

### DIFF
--- a/include/myst/spinlock.h
+++ b/include/myst/spinlock.h
@@ -5,6 +5,7 @@
 #define _MYST_SPINLOCK_H
 
 #include <errno.h>
+#include <myst/assume.h>
 #include <myst/defs.h>
 #include <myst/types.h>
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -718,9 +718,6 @@ long myst_wait(
             ERAISE(-ECHILD);
         }
 
-        myst_spin_unlock(&myst_process_list_lock);
-        locked = false;
-
         if ((options & WNOHANG))
         {
             ret = 0;


### PR DESCRIPTION
Two calls to myst_spin_unlock(&myst_process_list_lock) were being issued
one after the other. Sometimes, the second unlock would unlock the lock
held by a child thread that is exiting resulting in threading issues.

Remove the double unlock to fix the bug.

~Additionally, add an assertion to ensure that a spinlock that is
being unlocked is in fact locked.~

spinlock assertion to be added in another PR.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>