### PR TITLE
Add build stage to Azure SDK tests

### DIFF
--- a/.jenkins/scripts/global/run-azure-tests.sh
+++ b/.jenkins/scripts/global/run-azure-tests.sh
@@ -31,6 +31,12 @@ if [[ -z "${AZURE_CLIENT_ID}" || -z "${AZURE_CLIENT_SECRET}" || -z "${AZURE_TENA
     exit 1
 fi
 
+# Build first
+for test_suite in "$@"
+do
+	make -C "${test_suite}"
+done
+
 for test_suite in "$@"
 do
 	RUN_AZURE_TESTS=1 make tests -C "${test_suite}"

--- a/solutions/dotnet/Makefile
+++ b/solutions/dotnet/Makefile
@@ -17,10 +17,10 @@ run-unsigned:
 _run: appdir private.pem
 	timeout 45m $(MYST) package appdir private.pem config.json
 	myst/bin/$(APPNAME) $(OPTS)
-	
+
 run:
 	$(RUNTEST) make -C $(CURDIR) _run
-	
+
 gdb: appdir private.pem
 	$(MYST) package appdir private.pem config.json
 	$(MYST_GDB) --args myst/bin/$(APPNAME) $(OPTS)

--- a/solutions/dotnet_azure_sdk/Makefile
+++ b/solutions/dotnet_azure_sdk/Makefile
@@ -16,6 +16,11 @@ endif
 
 TIMEOUT=1200
 
+all: build
+
+build: __clean
+	@ $(MAKE) __build
+
 __clean:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) clean $(NL) )
 
@@ -26,6 +31,4 @@ __run:
 	@ $(foreach i, $(DIRS), $(MAKE) -C $(i) run $(NL) )
 
 tests:
-	@ $(MAKE) -s __clean 
-	@ $(MAKE) -s __build
 	@ TIMEOUT=$(TIMEOUT) $(RUNTEST) $(MAKE) -j -s __run

--- a/solutions/python_azure_sdk/Makefile
+++ b/solutions/python_azure_sdk/Makefile
@@ -9,7 +9,7 @@ ifdef STRACE
 OPTS += --strace
 endif
 
-TIMEOUT=1500
+TIMEOUT=900
 
 ifdef RUN_AZURE_TESTS
 RUNTEST=$(RUNTEST_COMMAND)
@@ -37,16 +37,16 @@ rootfs-storage-blob: appdir-storage-blob
 
 rootfs: rootfs-keyvault_identity rootfs-storage rootfs-storage-blob
 
-test-keyvault_identity: rootfs-keyvault_identity
+test-keyvault_identity:
 	./test-all-packages.sh "$(MYST_EXEC)" keyvault_identity/rootfs "$(OPTS)" keyvault_identity/packages.txt
 
-test-storage: rootfs-storage
+test-storage:
 	./test-all-packages.sh "$(MYST_EXEC)" storage/rootfs "$(OPTS)" storage/packages.txt
 
-test-storage-blob: rootfs-storage-blob
+test-storage-blob:
 	./test-all-packages.sh "$(MYST_EXEC)" storage-blob/rootfs "$(OPTS)" storage-blob/packages.txt
 
-_tests: all test-keyvault_identity test-storage test-storage-blob
+_tests: test-keyvault_identity test-storage test-storage-blob
 
 tests:
 	TIMEOUT=$(TIMEOUT) $(RUNTEST) make -C $(CURDIR) _tests 

--- a/tests/azure-sdk-for-cpp/Makefile
+++ b/tests/azure-sdk-for-cpp/Makefile
@@ -27,7 +27,7 @@ $(ROOTFS): $(APPDIR)
 
 OPTS += --app-config-path config.json
 
-_tests: all
+_tests: $(ROOTFS)
 	$(MYST_EXEC) $(OPTS) $(ROOTFS) /azure-sdk-for-cpp/build/sdk/template/azure-template/test/azure-template-test
 	$(MYST_EXEC) $(OPTS) $(ROOTFS) /azure-sdk-for-cpp/build/sdk/core/azure-core/test/ut/azure-core-global-context-test
 	$(MYST_EXEC) $(OPTS) $(ROOTFS) /azure-sdk-for-cpp/build/sdk/keyvault/azure-security-keyvault-keys/test/ut/azure-security-keyvault-keys-test


### PR DESCRIPTION
Previously the pipeline would build and run tests, which easily exceeded the timeout value. This PR move the build part to an individual step and only time the `make tests` part. So it's less likely to timeout