### PR TITLE
PyTorch test_GroupNorm_numeric_cpu => 8g

### DIFF
--- a/solutions/pytorch_tests/Makefile
+++ b/solutions/pytorch_tests/Makefile
@@ -115,7 +115,7 @@ run-test-nn: rootfs
 	grep -q -E '1322 passed.*1437 skipped.*43 deselected.*3 xfailed' $@.out
 
 .PHONY: run-test-nn-8g
-run-test-nn-8g: EXCLUDE_TESTS = "test_avg_pool2d_nhwc_cpu_float32 \
+run-test-nn-8g: INCLUDE_TESTS = "test_avg_pool2d_nhwc_cpu_float32 \
 or test_avg_pool2d_nhwc_cpu_float64 \
 or test_max_pool2d_nhwc_cpu_float32 \
 or test_max_pool2d_nhwc_cpu_float64 \
@@ -123,7 +123,7 @@ or test_cross_entropy_loss_precision \
 or test_l1_loss_correct \
 or test_GroupNorm_numeric_cpu"
 run-test-nn-8g: rootfs
-	$(MYST_EXEC) rootfs $(OPTS) --app-config-path config8g.json /usr/local/bin/python -m pytest -v /workspace/pytorch/test/test_nn.py -k $(EXCLUDE_TESTS)
+	$(MYST_EXEC) rootfs $(OPTS) --app-config-path config8g.json /usr/local/bin/python -m pytest -v /workspace/pytorch/test/test_nn.py -k $(INCLUDE_TESTS)
 
 .PHONY: run-test-ops
 run-test-ops: rootfs

--- a/solutions/pytorch_tests/Makefile
+++ b/solutions/pytorch_tests/Makefile
@@ -108,10 +108,11 @@ and not test_avg_pool2d_nhwc_cpu_float64 \
 and not test_max_pool2d_nhwc_cpu_float32 \
 and not test_max_pool2d_nhwc_cpu_float64 \
 and not test_cross_entropy_loss_precision \
-and not test_l1_loss_correct"
+and not test_l1_loss_correct \
+and not test_GroupNorm_numeric_cpu"
 run-test-nn: rootfs
 	$(RUN_PYTEST) /workspace/pytorch/test/test_nn.py -k $(EXCLUDE_TESTS) 2>&1 | tee $@.out
-	grep -q -E '1323 passed.*1437 skipped.*42 deselected.*3 xfailed' $@.out
+	grep -q -E '1322 passed.*1437 skipped.*43 deselected.*3 xfailed' $@.out
 
 .PHONY: run-test-nn-8g
 run-test-nn-8g: EXCLUDE_TESTS = "test_avg_pool2d_nhwc_cpu_float32 \
@@ -119,7 +120,8 @@ or test_avg_pool2d_nhwc_cpu_float64 \
 or test_max_pool2d_nhwc_cpu_float32 \
 or test_max_pool2d_nhwc_cpu_float64 \
 or test_cross_entropy_loss_precision \
-or test_l1_loss_correct"
+or test_l1_loss_correct \
+or test_GroupNorm_numeric_cpu"
 run-test-nn-8g: rootfs
 	$(MYST_EXEC) rootfs $(OPTS) --app-config-path config8g.json /usr/local/bin/python -m pytest -v /workspace/pytorch/test/test_nn.py -k $(EXCLUDE_TESTS)
 


### PR DESCRIPTION
This test case failed on DC8s_v3. The same test passes on DC4s_v3. The explanation is when cpu increases, the application allocates more memory based on core count. For example, maybe extra heap size. Besides increasing memory size, another fix is to set `--max-affinity-cpus=4`. Here I did not choose to set cpu limit as I don't want pytorch users to be caring about special options. Increasing memory size is more intuitive.

```txt
[2022-05-12T07:46:44.647Z] =================================== FAILURES ===================================
[2022-05-12T07:46:44.647Z] [31m[1m________________ TestNNDeviceTypeCPU.test_GroupNorm_numeric_cpu ________________[0m
[2022-05-12T07:46:44.647Z] Traceback (most recent call last):
[2022-05-12T07:46:44.647Z]   File "/workspace/pytorch/test/test_nn.py", line 13449, in test_GroupNorm_numeric
[2022-05-12T07:46:44.647Z]     self.assertEqual(Y, Y_ref, rtol=0, atol=1e-5)
[2022-05-12T07:46:44.647Z]   File "/usr/local/lib/python3.9/site-packages/torch/testing/_internal/common_utils.py", line 1870, in assertEqual
[2022-05-12T07:46:44.647Z]     result, debug_msg_generic = self._compareTensors(x, y, rtol=rtol, atol=atol,
[2022-05-12T07:46:44.647Z]   File "/usr/local/lib/python3.9/site-packages/torch/testing/_internal/common_utils.py", line 1736, in _compareTensors
[2022-05-12T07:46:44.647Z]     return _compare_tensors_internal(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
[2022-05-12T07:46:44.647Z]   File "/usr/local/lib/python3.9/site-packages/torch/testing/_core.py", line 96, in _compare_tensors_internal
[2022-05-12T07:46:44.647Z]     if torch.allclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan):
[2022-05-12T07:46:44.647Z] RuntimeError: [enforce fail at CPUAllocator.cpp:68] . DefaultCPUAllocator: can't allocate memory: you tried to allocate 150994944 bytes. Error code 12 (Out of memory)
```