### PR TITLE
IGNORE: Testing: 8-byte spinlocks that track the owner.

### DIFF
--- a/include/myst/spinlock.h
+++ b/include/myst/spinlock.h
@@ -4,14 +4,24 @@
 #ifndef _MYST_SPINLOCK_H
 #define _MYST_SPINLOCK_H
 
+#include <assert.h>
 #include <errno.h>
 #include <myst/defs.h>
 #include <myst/types.h>
 
-#define MYST_SPINLOCK_INITIALIZER 0
+#define MYST_SPINLOCK_INITIALIZER ((myst_spinlock_t)0)
 
 // #define MYST_SPINLOCK_BUILTINS
 #define MYST_SPINLOCK_ASSEMBLY
+
+typedef volatile uint64_t myst_spinlock_t;
+
+MYST_INLINE uint64_t __myst_spin_self(void)
+{
+    myst_spinlock_t self;
+    __asm__ volatile("mov %%fs:0, %0" : "=r"(self));
+    return self;
+}
 
 /*
 **==============================================================================
@@ -23,16 +33,19 @@
 
 #ifdef MYST_SPINLOCK_BUILTINS
 
-typedef volatile int myst_spinlock_t;
-
 MYST_INLINE void myst_spin_lock(myst_spinlock_t* s)
 {
-    while (*(volatile int*)s || __sync_val_compare_and_swap(s, 0, 1))
+    uint64_t thread_id = __myst_spin_self();
+
+    while (*s || __sync_val_compare_and_swap(s, 0, thread_id))
         __asm__ __volatile__("pause" : : : "memory");
 }
 
 MYST_INLINE void myst_spin_unlock(myst_spinlock_t* s)
 {
+    uint64_t thread_id = __myst_spin_self();
+    assert(*spinlock == thread_id);
+
     __sync_lock_test_and_set(s, 0);
 }
 
@@ -48,24 +61,31 @@ MYST_INLINE void myst_spin_unlock(myst_spinlock_t* s)
 
 #ifdef MYST_SPINLOCK_ASSEMBLY
 
-typedef volatile int myst_spinlock_t;
-
 MYST_INLINE void myst_spin_lock(myst_spinlock_t* spinlock)
 {
+    uint64_t thread_id = __myst_spin_self();
+
     for (;;)
     {
-        unsigned int previous_value = 1;
+        uint64_t previous_value;
 
-        /* Set the spinlock value to 1 and save the previous value */
-        asm volatile("lock xchg %0, %1;"
-                     : "=r"(previous_value) /* %0 */
+        /* Set spinlock to thread_id if it is equal to RAX (zero). */
+        asm volatile("lock cmpxchg %2, %1;"
+                     : "=a"(previous_value) /* %0 RAX */
                      : "m"(*spinlock),      /* %1 */
-                       "0"(previous_value)  /* %2 */
-                     : "memory");
+                       "r"(thread_id),      /* %2 */
+                       "a"(0L)              /* %3 RAX */
+                     : "memory", "cc");
 
         /* If the spinlock was unlocked then break out */
         if (previous_value == 0)
             break;
+
+        // Detect recursive calls.
+        {
+            bool recursive_spin_lock_call = (previous_value == thread_id);
+            assert(!recursive_spin_lock_call);
+        }
 
         /* Spin while waiting for spinlock to be released */
         while (*spinlock)
@@ -78,9 +98,12 @@ MYST_INLINE void myst_spin_lock(myst_spinlock_t* spinlock)
 
 MYST_INLINE void myst_spin_unlock(myst_spinlock_t* spinlock)
 {
-    asm volatile("movl %0, %1;"
-                 :
-                 : "r"(MYST_SPINLOCK_INITIALIZER), "m"(*spinlock) /* %1 */
+    uint64_t thread_id = __myst_spin_self();
+    assert(*spinlock == thread_id);
+
+    asm volatile("movq %1, %0;"
+                 : "=m"(*spinlock)
+                 : "c"(MYST_SPINLOCK_INITIALIZER)
                  : "memory");
 }
 

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -211,7 +211,11 @@ int myst_mutex_destroy(myst_mutex_t* mutex)
     {
         if (myst_thread_queue_empty(&m->queue))
         {
-            memset(m, 0, sizeof(myst_mutex_t));
+            // Clear all fields except the lock which will be cleared by
+            // unlocking below.
+            m->refs = 0;
+            m->owner = NULL;
+            memset(&m->queue, 0, sizeof(m->queue));
         }
         else
         {
@@ -219,7 +223,6 @@ int myst_mutex_destroy(myst_mutex_t* mutex)
         }
     }
     myst_spin_unlock(&m->lock);
-
     return ret;
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -718,9 +718,6 @@ long myst_wait(
             ERAISE(-ECHILD);
         }
 
-        myst_spin_unlock(&myst_process_list_lock);
-        locked = false;
-
         if ((options & WNOHANG))
         {
             ret = 0;


### PR DESCRIPTION
Also use GS for maintaining recursive spinlocks since GS
is not expected to be changed by the application

Used for
- Detecting correct ownership during an unlock
- FS change across a lock/unlock would assert

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>