### PR TITLE
Remove the relaxation of badaddr check

### DIFF
--- a/include/myst/config.h
+++ b/include/myst/config.h
@@ -26,6 +26,6 @@
 
 /* enable to relax the bad addr check (only check if the address is within
  * enclave memory region) */
-#define MYST_RELAX_BAD_ADDR_CHECK
+//#define MYST_RELAX_BAD_ADDR_CHECK
 
 #endif /* _MYST_CONFIG_H */

--- a/include/myst/defs.h
+++ b/include/myst/defs.h
@@ -10,6 +10,8 @@
 
 #define MYST_INLINE static __inline__
 
+#define MYST_INTERNAL static
+
 #define MYST_WEAK __attribute__((weak))
 
 #define MYST_NORETURN __attribute__((__noreturn__))

--- a/include/myst/syscall.h
+++ b/include/myst/syscall.h
@@ -206,8 +206,6 @@ long myst_syscall_load_symbols(void);
 
 long myst_syscall_unload_symbols(void);
 
-long myst_syscall_clock_getres(clockid_t clk_id, struct timespec* res);
-
 long myst_syscall_clock_gettime(clockid_t clk_id, struct timespec* tp);
 
 long myst_syscall_clock_settime(clockid_t clk_id, struct timespec* tp);


### PR DESCRIPTION
The detail of the PR is as follows:
- Remove the relaxation of badaddr check introduced in #1039 given  issue with using kstack during the user signal handler was fixed by #1177.
- Ensure the badaddr checks are only enforced in the code path through the syscall interface, avoiding invoking the checks from the kernel.
- Introduce `MYST_INTERNAL` annotation that helps reasoning whether a `myst_` function is private or public to the kernel.


Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>