### PR TITLE
Support setting send timeout socket option for UDS socket device

### DIFF
--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -824,6 +824,10 @@ long myst_signal_deliver(
             // Wake up target if necessary
             if (thread->signal.waiting_on_event)
             {
+#ifdef TRACE
+                printf("thread sleeping on thread->event futex. Waking up "
+                       "thread..\n");
+#endif
                 myst_tcall_wake(thread->event);
             }
 

--- a/kernel/sockdev.c
+++ b/kernel/sockdev.c
@@ -1007,12 +1007,26 @@ int myst_sockdev_reresolve(
     socklen_t optlen = sizeof(type);
     ECHECK(myst_udsdev->sd_getsockopt(
         myst_udsdev, sock, SOL_SOCKET, SO_TYPE, &type, &optlen));
+
+    struct timeval so_sndtimeo;
+    optlen = sizeof(struct timeval);
+    ECHECK(myst_udsdev->sd_getsockopt(
+        myst_udsdev, sock, SOL_SOCKET, SO_SNDTIMEO, &so_sndtimeo, &optlen));
+
     ECHECK(myst_udsdev->sd_close(myst_udsdev, sock));
 
     // create the hostdev socket
     myst_sockdev_t* host_sockdev = myst_sockdev_get();
     ECHECK(host_sockdev->sd_socket(
         host_sockdev, AF_LOCAL, type, 0, &hostuds_sock));
+
+    ECHECK(host_sockdev->sd_setsockopt(
+        host_sockdev,
+        hostuds_sock,
+        SOL_SOCKET,
+        SO_SNDTIMEO,
+        &so_sndtimeo,
+        optlen));
 
     // update mount entry
     ECHECK(myst_fdtable_update_sock_entry(

--- a/tests/hostfs_uds/Dockerfile
+++ b/tests/hostfs_uds/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["dotnet_client", "dotnet_client/"]
+WORKDIR "/src/dotnet_client"
+RUN dotnet publish -o /app/build --self-contained true -r linux-x64
+
+FROM mcr.microsoft.com/dotnet/runtime:6.0
+
+WORKDIR /app
+# Create hostfs mount target directory
+RUN mkdir -p /mnt/host
+COPY --from=build /app/build .

--- a/tests/hostfs_uds/Makefile
+++ b/tests/hostfs_uds/Makefile
@@ -23,8 +23,12 @@ net-client-rootfs:
 	$(APPBUILDER) -o net-appdir -m Dockerfile
 	$(MYST) mkext2 net-appdir net-client-rootfs
 
-ifdef STRACE
+ifdef STRACE-FILTER
 OPTS = --strace-filter SYS_epoll_pwait:SYS_socket:SYS_myst_clone:SYS_exit:SYS_setsockopt:SYS_connect:SYS_exit_group:SYS_exit
+endif
+
+ifdef STRACE
+OPTS = --strace
 endif
 
 HOSTDIR=/tmp/hostfs_uds_test/

--- a/tests/hostfs_uds/Makefile
+++ b/tests/hostfs_uds/Makefile
@@ -1,25 +1,30 @@
 TOP=$(abspath ../..)
 include $(TOP)/defs.mak
 
-APPDIR = appdir
+C-APPDIR = c-appdir
 CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 PROG = enclave_client
+APPBUILDER=$(TOP)/scripts/appbuilder
 
 all:
-	$(MAKE) rootfs
+	$(MAKE) c-client-rootfs
 	$(MAKE) build-server
 
 build-server:
 	gcc -o host_uds_server host_uds_server.c
 
-rootfs: $(PROG).c
-	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(PROG) $(PROG).c $(LDFLAGS)
-	$(MYST) mkcpio $(APPDIR) rootfs
+c-client-rootfs: $(PROG).c
+	mkdir -p $(C-APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(C-APPDIR)/bin/$(PROG) $(PROG).c $(LDFLAGS)
+	$(MYST) mkcpio $(C-APPDIR) c-client-rootfs
+
+net-client-rootfs:
+	$(APPBUILDER) -o net-appdir -m Dockerfile
+	$(MYST) mkext2 net-appdir net-client-rootfs
 
 ifdef STRACE
-OPTS = --strace
+OPTS = --strace-filter SYS_epoll_pwait:SYS_socket:SYS_myst_clone:SYS_exit:SYS_setsockopt:SYS_connect:SYS_exit_group:SYS_exit
 endif
 
 HOSTDIR=/tmp/hostfs_uds_test/
@@ -37,17 +42,29 @@ tests: all
 	$(MAKE) rm-hostdir
 	$(MAKE) mk-hostdir
 	$(MAKE) server
-	$(MAKE) client
+	$(MAKE) client-c
 
 server:
 	./host_uds_server $(HOSTDIR) &
 
-client:
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/$(PROG) $(HOSTDIR)
+client-c:
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) c-client-rootfs /bin/$(PROG) $(HOSTDIR)
+
+tests-net:
+	$(MAKE) rm-hostdir
+	$(MAKE) mk-hostdir
+	$(MAKE) server
+	sleep 2
+	$(MAKE) client-net
+
+client-net:
+	$(MYST_EXEC) net-client-rootfs $(OPTS) --app-config-path=config.json \
+	--mount $(HOSTDIR)=/mnt/host \
+	/app/hello $(HOSTDIR)
 
 killsrv:
 	killall host_uds_server || true
 
 clean:
 	$(MAKE) killsrv	
-	rm -rf $(APPDIR) $(HOSTDIR) rootfs host_uds_server
+	rm -rf $(C-APPDIR) $(HOSTDIR) c-client-rootfs host_uds_server

--- a/tests/hostfs_uds/config.json
+++ b/tests/hostfs_uds/config.json
@@ -1,0 +1,31 @@
+{
+    // OpenEnclave specific values
+
+    // Whether we are running myst+OE+app in debug mode
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+
+    // The heap size of the user application. Increase this setting if your app experienced OOM.
+    "MemorySize": "1g",
+    // The path to the entry point application in rootfs
+    "ApplicationPath": "/app/hello",
+    // The parameters to the entry point application
+    "ApplicationParameters": [],
+    // Whether we allow "ApplicationParameters" to be overridden by command line options of "myst exec"
+    "HostApplicationParameters": false,
+    // The environment variables accessible inside the enclave.
+    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0"],
+    // The environment variables we get from the host
+    "HostEnvironmentVariables": [],
+    // Stack size for each thread
+    "ThreadStackSize": "16m",
+    "Mount": [
+        {
+          "Target": "/mnt/host",
+          "Type": "hostfs"
+        }
+    ]
+}

--- a/tests/hostfs_uds/dotnet_client/Program.cs
+++ b/tests/hostfs_uds/dotnet_client/Program.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace hello
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Socket socket = new Socket(
+                AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+            socket.SendTimeout = 15000; // in milliseconds
+            socket.Connect(new UnixDomainSocketEndPoint("/mnt/host/hostsockfoo"));
+            byte[] data = Encoding.ASCII.GetBytes("foo bar baz");
+            socket.Send(data, data.Length, SocketFlags.None);
+
+            Byte[] bytesReceived = new Byte[256];
+            int nrcv = socket.Receive(bytesReceived, bytesReceived.Length, 0);
+            Console.WriteLine("nrcv="+nrcv);
+            Console.WriteLine(Encoding.ASCII.GetString(bytesReceived));
+            socket.Close();
+        }  
+    }
+}

--- a/tests/hostfs_uds/dotnet_client/hello.csproj
+++ b/tests/hostfs_uds/dotnet_client/hello.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/tests/hostfs_uds/host_uds_server.c
+++ b/tests/hostfs_uds/host_uds_server.c
@@ -1,5 +1,6 @@
 
 #include <fcntl.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -10,9 +11,13 @@
 #define PATH_MAX 4096
 
 const char* hostdir = NULL;
+char ready_path[PATH_MAX];
+bool ready = false;
 
 void failed()
 {
+    if (ready)
+        unlink(ready_path);
     char failed[PATH_MAX];
     snprintf(failed, PATH_MAX, "%s/SRVR_FAILED", hostdir);
     creat(failed, S_IRWXU | S_IROTH);
@@ -21,9 +26,9 @@ void failed()
 
 void publish_readiness()
 {
-    char ready[PATH_MAX];
-    snprintf(ready, PATH_MAX, "%s/SRVR_READY", hostdir);
-    creat(ready, S_IRWXU | S_IROTH);
+    ready = true;
+    snprintf(ready_path, PATH_MAX, "%s/SRVR_READY", hostdir);
+    creat(ready_path, S_IRWXU | S_IROTH);
 }
 
 void string_to_upper(char* s)
@@ -81,6 +86,8 @@ int main(int argc, const char* argv[])
 
     close(srvrfd);
     unlink(sock_path);
+    if (ready)
+        unlink(ready_path);
 
     return 0;
 }


### PR DESCRIPTION
This includes transferring the send timeout settings if a socket is
re-resolved to the host socket device at connect() or bind().

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>