### PR TITLE
Add runtest wrapper to cpython tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ alltests:
 
 solutions_tests:
 	$(MAKE) -C solutions tests RUNTEST=$(RUNTEST_COMMAND)
-	@ $(MAKE) -s summary
+	@ TESTDIR=$(BUILDDIR)/solutions $(MAKE) -s summary
 
 ##==============================================================================
 ##

--- a/scripts/runtest
+++ b/scripts/runtest
@@ -1,5 +1,33 @@
 #!/bin/bash
 
+# Usage of this script from Makefiles:
+# TESTNAME and TESTDIR is setup by defs.mak.
+#
+# TOP is the top-level directory of mystikos repository.
+#
+# TESTDIR is $(TOP)/build/tests by default. It should be specified explicity if running tests
+# from a different directory.
+#
+# TESTNAME is the relative directory path of the Makefile invoking runtest. Its relative to TOP.
+# TESTNAME may additionally have a suffix, which can be specified via TESTSUFFIX.
+# This is used by tests/Makefile to differentiate between sgx and linux target runs.
+#
+# If there are multiple subtests under directory pointed by TESTNAME,
+# SUBTEST can be used to differentiate between them. If not specified,
+# its computed by "cmd##*/". This treats the command passed to runtest as a path,
+# and computes the basepath, i.e the substring after the last "/" in cmd.
+#
+# For eg:
+#
+# If pwd is $(HOME)/mystikos/tests/ltp
+# And runtest is invoked with:
+# $(RUNTEST) $(MYST_EXEC) rootfs /ltp/testcases/kernel/syscalls/bind/bind01
+#
+# TOP = $(HOME)/mystikos
+# TESTDIR = $(HOME)/mystikos/build/tests
+# TESTNAME = tests/ltp (assuming no TESTSUFFIX)
+# SUBTEST = bind01
+
 if [ "$#" == "0" ]; then
     echo "Usage: $0 <test> <args...>"
     exit 1
@@ -85,18 +113,18 @@ run_test()
     else
         local subtest="${SUBTEST}"
     fi
+
     echo -e "${lightblue}=== start (${TESTNAME}/${subtest})${reset}"
 
-    local tempfile=$(/bin/mktemp)
-
-    # run the test
     if [ -z "${NOTIMEOUT}" ]; then
         timeout_command="/usr/bin/timeout ${timeout}"
     else
         timeout_command=
     fi
 
-    # save the test start time in a temporary file
+    # write resource statistics in a temporary file
+    # %e format specifies we are only interested in elapsed wall clock time(in seconds).
+    local tempfile=$(/bin/mktemp)
     time_command="/usr/bin/time -f "%e" --quiet -o ${tempfile}"
 
     # run the test
@@ -108,6 +136,7 @@ run_test()
     seconds=$(cat ${tempfile})
     rm -f ${tempfile}
 
+    # record test run status
     if [ "${ret}" == "0" ]; then
         test_passed $cmd
         echo -e "${lightblue}    ${seconds} seconds${reset}"

--- a/solutions/Makefile
+++ b/solutions/Makefile
@@ -53,7 +53,7 @@ remove_appdir =
 endif
 
 run:
-	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) run; $(call remove_appdir,$(i)) $(NL) )
+	@ $(foreach i, $(DIRS), TESTDIR=$(BUILDDIR)/solutions $(MAKE) -C $(i) run; $(call remove_appdir,$(i)) $(NL) )
 
 tests:
 	@ $(MAKE) -s clean

--- a/solutions/cpython-tests/Makefile
+++ b/solutions/cpython-tests/Makefile
@@ -64,21 +64,21 @@ ifdef MYST_NIGHTLY_TEST
 endif
 
 run-3.8: ext2fs3.8
-	$(MYST_EXEC) $(OPTS) ext2fs3.8 /cpython/python -m test -f /$(TESTFILE) --timeout 120 -v
+	SUBTEST=$(TESTFILE)-3.8 $(RUNTEST) $(MYST_EXEC) $(OPTS) ext2fs3.8 /cpython/python -m test -f /$(TESTFILE) --timeout 120 -v
 	$(foreach i, $(TEST_RUN_INDIVIDUAL_3_8), $(MAKE) one FS=ext2fs3.8 TEST=$(i) $(NL) )
 
 run-3.9: ext2fs3.9
-	$(MYST_EXEC) $(OPTS) ext2fs3.9 /cpython/python -m test -f /$(TESTFILE) --timeout 120 -v
+	SUBTEST=$(TESTFILE)-3.9 $(RUNTEST) $(MYST_EXEC) $(OPTS) ext2fs3.9 /cpython/python -m test -f /$(TESTFILE) --timeout 120 -v
 	$(foreach i, $(TEST_RUN_INDIVIDUAL_3_9), $(MAKE) one FS=ext2fs3.9 TEST=$(i) $(NL) )
 
 run-3.10: ext2fs3.10
-	$(MYST_EXEC) --app-config-path config-3.10.json ext2fs3.10 /cpython/python -m test -f /$(TESTFILE) --timeout 120 -v
+	SUBTEST=$(TESTFILE)-3.10 $(RUNTEST) $(MYST_EXEC) --app-config-path config-3.10.json ext2fs3.10 /cpython/python -m test -f /$(TESTFILE) --timeout 120 -v
 	$(foreach i, $(TEST_RUN_INDIVIDUAL_3_10), $(MAKE) one FS=ext2fs3.10 TEST=$(i) $(NL) )
 
-one: $(FS)
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m test $(TEST) -v
+one:
+	SUBTEST=$(TEST)-$(FS) $(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m test $(TEST) -v
 
-one-mpdb: $(FS)
+one-mpdb:
 	killall myst 2> /dev/null || echo ""
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m mpdb -m test $(TEST) -v &
 	sleep 15 # Increase this value in Makefile if connection fails
@@ -86,7 +86,7 @@ one-mpdb: $(FS)
 	# Once debugger prompt is available, do
 	# (Pdb) b /cpython/Lib/test/<test file>.py:line
 
-one-gdb: $(FS)
+one-gdb:
 	$(RUNTEST) $(MYST_GDB) -iex "source ./appdir$(VER)/cpython/python-gdb.py" \
            -iex "python print('\033[0;32m\n\
 type py-<tab> to see available python-gdb commands.\n\n\
@@ -96,10 +96,10 @@ To enable python source listing, do \n\
 before launching gdb.\033[0m\n')" \
            --args $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m test $(TEST) -v
 
-testcase: $(FS)
+testcase:
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(FS) /cpython/python -m unittest Lib.test.$(TESTCASE) -v
 
-testcase-gdb: $(FS)
+testcase-gdb:
 	$(RUNTEST) $(MYST_GDB) -iex "source ./appdir$(VER)/cpython/python-gdb.py" \
            -iex "python print('\033[0;32m\n\
 type py-<tab> to see available python-gdb commands.\n\n\


### PR DESCRIPTION
Without runtest, cpython failures cause skipping of rest of the tests under solutions/.
PR also removes $(FS) dependency for the dev targets. The dependency is causing the rootfs to be regenerated. 

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>