### PR TITLE
Remove fd type check in fpathconf

### DIFF
--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -552,7 +552,7 @@ index 02cb1aa2..07e76f19 100644
  		errno = EINVAL;
  		return 0;
 diff --git a/src/conf/fpathconf.c b/src/conf/fpathconf.c
-index e6aca5cf..d7392ced 100644
+index e6aca5cf..a4ed5482 100644
 --- a/src/conf/fpathconf.c
 +++ b/src/conf/fpathconf.c
 @@ -1,6 +1,7 @@
@@ -563,7 +563,7 @@ index e6aca5cf..d7392ced 100644
  
  long fpathconf(int fd, int name)
  {
-@@ -31,5 +32,20 @@ long fpathconf(int fd, int name)
+@@ -31,5 +32,15 @@ long fpathconf(int fd, int name)
  		errno = EINVAL;
  		return -1;
  	}
@@ -575,20 +575,15 @@ index e6aca5cf..d7392ced 100644
 +		if (fstat(fd, &buf) == -1) {
 +			return -1;
 +		}
-+		// Should be directory
-+		if (!S_ISDIR(buf.st_mode)) {
-+			errno = EBADF;
-+			return -1;
-+		}
 +	}
 +
  	return values[name];
  }
 diff --git a/src/conf/pathconf.c b/src/conf/pathconf.c
-index 01e19c59..30a9e3cb 100644
+index 01e19c59..11084aee 100644
 --- a/src/conf/pathconf.c
 +++ b/src/conf/pathconf.c
-@@ -1,6 +1,51 @@
+@@ -1,6 +1,46 @@
  #include <unistd.h>
 +#include <limits.h>
 +#include <errno.h>
@@ -630,11 +625,6 @@ index 01e19c59..30a9e3cb 100644
 +	if (name == _PC_NAME_MAX) {
 +		struct stat buf;
 +		if (stat(path, &buf) == -1) {
-+			return -1;
-+		}
-+		// Should be directory
-+		if (!S_ISDIR(buf.st_mode)) {
-+			errno = EBADF;
 +			return -1;
 +		}
 +	}


### PR DESCRIPTION
This type check is not necessary and causing LTP test case to fail:
make one TEST=/ltp/testcases/kernel/syscalls/fpathconf/fpathconf01

With this PR, LTP test would pass:
```
make one TEST=/ltp/testcases/kernel/syscalls/fpathconf/fpathconf01
sudo -E   /home/zijiewu/code/fork_mystikos/build/bin/myst exec-sgx --app-config-path config.json ext2fs /ltp/testcases/kernel/syscalls/fpathconf/fpathconf01 
[sudo] password for zijiewu: 
fpathconf01    1  TPASS  :  fpathconf(fd, _PC_MAX_CANON) returned 255
fpathconf01    2  TPASS  :  fpathconf(fd, _PC_MAX_INPUT) returned 255
fpathconf01    3  TPASS  :  fpathconf(fd, _PC_VDISABLE) returned 0
fpathconf01    4  TPASS  :  fpathconf(fd, _PC_LINK_MAX) returned 8
fpathconf01    5  TPASS  :  fpathconf(fd, _PC_NAME_MAX) returned 255
fpathconf01    6  TPASS  :  fpathconf(fd, _PC_PATH_MAX) returned 4096
fpathconf01    7  TPASS  :  fpathconf(fd, _PC_PIPE_BUF) returned 4096
fpathconf01    8  TPASS  :  fpathconf(fd, _PC_CHOWN_RESTRICTED) returned 1
fpathconf01    9  TPASS  :  fpathconf(fd, _PC_NO_TRUNC) returned 1
```