### PR TITLE
Upgrade flask version

### DIFF
--- a/solutions/python_flask_tests/Dockerfile
+++ b/solutions/python_flask_tests/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.9-slim
 WORKDIR /app
 
 RUN apt update && apt install -y git
-# Checkout a stable build of Flask as of Sept. 2021
-RUN git clone https://github.com/pallets/flask && cd flask && git checkout 6f852d0d22a9be486f3881d500ae83292a76cd46
+# Checkout v2.1.0
+RUN git clone https://github.com/pallets/flask && cd flask && git checkout 65b0eef303dfec6b7baa66ff34253e0285e1c3bf
 
 WORKDIR /app/flask
 


### PR DESCRIPTION
Older version of Flask is using a dependency that had breaking change:
https://stackoverflow.com/questions/71661851/typeerror-init-got-an-unexpected-keyword-argument-as-tuple