### PR TITLE
fix missing patch

### DIFF
--- a/tests/libcxx2/Makefile
+++ b/tests/libcxx2/Makefile
@@ -22,6 +22,7 @@ LIBCXX_TESTS_DIR=llvm-project/libcxx/test/
 ALLTESTS=tests.all
 export TIMEOUT=10000
 OPTS += --nobrk
+OPTS += --thread-stack-size 1048576
 
 all:
 	$(MAKE) myst

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -641,6 +641,18 @@ index 01e19c59..30a9e3cb 100644
 +
 +	return values[name];
  }
+
+diff --git a/src/errno/__strerror.h b/src/errno/__strerror.h
+index 2f04d400..7905ce1b 100644
+--- a/src/errno/__strerror.h
++++ b/src/errno/__strerror.h
+@@ -102,4 +102,4 @@ E(ENOMEDIUM,    "No medium found")
+ E(EMEDIUMTYPE,  "Wrong medium type")
+ E(EMULTIHOP,    "Multihop attempted")
+
+-E(0,            "No error information")
++E(0,            "Unknown error")
+
 diff --git a/src/exit/_Exit.c b/src/exit/_Exit.c
 index 7a6115c7..9f715d51 100644
 --- a/src/exit/_Exit.c


### PR DESCRIPTION
This patch fixes the libcxx test /app/llvm-project/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp.exe