### PR TITLE
Appbuilder: Retry stopping of container

### DIFF
--- a/scripts/appbuilder
+++ b/scripts/appbuilder
@@ -222,7 +222,7 @@ export_image()
     
     docker image inspect --format='{{json .Config}}' $IMAGE_NAME > $TEMP_APPENV
 
-    docker stop $TEMP_INAME >/dev/null
+    $(dirname $0)/myst-retry docker stop $TEMP_INAME >/dev/null
     docker export $TEMP_INAME -o $TEMP_FILE
     docker rm $TEMP_INAME >/dev/null
     if [ -z $DELETE_IMAGE ]; then


### PR DESCRIPTION
Based on following error message, it looks like docker stop is not
always successful:

```
Error response from daemon: cannot stop container: <container-hash>: tried to kill container, but did not receive an exit event
```
Retrying 5 times with backoff of 1,2,4,8,16 seconds.

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>