### PR TITLE
Mount docker image's overlayfs to get appdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 *lcov*
 *.gc*
 
+appenv.json*
+*/*/appenv.json*
+*/*/*/appenv.json*
 third_party/musl/musl/lib
 third_party/enclave-musl/musl/lib/
 **/*.signed/*

--- a/samples/go/Dockerfile
+++ b/samples/go/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine
 
 RUN mkdir /app
 
-COPY hello.go /app
+COPY src/hello.go /app
 
 RUN apk add build-base
 

--- a/samples/go/Makefile
+++ b/samples/go/Makefile
@@ -5,12 +5,11 @@ APPBUILDER=$(TOP)/scripts/appbuilder
 
 all: rootfs
 
-rootfs: Dockerfile
-	mkdir -p mntdir
-	docker build --quiet --iidfile .iid -f Dockerfile src
-	$(BINDIR)/mount-docker-image .iid mntdir | xargs sudo
-	sudo $(MYST) mkext2 --force mntdir rootfs
-	sudo umount mntdir
+appdir: Dockerfile
+	$(APPBUILDER) -m Dockerfile
+
+rootfs: appdir
+	$(MYST) mkext2 --force appdir rootfs
 
 OPTS =
 OPTS += --thread-stack-size=1m
@@ -27,4 +26,4 @@ ifeq ($(SGX2_PRESENT),1)
 endif
 
 clean:
-	rm -rf appdir rootfs .iid mntdir
+	rm -rf appdir rootfs

--- a/scripts/appbuilder
+++ b/scripts/appbuilder
@@ -37,6 +37,25 @@ function print_usage {
     echo
 }
 
+# Please add appropriate cleanup actions here for any new resources created in this script
+function cleanup()
+{
+    # this is a catchall, ignore errors
+    set +e
+    [ -f $TEMP_IMAGE_IIDFILE ] && rm $TEMP_IMAGE_IIDFILE
+    [ -d $EXTRACTED_ROOTFS_DIR ] && rm -rf $EXTRACTED_ROOTFS_DIR
+    if $USE_MOUNT; then
+        if [ -d $MNT_PNT_DIR ]; then
+            sudo umount $MNT_PNT_DIR
+            rm -rf $MNT_PNT_DIR
+        fi
+    else
+        [ -f $EXPORTED_IMG_TAR ] && rm $EXPORTED_IMG_TAR
+    fi
+
+}
+
+trap cleanup EXIT
 
 while getopts 'hvmd:i:f:o:e:' OPTION; do
     case "$OPTION" in
@@ -90,7 +109,7 @@ fi
 OUTPUT_NAME=${OUTPUT_NAME:-appdir}
 DELETE_OUTPUT=${DELETE_OUTPUT:-false}
 OUTPUT_FORMAT=${OUTPUT_FORMAT:-dir}
-TEMP_IMAGE_IIDFILE=$(mktemp /tmp/myst.XXXXXX)
+TEMP_IMAGE_IIDFILE=$(mktemp -t myst-iid.XXXXXX)
 NETWORK_NAME=$(basename ${PWD})-$(head /dev/urandom | tr -dc 'a-z0-9' | head -c 10)
 DOCKER_RETRIES=3
 
@@ -218,7 +237,7 @@ export_via_overlayfs_mount()
     LOWER_DIR=$(docker image inspect --format='{{json .GraphDriver.Data.LowerDir}}' $IMAGE_NAME | tr -d '"')
     UPPER_DIR=$(docker image inspect --format='{{json .GraphDriver.Data.UpperDir}}' $IMAGE_NAME | tr -d '"')
     WORK_DIR=$(docker image inspect --format='{{json .GraphDriver.Data.WorkDir}}' $IMAGE_NAME | tr -d '"')
-    MNT_PNT_DIR=$(mktemp -d)
+    MNT_PNT_DIR=$(mktemp -d -t myst-mntpnt.XXXXXX)
 
     sudo mount -t overlay overlay -olowerdir=$LOWER_DIR,upperdir=$UPPER_DIR,workdir=$WORK_DIR $MNT_PNT_DIR
     # change ownership back to current effective user and group
@@ -239,8 +258,8 @@ export_via_overlayfs_mount()
 
 export_via_docker_export()
 {
-    EXPORTED_IMG_TAR=$(mktemp)
-    EXTRACTED_ROOTFS_DIR=$(mktemp -d)
+    EXPORTED_IMG_TAR=$(mktemp -t myst-img-tar.XXXXXX)
+    EXTRACTED_ROOTFS_DIR=$(mktemp -d -t myst-rootfs-dir.XXXXXX)
 
     # note that we have to start up the image to flatten it
     TEMP_INAME=$(docker run -d $IMAGE_NAME)

--- a/scripts/appbuilder
+++ b/scripts/appbuilder
@@ -16,6 +16,7 @@ function print_usage {
     echo "  -e extras   Specify the extra options while building the container image"
     echo "  -o      Specify the name of the output file or directory"
     echo "          If not specified, defaults to 'appdir'"
+    echo "  -m      Export docker image by mount. This is faster but requires sudo."
     echo "  -v      Verbose"
     echo "  -h      Print this help message"
     echo
@@ -37,7 +38,7 @@ function print_usage {
 }
 
 
-while getopts 'hvd:i:f:o:e:' OPTION; do
+while getopts 'hvmd:i:f:o:e:' OPTION; do
     case "$OPTION" in
         d )
             DOCKER_FILE=${OPTARG:-Dockerfile}
@@ -62,6 +63,9 @@ while getopts 'hvd:i:f:o:e:' OPTION; do
             VERBOSE=true;
             QUIET=false;
             set -x
+            ;;
+        m )
+            USE_MOUNT=true;
             ;;
         * )
             print_usage;
@@ -209,37 +213,73 @@ get_image()
     fi
 }
 
-# export a flattened copy of the container
-export_image()
+export_via_overlayfs_mount()
 {
-    TEMP_FILE=$(mktemp)
-    TEMP_DIR=$(mktemp -d)
-    APPENV_FILENAME="appenv.json"
+    LOWER_DIR=$(docker image inspect --format='{{json .GraphDriver.Data.LowerDir}}' $IMAGE_NAME | tr -d '"')
+    UPPER_DIR=$(docker image inspect --format='{{json .GraphDriver.Data.UpperDir}}' $IMAGE_NAME | tr -d '"')
+    WORK_DIR=$(docker image inspect --format='{{json .GraphDriver.Data.WorkDir}}' $IMAGE_NAME | tr -d '"')
+    MNT_PNT_DIR=$(mktemp -d)
+
+    sudo mount -t overlay overlay -olowerdir=$LOWER_DIR,upperdir=$UPPER_DIR,workdir=$WORK_DIR $MNT_PNT_DIR
+    # change ownership back to current effective user and group
+    sudo chown -R $USER:$(id -ng) $MNT_PNT_DIR
+
+    # copy appenv.json
+    mv $TEMP_APPENV $MNT_PNT_DIR/appenv.json
+
+    if [ "$OUTPUT_FORMAT" == "dir" ]; then
+        cp -r $MNT_PNT_DIR $OUTPUT_NAME
+    elif [ "$OUTPUT_FORMAT" == "cpio" ]; then
+        myst mkcpio $MNT_PNT_DIR $OUTPUT_NAME
+    fi
+
+    sudo umount $MNT_PNT_DIR
+    rm -rf $MNT_PNT_DIR
+}
+
+export_via_docker_export()
+{
+    EXPORTED_IMG_TAR=$(mktemp)
+    EXTRACTED_ROOTFS_DIR=$(mktemp -d)
 
     # note that we have to start up the image to flatten it
     TEMP_INAME=$(docker run -d $IMAGE_NAME)
-    TEMP_APPENV=$APPENV_FILENAME-$TEMP_INAME
-    
-    docker image inspect --format='{{json .Config}}' $IMAGE_NAME > $TEMP_APPENV
-
     docker stop $TEMP_INAME >/dev/null
-    docker export $TEMP_INAME -o $TEMP_FILE
+    docker export $TEMP_INAME -o $EXPORTED_IMG_TAR
     docker rm $TEMP_INAME >/dev/null
     if [ -z $DELETE_IMAGE ]; then
         docker rmi -f $IMAGE_NAME
     fi
 
-    # create the 'appdir' from the docker export
-    tar xf $TEMP_FILE -C $TEMP_DIR
-    mv $TEMP_APPENV $TEMP_DIR/$APPENV_FILENAME
-    rm -rf $OUTPUT_NAME $TEMP_FILE
+    # extract rootfs directory from image tarball
+    tar xf $EXPORTED_IMG_TAR -C $EXTRACTED_ROOTFS_DIR
+    rm -rf $EXPORTED_IMG_TAR
+
+    # copy appenv.json
+    mv $TEMP_APPENV $EXTRACTED_ROOTFS_DIR/appenv.json
 
     if [ "$OUTPUT_FORMAT" == "dir" ]; then
-        mv $TEMP_DIR $OUTPUT_NAME
+        mv $EXTRACTED_ROOTFS_DIR $OUTPUT_NAME
     elif [ "$OUTPUT_FORMAT" == "cpio" ]; then
-        myst mkcpio $TEMP_DIR $OUTPUT_NAME
+        myst mkcpio $EXTRACTED_ROOTFS_DIR $OUTPUT_NAME
     fi
-    rm -rf $TEMP_DIR
+
+    rm -rf $EXTRACTED_ROOTFS_DIR
+}
+
+export_image()
+{
+    TEMP_APPENV="appenv.json-$(date +%s)"
+    docker image inspect --format='{{json .Config}}' $IMAGE_NAME > $TEMP_APPENV
+
+    # cleanup $OUTPUT_NAME if it exists
+    rm -rf $OUTPUT_NAME
+
+    if $USE_MOUNT; then
+        export_via_overlayfs_mount
+    else
+        export_via_docker_export
+    fi
 }
 
 get_image

--- a/solutions/aspnet_core/aspnet_minimal_server/Makefile
+++ b/solutions/aspnet_core/aspnet_minimal_server/Makefile
@@ -45,7 +45,7 @@ gdb: appdir private.pem
 	$(MYST_GDB) --args myst/bin/$(APPNAME) $(OPTS)
 
 appdir:
-	$(APPBUILDER) -v Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 clean:
 	./kill.sh

--- a/solutions/aspnet_core/aspnet_samples/Makefile
+++ b/solutions/aspnet_core/aspnet_samples/Makefile
@@ -13,7 +13,7 @@ TOP_TIMEOUT=240s
 build: rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkext2 appdir rootfs

--- a/solutions/confidential_ml/Makefile
+++ b/solutions/confidential_ml/Makefile
@@ -13,7 +13,7 @@ SHUTDOWN_WAIT = 2
 all: $(PACKAGE)
 
 appdir:
-	$(APPBUILDER) -d Dockerfile
+	$(APPBUILDER) -m -d Dockerfile
 
 $(PACKAGE): appdir package.pem
 	$(MYST) mkext2 appdir rootfs

--- a/solutions/cpprestsdk/Makefile
+++ b/solutions/cpprestsdk/Makefile
@@ -26,7 +26,7 @@ run-debug: ext2rootfs
 	$(RUNTEST) $(MYST_EXEC) --app-config-path debug-config.json $(OPTS) ext2rootfs /app/casablanca/build.debug/Release/Binaries/test_runner *_test.so
 
 $(APPDIR):
-	$(APPBUILDER) -v -d Dockerfile
+	$(APPBUILDER) -m -v -d Dockerfile
 
 cpio: $(APPDIR)
 	$(MYST) mkcpio $(APPDIR) rootfs

--- a/solutions/cpython-tests/Makefile
+++ b/solutions/cpython-tests/Makefile
@@ -40,16 +40,16 @@ mpdb.py:$(MPDB)
 
 ext2fs3.8:mpdb.py test_config_v3.8.11/tests.passed
 	rm -fr appdir3.8
-	$(APPBUILDER) -o appdir3.8 -e "--build-arg CPYTHON_TAG=v3.8.11" Dockerfile
+	$(APPBUILDER) -m -o appdir3.8 -e "--build-arg CPYTHON_TAG=v3.8.11" Dockerfile
 	$(MYST) mkext2 -f appdir3.8 ext2fs3.8
 
 ext2fs3.9:mpdb.py test_config_v3.9.7/tests.passed
 	rm -fr appdir3.9
-	$(APPBUILDER) -o appdir3.9 -e "--build-arg CPYTHON_TAG=v3.9.7" Dockerfile
+	$(APPBUILDER) -m -o appdir3.9 -e "--build-arg CPYTHON_TAG=v3.9.7" Dockerfile
 	$(MYST) mkext2 -f appdir3.9 ext2fs3.9
 
 appdir3.10: mpdb.py
-	$(APPBUILDER) -o appdir3.10 -e "--build-arg CPYTHON_TAG=v3.10.2" Dockerfile
+	$(APPBUILDER) -m -o appdir3.10 -e "--build-arg CPYTHON_TAG=v3.10.2" Dockerfile
 ext2fs3.10: appdir3.10
 	$(MYST) mkext2 -f appdir3.10 ext2fs3.10
 

--- a/solutions/dotnet/Makefile
+++ b/solutions/dotnet/Makefile
@@ -26,7 +26,7 @@ gdb: appdir private.pem
 	$(MYST_GDB) --args myst/bin/$(APPNAME) $(OPTS)
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 private.pem:
 	openssl genrsa -out private.pem -3 3072

--- a/solutions/dotnet_azure_sdk/Identity_Resource_Management_and_Storage/Makefile
+++ b/solutions/dotnet_azure_sdk/Identity_Resource_Management_and_Storage/Makefile
@@ -17,7 +17,7 @@ gdb: appdir private.pem
 
 appdir: $(SRC)
 	$(MAKE) clean
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 private.pem:
 	openssl genrsa -out private.pem -3 3072

--- a/solutions/dotnet_azure_sdk/KeyVault_Certificates/Makefile
+++ b/solutions/dotnet_azure_sdk/KeyVault_Certificates/Makefile
@@ -17,7 +17,7 @@ gdb: appdir private.pem
 
 appdir: $(SRC)
 	$(MAKE) clean
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 private.pem:
 	openssl genrsa -out private.pem -3 3072

--- a/solutions/dotnet_azure_sdk/KeyVault_Keys/Makefile
+++ b/solutions/dotnet_azure_sdk/KeyVault_Keys/Makefile
@@ -17,7 +17,7 @@ gdb: appdir private.pem
 
 appdir: $(SRC)
 	$(MAKE) clean
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 private.pem:
 	openssl genrsa -out private.pem -3 3072

--- a/solutions/dotnet_azure_sdk/KeyVault_Secrets/Makefile
+++ b/solutions/dotnet_azure_sdk/KeyVault_Secrets/Makefile
@@ -17,7 +17,7 @@ gdb: appdir private.pem
 
 appdir: $(SRC)
 	$(MAKE) clean
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 private.pem:
 	openssl genrsa -out private.pem -3 3072

--- a/solutions/memcached/Makefile
+++ b/solutions/memcached/Makefile
@@ -65,7 +65,7 @@ myst:
 
 appdir: 
 	@echo "\n------Building appdir------\n"
-	$(APPBUILDER) Dockerfile.server
+	$(APPBUILDER) -m Dockerfile.server
 	@echo "\n------Building client client application container------\n"
 	docker build -t $(CLIENT_IMAGE) -f Dockerfile.client .
 

--- a/solutions/mhsm_ssr/Makefile
+++ b/solutions/mhsm_ssr/Makefile
@@ -8,7 +8,7 @@ all: appdir
 
 appdir:
 	g++ -g -o $(APPNAME) test_ssr.c -ldl -I$(TOP)/include
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 $(PKEY_FILE):
 	./gen_pkey.sh $(PKEY_FILE)

--- a/solutions/nodejs/Makefile
+++ b/solutions/nodejs/Makefile
@@ -15,7 +15,7 @@ rootfs: appdir
 	$(MYST) mkcpio appdir rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 TIMEOUT=60s
 

--- a/solutions/numpy_core_tests/Makefile
+++ b/solutions/numpy_core_tests/Makefile
@@ -12,7 +12,7 @@ endif
 all: rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 	# Remove the test that depends on mmap(MAP_SHARED...).
 	rm appdir/usr/local/lib/python3.9/site-packages/numpy/core/tests/test_memmap.py
 	# Remove the test that fails due to rng

--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -33,7 +33,7 @@ endif
 all: rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 	cp $(PYTEST_INI_FILE) appdir/
 	@ $(foreach i, $(REMOVE_TESTS_TEMPORARILY),  rm  -rf appdir/$(i) )
 

--- a/solutions/py_multiprocessing/Makefile
+++ b/solutions/py_multiprocessing/Makefile
@@ -1,0 +1,33 @@
+TOP = $(abspath ../..)
+include $(TOP)/defs.mak
+
+APPBUILDER = $(TOP)/scripts/appbuilder
+OPTS= --memory-size 512m --thread-stack-size 1m --nobrk
+FS=rootfs
+
+ifdef STRACE
+	OPTS += --strace-filter SYS_unlink:SYS_exit:SYS_myst_clone:SYS_exit_group:SYS_read
+endif
+
+ifdef PERF
+	OPTS += --perf
+endif
+
+all: rootfs
+
+rootfs:
+	$(APPBUILDER) -m Dockerfile
+	$(MYST) mkcpio appdir rootfs
+
+clean:
+	rm -rf rootfs appdir
+run:
+	$(MYST_EXEC) $(OPTS) $(FS) /usr/local/bin/python3 /app/mp_test.py
+
+one-mpdb:
+	killall myst 2> /dev/null || echo ""
+	$(MYST_EXEC) $(OPTS) $(FS) /usr/local/bin/python3 -m mpdb /app/mp_test.py &
+	sleep 15 # Increase this value in Makefile if connection fails
+	rlwrap telnet 127.0.0.1 5678
+	# Once debugger prompt is available, do
+	# (Pdb) b /cpython/Lib/test/<test file>.py:line

--- a/solutions/python_app/Makefile
+++ b/solutions/python_app/Makefile
@@ -11,7 +11,7 @@ endif
 all: rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkext2 appdir rootfs

--- a/solutions/python_azure_sdk/Makefile
+++ b/solutions/python_azure_sdk/Makefile
@@ -18,13 +18,13 @@ endif
 all: rootfs
 
 appdir-keyvault_identity:
-	$(APPBUILDER) -i mystikos/azure-python-sdk-keyvault-identity:azure-mgmt-keyvault_9.1.0 -v -o keyvault_identity/appdir
+	$(APPBUILDER) -m -i mystikos/azure-python-sdk-keyvault-identity:azure-mgmt-keyvault_9.1.0 -v -o keyvault_identity/appdir
 
 appdir-storage:
-	$(APPBUILDER) -i mystikos/azure-python-sdk-storage:azure-mgmt-storage_19.0.0 -v -o storage/appdir
+	$(APPBUILDER) -m -i mystikos/azure-python-sdk-storage:azure-mgmt-storage_19.0.0 -v -o storage/appdir
 
 appdir-storage-blob:
-	$(APPBUILDER) -i mystikos/azure-python-sdk-storage-blob:azure-storage-blob_12.8.1 -v -o storage-blob/appdir
+	$(APPBUILDER) -m -i mystikos/azure-python-sdk-storage-blob:azure-storage-blob_12.8.1 -v -o storage-blob/appdir
 
 rootfs-keyvault_identity: appdir-keyvault_identity
 	$(MYST) mkext2 keyvault_identity/appdir keyvault_identity/rootfs

--- a/solutions/python_flask_tests/Makefile
+++ b/solutions/python_flask_tests/Makefile
@@ -12,7 +12,7 @@ all: build
 build: appdir rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkcpio appdir rootfs

--- a/solutions/python_web_frameworks/Makefile
+++ b/solutions/python_web_frameworks/Makefile
@@ -14,7 +14,7 @@ rootfs: appdir
 	$(MYST) mkcpio appdir $(ROOTFS)
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 _run:
 	$(MAKE) run1

--- a/solutions/python_webserver/Makefile
+++ b/solutions/python_webserver/Makefile
@@ -32,7 +32,7 @@ OPTS += --roothash=roothash
 endif
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 TIMEOUT=60s
 

--- a/solutions/pytorch_tests/Makefile
+++ b/solutions/pytorch_tests/Makefile
@@ -49,7 +49,7 @@ push:
 	docker push $(DOCKER_FULL_NAME):$(DOCKER_TAG)
 
 appdir:
-	$(APPBUILDER) -i $(DOCKER_FULL_NAME):$(DOCKER_TAG) -v
+	$(APPBUILDER) -m -i $(DOCKER_FULL_NAME):$(DOCKER_TAG) -v
 
 rootfs: appdir
 	$(MYST) mkext2 appdir rootfs
@@ -175,7 +175,7 @@ build-appdir: DOCKER_TAG   := $(PYTORCH_VERSION)-build
 build-appdir: BUILD_TARGET := build
 build-appdir: export DOCKER_BUILDKIT=1
 build-appdir:
-	$(APPBUILDER) -e '$(EXTRA_OPTIONS)' -v -d $(DOCKER_FILE) -o build-appdir
+	$(APPBUILDER) -m -e '$(EXTRA_OPTIONS)' -v -d $(DOCKER_FILE) -o build-appdir
 
 build-rootfs: build-appdir
 	$(MYST) mkext2 build-appdir build-rootfs

--- a/solutions/redis/Makefile
+++ b/solutions/redis/Makefile
@@ -53,7 +53,7 @@ gdb: clean package
 	$(MYST_GDB) --args myst/bin/$(APPNAME) $(OPTS)
 
 $(APPDIR):
-	$(APPBUILDER) -d Dockerfile
+	$(APPBUILDER) -m -d Dockerfile
 
 private.pem:
 	openssl genrsa -out private.pem -3 3072

--- a/solutions/tensorflow_lite/Makefile
+++ b/solutions/tensorflow_lite/Makefile
@@ -6,7 +6,7 @@ APPBUILDER=$(TOP)/scripts/appbuilder
 all: appdir rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkext2 appdir ext2rootfs

--- a/tests/appenv/Makefile
+++ b/tests/appenv/Makefile
@@ -24,7 +24,7 @@ all:
 	$(MAKE) $(ROOTFS)
 
 $(APPDIR):
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 $(ROOTFS):
 	$(MYST) mkext2 $(APPDIR) $(ROOTFS)

--- a/tests/aspnetcore5/Makefile
+++ b/tests/aspnetcore5/Makefile
@@ -31,7 +31,7 @@ all: ext2fs
 
 appdir:
 	$(MYST-RETRY) docker pull mcr.microsoft.com/dotnet/sdk:5.0-focal
-	$(APPBUILDER) -d Dockerfile.runner
+	$(APPBUILDER) -m -d Dockerfile.runner
 
 ext2fs: appdir
 	$(MYST) mkext2 appdir ext2fs

--- a/tests/aspnetcore6/Makefile
+++ b/tests/aspnetcore6/Makefile
@@ -45,7 +45,7 @@ all: ext2fs
 # ubuntu debug build: vtikoo/aspnetcore:oct8-2021
 appdir:
 	$(MYST-RETRY) docker pull mcr.microsoft.com/dotnet/sdk:6.0
-	$(APPBUILDER) -d Dockerfile.runner
+	$(APPBUILDER) -m -d Dockerfile.runner
 
 ext2fs: appdir
 	sudo $(MYST) mkext2 appdir ext2fs

--- a/tests/azure-sdk-for-cpp/Makefile
+++ b/tests/azure-sdk-for-cpp/Makefile
@@ -19,7 +19,7 @@ export TIMEOUT=900
 all: myst $(ROOTFS)
 
 $(APPDIR):
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 $(ROOTFS): $(APPDIR)
 	$(MYST) mkext2 $(APPDIR) $(ROOTFS)

--- a/tests/coreclr/p0-net5.0-alpine/Makefile
+++ b/tests/coreclr/p0-net5.0-alpine/Makefile
@@ -21,12 +21,12 @@ all: rootfs ext2fs build-package
 # docker build time ~1hr. Using prebuilt image.
 # Other docker images:
 # pr1(~10k tests) tests in debug
-#$(APPBUILDER) vtikoo/coreclr-tests:release
+#$(APPBUILDER) -m vtikoo/coreclr-tests:release
 # runtime with debug symbols -
-#$(APPBUILDER) vtikoo/coreclr-tests:debug3
+#$(APPBUILDER) -m vtikoo/coreclr-tests:debug3
 appdir:
 	# pr0(~2.7k tests) tests in release
-	$(APPBUILDER) -i vtikoo/coreclr-tests:pr0-release
+	$(APPBUILDER) -m -i vtikoo/coreclr-tests:pr0-release
 
 rootfs: appdir
 	$(MYST) mkcpio appdir rootfs

--- a/tests/coreclr/p0-net6.0-ubuntu/Makefile
+++ b/tests/coreclr/p0-net6.0-ubuntu/Makefile
@@ -21,7 +21,7 @@ all: ext2fs build-package
 # docker build time ~1hr. Using prebuilt image.
 appdir:
 	# pr0(~2.8k tests) tests in release
-	$(APPBUILDER) -i jxyang100/coreclr-tests:pr0-release
+	$(APPBUILDER) -m -i jxyang100/coreclr-tests:pr0-release
 
 ext2fs: appdir
 	$(MYST) mkext2 appdir ext2fs

--- a/tests/coreclr/p1-net6.0-ubuntu/Makefile
+++ b/tests/coreclr/p1-net6.0-ubuntu/Makefile
@@ -19,7 +19,7 @@ OPTS += --app-config-path=config_3g.json
 all: ext2fs build-package
 
 appdir:
-	$(APPBUILDER) -i vtikoo/coreclr-tests:6.0-p1-release
+	$(APPBUILDER) -m -i vtikoo/coreclr-tests:6.0-p1-release
 
 rootfs: appdir
 	$(MYST) mkcpio appdir rootfs

--- a/tests/curl/Makefile
+++ b/tests/curl/Makefile
@@ -24,7 +24,7 @@ gdb: all
 	$(MYST_GDB) --args $(MYST_EXEC) $(OPTS) rootfs /curl https://www.microsoft.com
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs:
 	$(BINDIR)/myst mkcpio appdir rootfs

--- a/tests/dotnet-lib-5/Makefile
+++ b/tests/dotnet-lib-5/Makefile
@@ -17,7 +17,7 @@ all: build-runner
 build: rootfs
 
 appdir:
-	$(MYST-RETRY) $(APPBUILDER) -i $(DOCKER_IMAGE_MUSL)
+	$(MYST-RETRY) $(APPBUILDER) -m -i $(DOCKER_IMAGE_MUSL)
 
 rootfs: appdir
 	$(MYST) mkext2 appdir rootfs
@@ -51,7 +51,7 @@ rootfsr: $(RAPPDIR)
 	$(MYST) mkext2 $(RAPPDIR) $(RROOTFS)
 
 appdirr:
-	$(MYST-RETRY) $(APPBUILDER) -o $(RAPPDIR) Dockerfile.musl.runner 
+	$(MYST-RETRY) $(APPBUILDER) -m -o $(RAPPDIR) Dockerfile.musl.runner 
 
 TESTCASE=testcases/pass.txt
 

--- a/tests/dotnet-lib-6/Makefile
+++ b/tests/dotnet-lib-6/Makefile
@@ -22,7 +22,7 @@ rootfs: $(APPDIR)
 	$(MYST) mkext2 $(APPDIR) $(ROOTFS)
 
 appdir:
-	$(MYST-RETRY) $(APPBUILDER) -o $(APPDIR) Dockerfile.glibc.runner 
+	$(MYST-RETRY) $(APPBUILDER) -m -o $(APPDIR) Dockerfile.glibc.runner 
 
 tests:
 	$(RUNTEST) $(MYST_EXEC) $(OPTS) $(ROOTFS) --app-config-path config.json $(RUNNER) /testcases/pass.1 /dotnet-lib-release/

--- a/tests/dotnet-proc-maps/Makefile
+++ b/tests/dotnet-proc-maps/Makefile
@@ -18,7 +18,7 @@ gdb: rootfs
 	$(MYST_GDB) --args $(MYST_EXEC) $(OPTS) --memory-size=1024m rootfs /app/HelloWorld
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkcpio appdir rootfs

--- a/tests/dotnet-sos/Makefile
+++ b/tests/dotnet-sos/Makefile
@@ -19,7 +19,7 @@ all: ext2fs runner-image
 appdir:
 	$(MYST-RETRY) docker pull mcr.microsoft.com/dotnet/sdk:6.0
 	$(MYST-RETRY) docker pull mcr.microsoft.com/dotnet/runtime:6.0
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 	# libmscordaccore is required by sos_test.py
 	cp appdir/app/libmscordaccore.so .
 

--- a/tests/dotnet-ubuntu/Makefile
+++ b/tests/dotnet-ubuntu/Makefile
@@ -15,7 +15,7 @@ all: ext2fs
 appdir:
 	$(MYST-RETRY) docker pull mcr.microsoft.com/dotnet/sdk:6.0
 	$(MYST-RETRY) docker pull mcr.microsoft.com/dotnet/runtime:6.0
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 ext2fs: appdir
 	$(MYST) mkext2 appdir ext2fs

--- a/tests/glibc/Makefile
+++ b/tests/glibc/Makefile
@@ -41,9 +41,9 @@ build: glibc
 PWD=$(shell pwd)
 
 $(APPDIR):
-	# $(APPBUILDER) -i mystikos/glibc-test:0.1
+	# $(APPBUILDER) -m -i mystikos/glibc-test:0.1
 	# todo: replace with pre-built image
-	$(APPBUILDER) -i hullcritical/glibc-test:0.1
+	$(APPBUILDER) -m -i hullcritical/glibc-test:0.1
 	cp $(CURDIR)/tests.passed $(APPDIR)
 
 $(APPDIR)/bin/run: run.c

--- a/tests/hello_world/java/Makefile
+++ b/tests/hello_world/java/Makefile
@@ -12,7 +12,7 @@ endif
 all: appdir rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkext2 --force appdir ext2rootfs

--- a/tests/libcxx/Makefile
+++ b/tests/libcxx/Makefile
@@ -45,7 +45,7 @@ $(APPDIR)/bin/run: run.c
 	$(MUSL_GCC) -Wall -o $(APPDIR)/bin/run run.c
 
 $(APPDIR):
-	$(APPBUILDER) -i mystikos/libcxx_11x:0.1
+	$(APPBUILDER) -m -i mystikos/libcxx_11x:0.1
 	cp $(CURDIR)/tests.passed $(APPDIR)
 # To build a new image, push the new container to dockerhub and update 
 # this call.

--- a/tests/libcxx2/Makefile
+++ b/tests/libcxx2/Makefile
@@ -46,7 +46,7 @@ $(APPDIR)/bin/run: run.c
 	$(MUSL_GCC) -Wall -o $(APPDIR)/bin/run run.c
 
 $(APPDIR):
-	$(APPBUILDER) -i mystikos/libcxx2_11x:0.1
+	$(APPBUILDER) -m -i mystikos/libcxx2_11x:0.1
 	cp $(CURDIR)/testsa*.passed $(APPDIR)
 # To build a new image, push the new container to dockerhub and update 
 # this call.

--- a/tests/openmp/Makefile
+++ b/tests/openmp/Makefile
@@ -10,7 +10,7 @@ endif
 all: rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkcpio appdir rootfs

--- a/tests/openmp_testsuite/Makefile
+++ b/tests/openmp_testsuite/Makefile
@@ -23,7 +23,7 @@ $(ROOTFS):
 	$(MYST) mkcpio $(APPDIR) $(ROOTFS)
 
 $(APPDIR):
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 TESTS=$(shell cat $(TEST_FILE))
 

--- a/tests/python_pdb/Makefile
+++ b/tests/python_pdb/Makefile
@@ -11,7 +11,7 @@ endif
 all: rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkext2 appdir rootfs

--- a/tests/python_subprocess/Makefile
+++ b/tests/python_subprocess/Makefile
@@ -10,7 +10,7 @@ endif
 all: ext2fs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 ext2fs: appdir
 	$(MYST) mkext2 appdir ext2fs

--- a/tests/python_vfork/Makefile
+++ b/tests/python_vfork/Makefile
@@ -10,7 +10,7 @@ endif
 all: rootfs
 
 appdir:
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 
 rootfs: appdir
 	$(MYST) mkext2 appdir rootfs

--- a/tests/sockperf/Makefile
+++ b/tests/sockperf/Makefile
@@ -14,7 +14,7 @@ all: $(ROOTFS)
 export TIMEOUT=10000
 
 $(APPDIR):
-	$(APPBUILDER) Dockerfile
+	$(APPBUILDER) -m Dockerfile
 	$(MYST_RETRY) docker build -t temp-image-for-server . -f Dockerfile_ubuntu
 	# This docker image contains the compiled contents of the dockerfile that is in the same file tree here.
 	# To update the image, update the dockerfile and then push a new image.


### PR DESCRIPTION
Docker image manifest has upper and lower directory info in
GraphDriver.Data.{Lower, Upper, Work}Dir fields.

Based on this information, a merged overlayfs can be mounted.

For directly creating rootfs, mount point can directly be passed to myst
mkcpio or myst mkext2.

For appdir, we still need to copy the merged fs before unmounting.

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>