### PR TITLE
Ignore third_party CodeQL issues

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,22 @@ jobs:
     - name: Building Mystikos
       run: |
         make MYST_PRODUCT_BUILD=1 -j4
-              
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+      with:
+        upload: false
+        output: sarif-results
+
+    - name: Remove third_party issues from SARIF
+      uses: zbazztian/filter-sarif@a347e7442e403a432234e777ca5f21ec51f51b7a
+      with:
+        patterns: |
+          -third_party/**
+        input: sarif-results/cpp.sarif
+        output: sarif-results/cpp.sarif
+
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: sarif-results/cpp.sarif


### PR DESCRIPTION
Used 3rd party action to filter out unwanted issues
https://github.com/zbazztian/filter-sarif

Had a test run against this PR, and it successfully ignores third party issues, reduced number of issues from 485 to 95