### PR TITLE
Add support for unix domain sockets bound to hostfs paths

### DIFF
--- a/include/myst/fdtable.h
+++ b/include/myst/fdtable.h
@@ -179,4 +179,10 @@ long myst_fdtable_sync(myst_fdtable_t* fdtable);
 
 ssize_t myst_fdtable_count(const myst_fdtable_t* fdtable);
 
+int myst_fdtable_update_sock_entry(
+    myst_fdtable_t* fdtable,
+    int fd,
+    myst_sockdev_t* device,
+    myst_sock_t* new_sock);
+
 #endif /* _MYST_FDTABLE_H */

--- a/include/myst/hostfs.h
+++ b/include/myst/hostfs.h
@@ -10,4 +10,10 @@ int myst_init_hostfs(myst_fs_t** fs_out);
 
 bool myst_is_hostfs(const myst_fs_t* fs);
 
+int myst_hostfs_suffix_to_host_abspath(
+    void* hostfs,
+    char* buf,
+    size_t size,
+    const char* path);
+
 #endif /* _MYST_HOSTFS_H */

--- a/include/myst/mount.h
+++ b/include/myst/mount.h
@@ -6,6 +6,7 @@
 
 #include <limits.h>
 #include <myst/fs.h>
+#include <stdbool.h>
 
 /* Mount a file system onto a target path */
 int myst_mount(

--- a/include/myst/sockdev.h
+++ b/include/myst/sockdev.h
@@ -167,6 +167,38 @@ myst_sockdev_t* myst_udsdev_get(void);
 
 int myst_sockdev_resolve(int domain, int type, myst_sockdev_t** dev);
 
+/*
+Input params:
+sockfd, sockdev, sock - file descriptor, socket device and object being
+reresolved.
+addr, addrlen - address being bound(server side) or connected(client
+side) to.
+
+Output params:
+reresolved - If 'sockdev' is myst kernel udsdev and 'addr' is a hostfs path, set
+to true. Otherwise false.
+
+Rest of the output params are only set if 'reresolved' is true.
+
+sockdev_out, sock_out - host socket device and newly created host socket object.
+addr_out, addrlen_out - file path in input param 'addr' is a myst internal
+path. This function allocates addr_out and maps the file path to the
+corresponding host path. This is used subsequent by callers to pass as a
+parameter to host socket device function calls - like bind, connect.
+
+*/
+int myst_sockdev_reresolve(
+    int sockfd,
+    myst_sockdev_t* sockdev,
+    myst_sock_t* sock,
+    const struct sockaddr* addr,
+    socklen_t addrlen,
+    bool* reresolved,
+    myst_sockdev_t** sockdev_out,
+    myst_sock_t** sock_out,
+    struct sockaddr** addr_out,
+    socklen_t* addrlen_out);
+
 const char* myst_socket_type_str(int type);
 
 const char* myst_socket_domain_str(int domain);

--- a/kernel/mount.c
+++ b/kernel/mount.c
@@ -32,8 +32,9 @@
 
 typedef struct mount_table_entry
 {
-    char* source;
-    char* path;
+    char* source; /* path where the device or directory to be mounted is
+                     specified */
+    char* path;   /* path where device is attached */
     size_t path_size;
     myst_fs_t* fs;
     uint32_t flags;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -130,6 +130,7 @@ DIRS += stack_overflow
 DIRS += sendfile
 DIRS += strtonum
 DIRS += fsflags
+DIRS += hostfs_uds
 
 ifdef MYST_NIGHTLY_TEST
 DIRS += aspnetcore5

--- a/tests/hostfs_uds/Makefile
+++ b/tests/hostfs_uds/Makefile
@@ -1,0 +1,53 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC -g
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+PROG = enclave_client
+
+all:
+	$(MAKE) rootfs
+	$(MAKE) build-server
+
+build-server:
+	gcc -o host_uds_server host_uds_server.c
+
+rootfs: $(PROG).c
+	mkdir -p $(APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(PROG) $(PROG).c $(LDFLAGS)
+	$(MYST) mkcpio $(APPDIR) rootfs
+
+ifdef STRACE
+OPTS = --strace
+endif
+
+HOSTDIR=/tmp/hostfs_uds_test/
+
+mk-hostdir:
+	mkdir -p $(HOSTDIR)
+
+ls-hostdir:
+	ls -l $(HOSTDIR)
+
+rm-hostdir:
+	rm -rf $(HOSTDIR) || true
+
+tests: all
+	$(MAKE) rm-hostdir
+	$(MAKE) mk-hostdir
+	$(MAKE) server
+	$(MAKE) client
+
+server:
+	./host_uds_server $(HOSTDIR) &
+
+client:
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/$(PROG) $(HOSTDIR)
+
+killsrv:
+	killall host_uds_server || true
+
+clean:
+	$(MAKE) killsrv	
+	rm -rf $(APPDIR) $(HOSTDIR) rootfs host_uds_server

--- a/tests/hostfs_uds/enclave_client.c
+++ b/tests/hostfs_uds/enclave_client.c
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define PATH_MAX 4096
+
+const char* hostdir = NULL;
+
+void check_server_readiness_or_failure()
+{
+    int ret;
+    struct stat stbuf;
+
+    while (1)
+    {
+        if (stat("/mnt/host/SRVR_FAILED", &stbuf) == 0)
+        {
+            printf("host server failure detected. aborting client!\n");
+            _exit(1);
+        }
+
+        ret = stat("/mnt/host/SRVR_READY", &stbuf);
+
+        if (ret == 0)
+            return;
+        else if (errno == ENOENT)
+            sleep(1);
+        else
+        {
+            printf("Unexpected error: %s", strerror(errno));
+            _exit(1);
+        }
+    }
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s host-directory\n", argv[0]);
+        _exit(1);
+    }
+
+    /* mount the host directory */
+    assert(mkdir("/mnt", 0777) == 0);
+    assert(mkdir("/mnt/host", 0777) == 0);
+    assert(mount(argv[1], "/mnt/host", "hostfs", 0, NULL) == 0);
+
+    check_server_readiness_or_failure();
+
+    char sock_path[PATH_MAX];
+    snprintf(sock_path, PATH_MAX, "/mnt/host/hostsockfoo");
+
+    int fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+    assert(fd >= 0);
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(struct sockaddr_un));
+    addr.sun_family = AF_LOCAL;
+    strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path) - 1);
+    assert(
+        connect(fd, (struct sockaddr*)&addr, sizeof(struct sockaddr_un)) == 0);
+
+    {
+        int nsend, nread;
+        char sockbuf[1024];
+        strcpy(sockbuf, "foO BaR Baz");
+        nsend = send(fd, sockbuf, 1024, 0);
+        assert(nsend > 0);
+
+        nread = recv(fd, sockbuf, 1024, 0);
+        printf("message received from server: %s\n", sockbuf);
+        assert(strcmp(sockbuf, "FOO BAR BAZ") == 0);
+    }
+
+    close(fd);
+    assert(umount("/mnt/host") == 0);
+
+    return 0;
+}

