### PR TITLE
Increase numpy_core_tests timeout

### DIFF
--- a/solutions/numpy_core_tests/Makefile
+++ b/solutions/numpy_core_tests/Makefile
@@ -24,7 +24,7 @@ rootfs: appdir
 	$(MYST) mkext2 appdir rootfs
 
 run: rootfs
-	$(RUNTEST) $(MYST_EXEC) rootfs $(OPTS) --app-config-path config.json /usr/local/bin/python3 /app/app.py
+	TIMEOUT=150s $(RUNTEST) $(MYST_EXEC) rootfs $(OPTS) --app-config-path config.json /usr/local/bin/python3 /app/app.py
 
 one: rootfs
 	$(MYST_EXEC) rootfs $(OPTS) --app-config-path config.json /usr/local/bin/python3 -m pytest /usr/local/lib/python3.9/site-packages/$(TEST)


### PR DESCRIPTION
The default timeout value (120s) is very close to what the test would usually take (114-115s). Increasing the timeout to 150s to leave some safe margin