### PR TITLE
Switch to OE master

### DIFF
--- a/solutions/pytorch_tests/Makefile
+++ b/solutions/pytorch_tests/Makefile
@@ -111,7 +111,7 @@ and not test_cross_entropy_loss_precision \
 and not test_l1_loss_correct"
 run-test-nn: rootfs
 	$(RUN_PYTEST) /workspace/pytorch/test/test_nn.py -k $(EXCLUDE_TESTS) 2>&1 | tee $@.out
-	grep -q -E '1325 passed.*1435 skipped.*42 deselected.*3 xfailed' $@.out
+	grep -q -E '1323 passed.*1437 skipped.*42 deselected.*3 xfailed' $@.out
 
 .PHONY: run-test-nn-8g
 run-test-nn-8g: EXCLUDE_TESTS = "test_avg_pool2d_nhwc_cpu_float32 \

--- a/solutions/pytorch_tests/README.md
+++ b/solutions/pytorch_tests/README.md
@@ -26,7 +26,7 @@ PyTorch validation are run against the Python [Unit Tests](https://github.com/py
 
 ### 3. test_nn.py - Tests for NN operators and their automatic differentiation.
 - **host**: 1361 passed, 1441 skipped, 3 xfailed, 138 warnings
-- **myst**: 29 failed, 1331 passed, 1435 skipped, 35 deselected, 3 xfailed, 138 warnings
+- **myst**: 29 failed, 1323 passed, 1437 skipped, 42 deselected, 3 xfailed, 138 warnings
 
 | #  | NAME  | ROOT CAUSE  |
 |---|---|---|

--- a/tests/gdb/Makefile
+++ b/tests/gdb/Makefile
@@ -14,7 +14,7 @@ GDB_CMDS=--batch \
 	-ex "backtrace" \
 	--args
 
-GDB_MATCH=Breakpoint 2, .................. in print_hello ()
+GDB_MATCH=Breakpoint 1, .................. in print_hello ()
 
 # runtest timeouts cause gdb to hang
 export NOTIMEOUT=1

--- a/third_party/openenclave/Makefile
+++ b/third_party/openenclave/Makefile
@@ -5,7 +5,8 @@ TOP=$(abspath $(CURDIR)/../..)
 BUILDDIR=${TOP}/build
 
 URL=https://github.com/openenclave/openenclave
-BRANCH=mystikos.v6
+BRANCH=master
+COMMIT=01fb810da80794a8bb221f4905de6c0a7138bb44
 
 OPENENCLAVE_INSTALL_PREFIX=$(BUILDDIR)/openenclave
 OPENENCLAVE_SRC = $(CURDIR)/openenclave
@@ -57,13 +58,15 @@ $(TOP)/build/bin/myst-lldb:
 FETCH_SUBMODULE = git submodule update --init --progress
 
 openenclave:
-	git clone $(URL) -b $(BRANCH)
+	git clone $(URL)
+	( cd openenclave; git checkout $(COMMIT) )
 	( cd openenclave; $(FETCH_SUBMODULE) tools/oeedger8r-cpp )
 	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/musl/musl )
 	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/mbedtls/mbedtls )
 	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/openssl/openssl )
 	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/openssl/intel-sgx-ssl )
 	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/snmalloc )
+	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/symcrypt_engine/SymCrypt-OpenSSL )
 
 configure_oe: $(OPENENCLAVE_BUILD)/Makefile
 
@@ -87,9 +90,11 @@ $(OPENENCLAVE_BUILD)/Makefile:
 
 install_oe:
 	$(MAKE) -C $(OPENENCLAVE_BUILD) install
+	cp ${OPENENCLAVE_BUILD}/output/lib/openenclave/host/liboesign.a ${TOP}/build/openenclave/lib/openenclave/host
 ifdef MYST_USE_BUILD_CACHE
 	rm -rf $(CACHE)
 	$(MAKE) -C $(OPENENCLAVE_BUILD) install DESTDIR=$(CACHE_DIR)/tmp
+	cp ${OPENENCLAVE_BUILD}/output/lib/openenclave/host/liboesign.a ${CACHE_DIR}/tmp/${OPENENCLAVE_INSTALL_PREFIX}/lib/openenclave/host
 	mv $(CACHE_DIR)/tmp/$(OPENENCLAVE_INSTALL_PREFIX) $(CACHE)
 	rm -rf $(CACHE_DIR)/tmp
 endif

--- a/tools/myst/config.h
+++ b/tools/myst/config.h
@@ -23,15 +23,9 @@
 
 #define ENCLAVE_SECURITY_VERSION 1
 
-#define ENCLAVE_EXTENDED_PRODUCT_ID \
-    {                               \
-        0                           \
-    }
+#define ENCLAVE_EXTENDED_PRODUCT_ID ({0})
 
-#define ENCLAVE_FAMILY_ID \
-    {                     \
-        0                 \
-    }
+#define ENCLAVE_FAMILY_ID ({0})
 
 #define ENCLAVE_DEBUG true
 

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -59,6 +59,16 @@
 /* TODO: Make it configurable through json */
 #define CLOCK_TICK 1000
 
+/* forward declarations of the OE data type and internal API */
+typedef oe_result_t (
+    *oe_load_extra_enclave_data_hook_t)(void* arg, uint64_t baseaddr);
+
+void oe_register_load_extra_enclave_data_hook(
+    oe_load_extra_enclave_data_hook_t hook);
+
+/* forward declaration of the hook implemented in regions_sgx.c */
+oe_result_t myst_load_extra_enclave_data_hook(void* arg, uint64_t baseaddr);
+
 static struct myst_shm shared_memory = {0};
 
 /* wait for so many milliseconds */
