### PR TITLE
Increase MemorySize from 4g to 8g for PyTorch test-ops

### DIFF
--- a/solutions/pytorch_tests/Makefile
+++ b/solutions/pytorch_tests/Makefile
@@ -127,7 +127,7 @@ run-test-nn-8g: rootfs
 
 .PHONY: run-test-ops
 run-test-ops: rootfs
-	$(MYST_EXEC) rootfs $(OPTS) --app-config-path config4g.json /usr/local/bin/python -m pytest -v /workspace/pytorch/test/test_ops.py 2>&1 | tee $@.out
+	$(MYST_EXEC) rootfs $(OPTS) --app-config-path config8g.json /usr/local/bin/python -m pytest -v /workspace/pytorch/test/test_ops.py 2>&1 | tee $@.out
 	grep -q -E '4200 passed.*10069 skipped' $@.out
 
 .PHONY: run-test-torch


### PR DESCRIPTION
When running on DCs8_v3 (8 core icelake), some test cases fail:

```txt
[2022-05-16T07:40:24.243Z] workspace/pytorch/test/test_ops.py::TestJitCPU::test_variant_consistency_jit_tensordot_cpu_float32 SKIPPED terminate called after throwing an instance of 'std::bad_alloc'

[2022-05-16T07:40:24.243Z]   what():  std::bad_alloc

[2022-05-16T07:40:24.243Z] Fatal Python error: Aborted

...

[2022-05-16T07:40:24.244Z] workspace/pytorch/test/test_ops.py::TestJitCPU::test_variant_consistency_jit_triangular_solve_cpu_complex64 FAILED [ 88%]

[2022-05-16T07:40:24.244Z] workspace/pytorch/test/test_ops.py::TestJitCPU::test_variant_consistency_jit_triangular_solve_cpu_float32 FAILED [ 88%]
```

- Passing on 4 core icelake machine
- If only running partial test cases, e.g. test_variant_consistency_jit_*, passing (doesn't matter 4 or 8 core)
- Limiting `MaxAffinityCPUs=4` on 8 core machine, same error
- Doubling memory size fixes the problem (passing on both 4 core and 8 core machines)
- The "bad_alloc" is a clear indicator of running out of memory. Although I can't explain why limiting "MaxAffinityCPUs" doesn't solve the problem. So increasing memory for now to make the pipeline pass.