--- a/tests/hostfs_uds/host_uds_server.c
+++ b/tests/hostfs_uds/host_uds_server.c
@@ -1,0 +1,86 @@
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define PATH_MAX 4096
+
+const char* hostdir = NULL;
+
+void failed()
+{
+    char failed[PATH_MAX];
+    snprintf(failed, PATH_MAX, "%s/SRVR_FAILED", hostdir);
+    creat(failed, S_IRWXU | S_IROTH);
+    _exit(1);
+}
+
+void publish_readiness()
+{
+    char ready[PATH_MAX];
+    snprintf(ready, PATH_MAX, "%s/SRVR_READY", hostdir);
+    creat(ready, S_IRWXU | S_IROTH);
+}
+
+void string_to_upper(char* s)
+{
+    for (int i = 0; s[i] != '\0'; i++)
+    {
+        if (s[i] >= 'a' && s[i] <= 'z')
+        {
+            s[i] = s[i] - 32;
+        }
+    }
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 2)
+        failed();
+
+    hostdir = argv[1];
+    if (hostdir[0] != '/')
+        failed();
+
+    char sock_path[PATH_MAX];
+    snprintf(sock_path, PATH_MAX, "%s/hostsockfoo", hostdir);
+
+    int srvrfd = socket(AF_LOCAL, SOCK_STREAM, 0);
+    if (srvrfd < 0)
+        failed();
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(struct sockaddr_un));
+    addr.sun_family = AF_LOCAL;
+    strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path) - 1);
+    if (bind(srvrfd, (struct sockaddr*)&addr, sizeof(struct sockaddr_un)) != 0)
+        failed();
+
+    publish_readiness();
+
+    if (listen(srvrfd, 1) != 0)
+        failed();
+
+    {
+        int connfd = accept(srvrfd, NULL, 0);
+        if (connfd < 0)
+            failed();
+
+        char sockbuf[1024];
+        int nread, nwrite;
+
+        nread = recv(connfd, sockbuf, 1024, 0);
+        string_to_upper(sockbuf);
+        send(connfd, sockbuf, strlen(sockbuf), 0);
+        close(connfd);
+    }
+
+    close(srvrfd);
+    unlink(sock_path);
+
+    return 0;
+}


### PR DESCRIPTION
For UDS sockets its not known at socket creation time whether socket
will bind or connect to a hostfs path.

This patch introduces myst_sockdev_reresolve, which is called from
SYS_bind and SYS_connect syscall handlers. If the socket is an UDS
socket and the address provided is a hostfs path, this method does the
following things -

- create new struct sockaddr_un address with sun_path set to absolute
  path name of socket on host. Address is dynamically allocated in this
  method and should be freed by the caller once its done using it.

- Get socket type from Mystikos kernel's internal UDS socket device,
  and close the internal UDS socket.

- Create socket using the host socket device.

- Patch the mount table entry for the socket, updating the device and
  socket fields.

Once back in the SYS_bind and SYS_connect handlers, the newly created
host device socket and host sock address is passed to host socket 
device's bind or connect routine.

Assumption:
For datagram sockets, the clients call `connect()` before starting communication with `sendto()` or `recvfrom()`