### PR TITLE
Fix gcov-related build error in mount-docker-image

### DIFF
--- a/tools/mount-docker-image/Makefile
+++ b/tools/mount-docker-image/Makefile
@@ -10,6 +10,18 @@ INCLUDES = -I$(INCDIR)
 
 CFLAGS = $(DEFAULT_CFLAGS)
 
+ifdef MYST_ENABLE_GCOV
+DEFINES += -DMYST_ENABLE_GCOV
+endif
+
+ifdef MYST_ENABLE_GCOV
+CFLAGS += $(GCOV_CFLAGS)
+endif
+
+ifdef MYST_ENABLE_GCOV
+LIBS += $(LIBDIR)/libmystgcovserver.a
+endif
+
 LIBS += $(LIBDIR)/libjson.a
 LIBS += $(LIBDIR)/libmystutils.a
 LIBS += $(LIBDIR)/libmysthost.a


### PR DESCRIPTION
This PR fixes a build error (missing gcov-related symbols) in mount-docker-image. This PR fixes the build for both Ubuntu 18.04 and 20.04.

Note: we still saw periodic errors with gcov enabled in solutions but this PR should be merged to at least fix the build errors.