@@ -245,6 +255,9 @@ int exec_launch_enclave(
 
         settings[num_settings++] = setting;
     }
+
+    /* Register the hook */
+    oe_register_load_extra_enclave_data_hook(myst_load_extra_enclave_data_hook);
 
     /* Load the enclave: calls oe_load_extra_enclave_data_hook() */
 #ifndef SUPPRESS_SWITCHLESS

--- a/tools/myst/host/host.c
+++ b/tools/myst/host/host.c
@@ -38,6 +38,10 @@
 #include "sign.h"
 #include "utils.h"
 
+/* forward declarations of OE internal APIs */
+void oe_debug_module_loaded_hook(oe_debug_module_t* module);
+void oe_debug_module_unloaded_hook(oe_debug_module_t* module);
+
 _Static_assert(sizeof(struct myst_timespec) == sizeof(struct timespec), "");
 
 typedef struct debug_module
@@ -92,29 +96,15 @@ void myst_cpuid_ocall(
     __cpuid_count(leaf, subleaf, *rax, *rbx, *rcx, *rdx);
 }
 
-OE_EXPORT
-OE_NEVER_INLINE
-void oe_notify_debugger_library_load(oe_debug_module_t* module)
-{
-    OE_UNUSED(module);
-}
-
-OE_EXPORT
-OE_NEVER_INLINE
-void oe_notify_debugger_library_unload(oe_debug_module_t* module)
-{
-    OE_UNUSED(module);
-}
-
 oe_result_t oe_debug_notify_library_loaded(oe_debug_module_t* module)
 {
-    oe_notify_debugger_library_load(module);
+    oe_debug_module_loaded_hook(module);
     return OE_OK;
 }
 
 oe_result_t oe_debug_notify_library_unloaded(oe_debug_module_t* module)
 {
-    oe_notify_debugger_library_unload(module);
+    oe_debug_module_unloaded_hook(module);
     return OE_OK;
 }
 

--- a/tools/myst/host/regions_linux.c
+++ b/tools/myst/host/regions_linux.c
@@ -3,8 +3,6 @@
 
 #include <myst/errno.h>
 #include <myst/regions.h>
-#include <openenclave/bits/sgx/sgxextra.h>
-#include <openenclave/bits/sgx/sgxtypes.h>
 #include "regions.h"
 #include "utils.h"
 

--- a/tools/myst/host/regions_sgx.c
+++ b/tools/myst/host/regions_sgx.c
@@ -1,10 +1,17 @@
 #include <myst/eraise.h>
 #include <myst/errno.h>
 #include <myst/regions.h>
-#include <openenclave/bits/sgx/sgxextra.h>
 #include <openenclave/bits/sgx/sgxtypes.h>
 #include "regions.h"
 #include "utils.h"
+
+/* forward declaration of the OE internal API */
+oe_result_t oe_load_extra_enclave_data(
+    void* arg,
+    uint64_t vaddr,
+    const void* page,
+    uint64_t flags,
+    bool extend);
 
 void* __image_data;
 size_t __image_size;
@@ -35,7 +42,7 @@ static int _add_page(void* arg, uint64_t vaddr, const void* page, int flags)
     return 0;
 }
 
-oe_result_t oe_load_extra_enclave_data_hook(void* arg, uint64_t baseaddr)
+oe_result_t myst_load_extra_enclave_data_hook(void* arg, uint64_t baseaddr)
 {
     add_regions(arg, baseaddr, _add_page);
     return OE_OK;

--- a/tools/myst/host/sign.c
+++ b/tools/myst/host/sign.c
@@ -37,6 +37,16 @@ int oesign(
     const char* engine_load_path,
     const char* key_id);
 
+/* forward declarations of the OE data type and internal API */
+typedef oe_result_t (
+    *oe_load_extra_enclave_data_hook_t)(void* arg, uint64_t baseaddr);
+
+void oe_register_load_extra_enclave_data_hook(
+    oe_load_extra_enclave_data_hook_t hook);
+
+/* forward declaration of the hook implemented in regions_sgx.c */
+oe_result_t myst_load_extra_enclave_data_hook(void* arg, uint64_t baseaddr);
+
 #define USAGE_SIGN \
     "\
 \n\
@@ -463,6 +473,9 @@ int _sign(int argc, const char* argv[])
     // oesign(). This suppresses the "Created <tempfile>" message, which
     // conveys nothing useful to the user.
     freopen("/dev/null", "a+", stdout);
+
+    /* Register the hook */
+    oe_register_load_extra_enclave_data_hook(myst_load_extra_enclave_data_hook);
 
     if (oesign(
             scratch_path,

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -4,6 +4,8 @@ enclave
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import oe_syscall_writev_ocall;
     from "openenclave/edl/fcntl.edl" import oe_syscall_dup_ocall;
+    from "openenclave/edl/fcntl.edl" import oe_syscall_readv_ocall;
+    from "openenclave/edl/fcntl.edl" import oe_syscall_close_ocall;
 
     include "time.h"
     include "sys/socket.h"


### PR DESCRIPTION
With the upstreaming Mystikos-dependent OE feature completed, This PR switches from Mystikos OE branch to OE master.
This changes on the Mystikos-side is as follows:
- Making sure to use the OE-default FS register before returning to OE (i.e., making ocall).
- Use the new `oe_register_load_extra_enclave_data_hook` API for regions support
- Replace the duplicated `oe_notify_debugger_library_load` by `oe_debug_module_loaded_hook` in the OE debugger contract.


Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>