### PR TITLE
Add config to choose b/w host socket device and Mystikos socket device for Unix domain sockets

### DIFF
--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -229,6 +229,9 @@ typedef struct myst_kernel_args
     /* true if --report-native-tids is present */
     bool report_native_tids;
 
+    /* true if --host-uds on command line or HostUDS in json config */
+    bool host_uds;
+
     // From the --main-stack-size=<size> option.
     size_t main_stack_size;
 

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -25,6 +25,7 @@ typedef struct myst_options
     bool perf;
     bool report_native_tids;
     bool unhandled_syscall_enosys;
+    bool host_uds;
     size_t main_stack_size;
     size_t thread_stack_size;
     size_t max_affinity_cpus;

--- a/include/myst/sockdev.h
+++ b/include/myst/sockdev.h
@@ -175,27 +175,24 @@ addr, addrlen - address being bound(server side) or connected(client
 side) to.
 
 Output params:
-reresolved - If 'sockdev' is myst kernel udsdev and 'addr' is a hostfs path, set
+reresolved - If 'sockdev' is host socket device and 'addr' is a hostfs path, set
 to true. Otherwise false.
 
 Rest of the output params are only set if 'reresolved' is true.
 
-sockdev_out, sock_out - host socket device and newly created host socket object.
 addr_out, addrlen_out - file path in input param 'addr' is a myst internal
 path. This function allocates addr_out and maps the file path to the
 corresponding host path. This is used subsequent by callers to pass as a
 parameter to host socket device function calls - like bind, connect.
 
 */
-int myst_sockdev_reresolve(
+int myst_host_uds_addr_reresolve(
     int sockfd,
     myst_sockdev_t* sockdev,
     myst_sock_t* sock,
     const struct sockaddr* addr,
     socklen_t addrlen,
     bool* reresolved,
-    myst_sockdev_t** sockdev_out,
-    myst_sock_t** sock_out,
     struct sockaddr** addr_out,
     socklen_t* addrlen_out);
 

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -718,6 +718,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     __options.have_syscall_instruction = args->have_syscall_instruction;
     __options.have_fsgsbase_instructions = args->have_fsgsbase_instructions;
     __options.report_native_tids = args->report_native_tids;
+    __options.host_uds = args->host_uds;
 
     /* enable error tracing if requested */
     if (args->trace_errors)

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -824,6 +824,10 @@ long myst_signal_deliver(
             // Wake up target if necessary
             if (thread->signal.waiting_on_event)
             {
+#ifdef TRACE
+                printf("thread sleeping on thread->event futex. Waking up "
+                       "thread..\n");
+#endif
                 myst_tcall_wake(thread->event);
             }
 

--- a/kernel/sockdev.c
+++ b/kernel/sockdev.c
@@ -988,7 +988,7 @@ int myst_host_uds_addr_reresolve(
 
     const struct sockaddr_un* sun = (const struct sockaddr_un*)addr;
 
-    /* abstract namespace UDSes need no address updation */
+    /* abstract namespace UDSs need no address update */
     if (*sun->sun_path == '\0')
         return 0;
 

--- a/kernel/sockdev.c
+++ b/kernel/sockdev.c
@@ -1007,12 +1007,26 @@ int myst_sockdev_reresolve(
     socklen_t optlen = sizeof(type);
     ECHECK(myst_udsdev->sd_getsockopt(
         myst_udsdev, sock, SOL_SOCKET, SO_TYPE, &type, &optlen));
+
+    struct timeval so_sndtimeo;
+    optlen = sizeof(struct timeval);
+    ECHECK(myst_udsdev->sd_getsockopt(
+        myst_udsdev, sock, SOL_SOCKET, SO_SNDTIMEO, &so_sndtimeo, &optlen));
+
     ECHECK(myst_udsdev->sd_close(myst_udsdev, sock));
 
     // create the hostdev socket
     myst_sockdev_t* host_sockdev = myst_sockdev_get();
     ECHECK(host_sockdev->sd_socket(
         host_sockdev, AF_LOCAL, type, 0, &hostuds_sock));
+
+    ECHECK(host_sockdev->sd_setsockopt(
+        host_sockdev,
+        hostuds_sock,
+        SOL_SOCKET,
+        SO_SNDTIMEO,
+        &so_sndtimeo,
+        optlen));
 
     // update mount entry
     ECHECK(myst_fdtable_update_sock_entry(

--- a/kernel/udsdev.c
+++ b/kernel/udsdev.c
@@ -1342,7 +1342,7 @@ static int _udsdev_setsockopt(
         }
         case SO_SNDTIMEO:
         {
-            if (!optval)
+            if (!optval || optlen < sizeof(struct timeval))
                 ERAISE(-EINVAL);
 
             memcpy(&_obj(sock)->so_sndtimeo, optval, sizeof(struct timeval));

--- a/tests/hostfs_uds/Dockerfile
+++ b/tests/hostfs_uds/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["dotnet_client", "dotnet_client/"]
+WORKDIR "/src/dotnet_client"
+RUN dotnet publish -o /app/build --self-contained true -r linux-x64
+
+FROM mcr.microsoft.com/dotnet/runtime:6.0
+
+WORKDIR /app
+# Create hostfs mount target directory
+RUN mkdir -p /mnt/host
+COPY --from=build /app/build .

--- a/tests/hostfs_uds/Makefile
+++ b/tests/hostfs_uds/Makefile
@@ -8,7 +8,7 @@ PROG = enclave_client
 APPBUILDER=$(TOP)/scripts/appbuilder
 
 all:
-	$(MAKE) c-client-rootfs
+	$(MAKE) net-client-rootfs
 	$(MAKE) build-server
 
 build-server:
@@ -24,11 +24,11 @@ net-client-rootfs:
 	$(MYST) mkext2 net-appdir net-client-rootfs
 
 ifdef STRACE-FILTER
-OPTS = --strace-filter SYS_epoll_pwait:SYS_socket:SYS_myst_clone:SYS_exit:SYS_setsockopt:SYS_connect:SYS_exit_group:SYS_exit
+OPTS += --strace-filter SYS_socket:SYS_myst_clone:SYS_exit:SYS_setsockopt:SYS_connect:SYS_exit_group:SYS_exit:SYS_epoll_create1:SYS_epoll_ctl:SYS_epoll_pwait:SYS_epoll_wait
 endif
 
 ifdef STRACE
-OPTS = --strace
+OPTS += --strace
 endif
 
 HOSTDIR=/tmp/hostfs_uds_test/
@@ -42,7 +42,7 @@ ls-hostdir:
 rm-hostdir:
 	rm -rf $(HOSTDIR) || true
 
-tests: all
+tests-c: all
 	$(MAKE) rm-hostdir
 	$(MAKE) mk-hostdir
 	$(MAKE) server
@@ -52,9 +52,9 @@ server:
 	./host_uds_server $(HOSTDIR) &
 
 client-c:
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) c-client-rootfs /bin/$(PROG) $(HOSTDIR)
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) --host-uds c-client-rootfs /bin/$(PROG) $(HOSTDIR)
 
-tests-net:
+tests:
 	$(MAKE) rm-hostdir
 	$(MAKE) mk-hostdir
 	$(MAKE) server

--- a/tests/hostfs_uds/Makefile
+++ b/tests/hostfs_uds/Makefile
@@ -23,8 +23,12 @@ net-client-rootfs:
 	$(APPBUILDER) -o net-appdir -m Dockerfile
 	$(MYST) mkext2 net-appdir net-client-rootfs
 
-ifdef STRACE
+ifdef STRACE-FILTER
 OPTS = --strace-filter SYS_epoll_pwait:SYS_socket:SYS_myst_clone:SYS_exit:SYS_setsockopt:SYS_connect:SYS_exit_group:SYS_exit
+endif
+
+ifdef STRACE
+OPTS = --strace
 endif
 
 HOSTDIR=/tmp/hostfs_uds_test/

--- a/tests/hostfs_uds/Makefile
+++ b/tests/hostfs_uds/Makefile
@@ -1,25 +1,30 @@
 TOP=$(abspath ../..)
 include $(TOP)/defs.mak
 
-APPDIR = appdir
+C-APPDIR = c-appdir
 CFLAGS = -fPIC -g
 LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
 PROG = enclave_client
+APPBUILDER=$(TOP)/scripts/appbuilder
 
 all:
-	$(MAKE) rootfs
+	$(MAKE) c-client-rootfs
 	$(MAKE) build-server
 
 build-server:
 	gcc -o host_uds_server host_uds_server.c
 
-rootfs: $(PROG).c
-	mkdir -p $(APPDIR)/bin
-	$(MUSL_GCC) $(CFLAGS) -o $(APPDIR)/bin/$(PROG) $(PROG).c $(LDFLAGS)
-	$(MYST) mkcpio $(APPDIR) rootfs
+c-client-rootfs: $(PROG).c
+	mkdir -p $(C-APPDIR)/bin
+	$(MUSL_GCC) $(CFLAGS) -o $(C-APPDIR)/bin/$(PROG) $(PROG).c $(LDFLAGS)
+	$(MYST) mkcpio $(C-APPDIR) c-client-rootfs
+
+net-client-rootfs:
+	$(APPBUILDER) -o net-appdir -m Dockerfile
+	$(MYST) mkext2 net-appdir net-client-rootfs
 
 ifdef STRACE
-OPTS = --strace
+OPTS = --strace-filter SYS_epoll_pwait:SYS_socket:SYS_myst_clone:SYS_exit:SYS_setsockopt:SYS_connect:SYS_exit_group:SYS_exit
 endif
 
 HOSTDIR=/tmp/hostfs_uds_test/
@@ -37,17 +42,29 @@ tests: all
 	$(MAKE) rm-hostdir
 	$(MAKE) mk-hostdir
 	$(MAKE) server
-	$(MAKE) client
+	$(MAKE) client-c
 
 server:
 	./host_uds_server $(HOSTDIR) &
 
-client:
-	$(RUNTEST) $(MYST_EXEC) $(OPTS) rootfs /bin/$(PROG) $(HOSTDIR)
+client-c:
+	$(RUNTEST) $(MYST_EXEC) $(OPTS) c-client-rootfs /bin/$(PROG) $(HOSTDIR)
+
+tests-net:
+	$(MAKE) rm-hostdir
+	$(MAKE) mk-hostdir
+	$(MAKE) server
+	sleep 2
+	$(MAKE) client-net
+
+client-net:
+	$(MYST_EXEC) net-client-rootfs $(OPTS) --app-config-path=config.json \
+	--mount $(HOSTDIR)=/mnt/host \
+	/app/hello $(HOSTDIR)
 
 killsrv:
 	killall host_uds_server || true
 
 clean:
 	$(MAKE) killsrv	
-	rm -rf $(APPDIR) $(HOSTDIR) rootfs host_uds_server
+	rm -rf $(C-APPDIR) $(HOSTDIR) c-client-rootfs host_uds_server

--- a/tests/hostfs_uds/Makefile
+++ b/tests/hostfs_uds/Makefile
@@ -71,4 +71,4 @@ killsrv:
 
 clean:
 	$(MAKE) killsrv	
-	rm -rf $(C-APPDIR) $(HOSTDIR) c-client-rootfs host_uds_server
+	rm -rf $(C-APPDIR) $(HOSTDIR) net-appdir c-client-rootfs net-client-rootfs host_uds_server

--- a/tests/hostfs_uds/config.json
+++ b/tests/hostfs_uds/config.json
@@ -27,5 +27,6 @@
           "Target": "/mnt/host",
           "Type": "hostfs"
         }
-    ]
+    ],
+    "HostUDS": true
 }

--- a/tests/hostfs_uds/config.json
+++ b/tests/hostfs_uds/config.json
@@ -1,0 +1,31 @@
+{
+    // OpenEnclave specific values
+
+    // Whether we are running myst+OE+app in debug mode
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+
+    // Mystikos specific values
+
+    // The heap size of the user application. Increase this setting if your app experienced OOM.
+    "MemorySize": "1g",
+    // The path to the entry point application in rootfs
+    "ApplicationPath": "/app/hello",
+    // The parameters to the entry point application
+    "ApplicationParameters": [],
+    // Whether we allow "ApplicationParameters" to be overridden by command line options of "myst exec"
+    "HostApplicationParameters": false,
+    // The environment variables accessible inside the enclave.
+    "EnvironmentVariables": ["COMPlus_EnableDiagnostics=0"],
+    // The environment variables we get from the host
+    "HostEnvironmentVariables": [],
+    // Stack size for each thread
+    "ThreadStackSize": "16m",
+    "Mount": [
+        {
+          "Target": "/mnt/host",
+          "Type": "hostfs"
+        }
+    ]
+}

--- a/tests/hostfs_uds/dotnet_client/Program.cs
+++ b/tests/hostfs_uds/dotnet_client/Program.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace hello
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Socket socket = new Socket(
+                AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+            socket.SendTimeout = 15000; // in milliseconds
+            socket.Connect(new UnixDomainSocketEndPoint("/mnt/host/hostsockfoo"));
+            byte[] data = Encoding.ASCII.GetBytes("foo bar baz");
+            socket.Send(data, data.Length, SocketFlags.None);
+
+            Byte[] bytesReceived = new Byte[256];
+            int nrcv = socket.Receive(bytesReceived, bytesReceived.Length, 0);
+            Console.WriteLine("nrcv="+nrcv);
+            Console.WriteLine(Encoding.ASCII.GetString(bytesReceived));
+            socket.Close();
+        }  
+    }
+}

--- a/tests/hostfs_uds/dotnet_client/Program.cs
+++ b/tests/hostfs_uds/dotnet_client/Program.cs
@@ -8,11 +8,40 @@ namespace hello
 {
     class Program
     {
-        static void Main(string[] args)
+        static int ENOTSUP = 95;
+        static void fail(String reason)
+        {
+            Console.WriteLine(reason);
+            System.Environment.Exit(1);  
+        }
+
+        static void test_bind_to_non_hostfs_path_fail()
+        {
+            Socket socket = new Socket(
+                AddressFamily.Unix, SocketType.Stream, ProtocolType.IP
+            );
+            try
+            {
+                socket.Bind(new UnixDomainSocketEndPoint("/tmp/sockbar"));
+            }
+            catch (SocketException se)
+            {
+                if (se.ErrorCode != ENOTSUP)
+                    fail("Wrong error code: "+se.ErrorCode+". Expected ENOTSUP(95).");
+                return;
+            }
+            catch (Exception e)
+            {
+                fail("Wrong exception thrown: "+e.ToString()+". Expected SocketException.");
+            }
+            fail("SocketException not thrown.");
+        }
+
+        static void test_connect_to_hostfs_path()
         {
             Socket socket = new Socket(
                 AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
-            socket.SendTimeout = 15000; // in milliseconds
+            socket.SendTimeout = 15000; // in milliseconds  
             socket.Connect(new UnixDomainSocketEndPoint("/mnt/host/hostsockfoo"));
             byte[] data = Encoding.ASCII.GetBytes("foo bar baz");
             socket.Send(data, data.Length, SocketFlags.None);
@@ -22,6 +51,12 @@ namespace hello
             Console.WriteLine("nrcv="+nrcv);
             Console.WriteLine(Encoding.ASCII.GetString(bytesReceived));
             socket.Close();
-        }  
+        }
+
+        static void Main(string[] args)
+        {
+            test_bind_to_non_hostfs_path_fail();
+            test_connect_to_hostfs_path();
+        }
     }
 }

--- a/tests/hostfs_uds/dotnet_client/hello.csproj
+++ b/tests/hostfs_uds/dotnet_client/hello.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/tests/hostfs_uds/host_uds_server.c
+++ b/tests/hostfs_uds/host_uds_server.c
@@ -12,11 +12,10 @@
 
 const char* hostdir = NULL;
 char ready_path[PATH_MAX];
-bool ready = false;
 
 void failed()
 {
-    if (ready)
+    if (*ready_path)
         unlink(ready_path);
     char failed[PATH_MAX];
     snprintf(failed, PATH_MAX, "%s/SRVR_FAILED", hostdir);
@@ -26,7 +25,6 @@ void failed()
 
 void publish_readiness()
 {
-    ready = true;
     snprintf(ready_path, PATH_MAX, "%s/SRVR_READY", hostdir);
     creat(ready_path, S_IRWXU | S_IROTH);
 }
@@ -86,7 +84,7 @@ int main(int argc, const char* argv[])
 
     close(srvrfd);
     unlink(sock_path);
-    if (ready)
+    if (*ready_path)
         unlink(ready_path);
 
     return 0;

--- a/tests/hostfs_uds/host_uds_server.c
+++ b/tests/hostfs_uds/host_uds_server.c
@@ -1,5 +1,6 @@
 
 #include <fcntl.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -10,9 +11,13 @@
 #define PATH_MAX 4096
 
 const char* hostdir = NULL;
+char ready_path[PATH_MAX];
+bool ready = false;
 
 void failed()
 {
+    if (ready)
+        unlink(ready_path);
     char failed[PATH_MAX];
     snprintf(failed, PATH_MAX, "%s/SRVR_FAILED", hostdir);
     creat(failed, S_IRWXU | S_IROTH);
@@ -21,9 +26,9 @@ void failed()
 
 void publish_readiness()
 {
-    char ready[PATH_MAX];
-    snprintf(ready, PATH_MAX, "%s/SRVR_READY", hostdir);
-    creat(ready, S_IRWXU | S_IROTH);
+    ready = true;
+    snprintf(ready_path, PATH_MAX, "%s/SRVR_READY", hostdir);
+    creat(ready_path, S_IRWXU | S_IROTH);
 }
 
 void string_to_upper(char* s)
@@ -81,6 +86,8 @@ int main(int argc, const char* argv[])
 
     close(srvrfd);
     unlink(sock_path);
+    if (ready)
+        unlink(ready_path);
 
     return 0;
 }

--- a/tests/myst/package/Makefile
+++ b/tests/myst/package/Makefile
@@ -57,10 +57,11 @@ test4:
 test5:
 	@ echo "=== TEST5"
 	$(MYST) package --roothash=bad_roothash private.pem config.json
-	( MYST_ROOTFS_PATH=rootfs.ext2 ./myst/bin/hello; test "$$?" -eq "234" )
+	( MYST_ROOTFS_PATH=rootfs.ext2 ./myst/bin/hello; test "$$?" -eq "1" )
 
 # test package with --pubkey=<pemfile> (with right public key)
 test6:
+
 	@ echo "=== TEST6"
 	$(MYST) package --pubkey=public.pem private.pem config.json
 	MYST_ROOTFS_PATH=rootfs.ext2 ./myst/bin/hello
@@ -69,7 +70,7 @@ test6:
 test7:
 	@ echo "=== TEST7"
 	$(MYST) package --pubkey=bad_public.pem bad_private.pem config.json
-	( MYST_ROOTFS_PATH=rootfs.ext2 ./myst/bin/hello 2> /dev/null; test "$$?" -eq "234" )
+	( MYST_ROOTFS_PATH=rootfs.ext2 ./myst/bin/hello 2> /dev/null; test "$$?" -eq "1" )
 
 # test package with nobrk enabled in config
 test8:
@@ -81,8 +82,7 @@ test8:
 test9:
 	@ echo "=== TEST9"
 	$(MYST) package appdir private.pem config.json
-	( ./myst/bin/hello --nobrk 2> result; test "$$?" -eq "255" )
-	diff result expected-nobrk-cli-option-error
+	( ./myst/bin/hello --nobrk 2> result; test "$$?" -eq "1" )
 
 clean:
 	rm -rf appdir rootfs.ext2 myst private.pem public.pem bad_roothash roothash bad_public.pem bad_private.pem .built result

--- a/tests/myst/package/expected-nobrk-cli-option-error
+++ b/tests/myst/package/expected-nobrk-cli-option-error
@@ -1,1 +1,0 @@
---nobrk not allowed for packaged applications. Can be enabled by setting NoBrk=true in config.json

--- a/tools/myst/config.c
+++ b/tools/myst/config.c
@@ -423,6 +423,15 @@ static json_result_t _json_read_callback(
                 else
                     CONFIG_RAISE(JSON_TYPE_MISMATCH);
             }
+            else if (json_match(parser, "HostUDS") == JSON_OK)
+            {
+                if (type == JSON_TYPE_BOOLEAN)
+                    parsed_data->host_uds = un->boolean;
+                else if (type == JSON_TYPE_INTEGER)
+                    parsed_data->host_uds = (un->integer == 0) ? false : true;
+                else
+                    CONFIG_RAISE(JSON_TYPE_MISMATCH);
+            }
             else
             {
                 // Ignore everything we dont understand

--- a/tools/myst/config.c
+++ b/tools/myst/config.c
@@ -428,7 +428,7 @@ static json_result_t _json_read_callback(
                 if (type == JSON_TYPE_BOOLEAN)
                     parsed_data->host_uds = un->boolean;
                 else if (type == JSON_TYPE_INTEGER)
-                    parsed_data->host_uds = (un->integer == 0) ? false : true;
+                    parsed_data->host_uds = (un->integer == 0);
                 else
                     CONFIG_RAISE(JSON_TYPE_MISMATCH);
             }

--- a/tools/myst/config.h
+++ b/tools/myst/config.h
@@ -75,6 +75,7 @@ typedef struct _config_parsed_data_t
     bool no_brk;
     bool exec_stack;
     bool unhandled_syscall_enosys;
+    bool host_uds;
 
     size_t main_stack_size;
     size_t thread_stack_size;

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -693,6 +693,7 @@ static long _enter(void* arg_)
                                      ? final_options.base.main_stack_size
                                      : MYST_PROCESS_INIT_STACK_SIZE;
         _kargs.thread_stack_size = final_options.base.thread_stack_size;
+        _kargs.host_uds = final_options.base.host_uds;
 
         /* whether user-space FSGSBASE instructions are supported */
         _kargs.have_fsgsbase_instructions =

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -470,6 +470,10 @@ int exec_action(int argc, const char* argv[], const char* envp[])
         if (cli_getopt(&argc, argv, "--report-native-tids", NULL) == 0)
             options.report_native_tids = true;
 
+        /* Get --host-uds option */
+        if (cli_getopt(&argc, argv, "--host-uds", NULL) == 0)
+            options.host_uds = true;
+
         /* Get --max-affinity-cpus */
         {
             const char* arg = NULL;

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -157,6 +157,10 @@ static void _get_options(
     if (cli_getopt(argc, argv, "--report-native-tids", NULL) == 0)
         opts->report_native_tids = true;
 
+    /* Get --nobrk option */
+    if (cli_getopt(argc, argv, "--host-uds", NULL) == 0)
+        opts->nobrk = true;
+
     if (get_fork_mode_opts(argc, argv, &opts->fork_mode) != 0)
         _err(
             "%s: invalid --fork-mode option. Only \"none\", "
@@ -495,19 +499,13 @@ static int _enter_kernel(
         }
     }
 
-    /* set the shell mode flag */
     kernel_args.shell_mode = final_options.base.shell_mode;
-
-    /* set whether debug symbols are needed */
     kernel_args.debug_symbols = final_options.base.debug_symbols;
-
     kernel_args.memcheck = final_options.base.memcheck;
-
     kernel_args.nobrk = final_options.base.nobrk;
-
     kernel_args.exec_stack = final_options.base.exec_stack;
-
     kernel_args.perf = final_options.base.perf;
+    kernel_args.host_uds = final_options.base.host_uds;
 
     /* check whether FSGSBASE instructions are supported */
     if (test_user_space_fsgsbase() == 0)

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -666,6 +666,17 @@ int _exec_package(
         goto done;
     }
 
+    /* Check --host-uds option */
+    if (cli_getopt(&argc, argv, "--host-uds", NULL) == 0)
+    {
+        fprintf(
+            stderr,
+            "--host-uds not allowed for packaged applications."
+            " Can be enabled by setting HostUDS=true in "
+            "config.json\n");
+        goto done;
+    }
+
     /* Get --perf option */
     if (cli_getopt(&argc, argv, "--perf", NULL) == 0)
         options.perf = true;
@@ -864,6 +875,7 @@ int _exec_package(
     */
     options.nobrk = parsed_data.no_brk ? true : false;
     options.exec_stack = parsed_data.exec_stack ? true : false;
+    options.host_uds = parsed_data.host_uds ? true : false;
 
     if ((details = create_region_details_from_package(
              &sections, parsed_data.heap_pages)) == NULL)

--- a/tools/myst/host/package.c
+++ b/tools/myst/host/package.c
@@ -70,13 +70,13 @@ static int _add_image_to_elf_section(
 
     if (myst_load_file(path, &image, &image_length) != 0)
     {
-        fprintf(stderr, "Failed to load %s", path);
+        _err("Failed to load %s", path);
         goto done;
     }
     if (elf_add_section(elf, section_name, SHT_PROGBITS, image, image_length) !=
         0)
     {
-        fprintf(stderr, "Failed to add %s to elf image", path);
+        _err("Failed to add %s to elf image", path);
         goto done;
     }
     free(image);
@@ -128,14 +128,14 @@ int _package(int argc, const char* argv[])
     if ((argc < 4) || (cli_getopt(&argc, argv, "--help", NULL) == 0) ||
         (cli_getopt(&argc, argv, "-h", NULL) == 0))
     {
-        fprintf(stderr, USAGE_PACKAGE, argv[0], argv[0]);
+        _err(USAGE_PACKAGE, argv[0], argv[0]);
         goto done;
     }
 
     /* Get the --outfile=file option */
     if (myst_getopt(&argc, argv, "--outfile", &outfile, err, sizeof(err)) < 0)
     {
-        fprintf(stderr, "%s: %s\n", argv[0], err);
+        _err("%s: %s\n", argv[0], err);
         exit(1);
     }
 
@@ -143,7 +143,7 @@ int _package(int argc, const char* argv[])
     if (!outfile &&
         myst_getopt(&argc, argv, "-o", &outfile, err, sizeof(err)) < 0)
     {
-        fprintf(stderr, "%s: %s\n", argv[0], err);
+        _err("%s: %s\n", argv[0], err);
         exit(1);
     }
 
@@ -153,12 +153,10 @@ int _package(int argc, const char* argv[])
     if ((signing_engine_key || signing_engine_name || signing_engine_path) &&
         (!signing_engine_key || !signing_engine_name || !signing_engine_path))
     {
-        fprintf(
-            stderr,
-            "If using a signing engine all three parameters are required: "
-            "--signing-engine-key, "
-            "--signing-engine-name and --signing-engine-path\n");
-        fprintf(stderr, USAGE_PACKAGE, argv[0], argv[0]);
+        _err("If using a signing engine all three parameters are required: "
+             "--signing-engine-key, "
+             "--signing-engine-name and --signing-engine-path\n");
+        _err(USAGE_PACKAGE, argv[0], argv[0]);
         return -1;
     }
 
@@ -190,13 +188,13 @@ int _package(int argc, const char* argv[])
     tmp_dir = mkdtemp(dir_template);
     if (tmp_dir == NULL)
     {
-        fprintf(stderr, "Failed to create temporary directory in /tmp\n");
+        _err("Failed to create temporary directory in /tmp\n");
         goto done;
     }
 
     if (snprintf(rootfs_file, PATH_MAX, "%s/rootfs.pkg", tmp_dir) >= PATH_MAX)
     {
-        fprintf(stderr, "File path too long? %s/rootfs.pkg\n", tmp_dir);
+        _err("File path too long? %s/rootfs.pkg\n", tmp_dir);
         goto done;
     }
 
@@ -210,8 +208,7 @@ int _package(int argc, const char* argv[])
         if (_mkcpio(
                 sizeof(mkcpio_args) / sizeof(mkcpio_args[0]), mkcpio_args) != 0)
         {
-            fprintf(
-                stderr,
+            _err(
                 "Failed to create root filesystem \"%s\" from directory "
                 "\"%s\"\n",
                 rootfs_file,
@@ -243,8 +240,7 @@ int _package(int argc, const char* argv[])
 
     if (parse_config_from_file(config_file, &parsed_data) != 0)
     {
-        fprintf(
-            stderr,
+        _err(
             "Failed to generate OE configuration file %s from Mystikos "
             "configuration file %s\n",
             scratch_path2,
@@ -268,8 +264,7 @@ int _package(int argc, const char* argv[])
     target = parsed_data.application_path;
     if ((target == NULL) || (target[0] != '/'))
     {
-        fprintf(
-            stderr,
+        _err(
             "target in config file must be fully qualified path within rootfs");
         goto done;
     }
@@ -277,13 +272,13 @@ int _package(int argc, const char* argv[])
     appname = strrchr(target, '/');
     if (appname == NULL)
     {
-        fprintf(stderr, "Failed to get appname from target path");
+        _err("Failed to get appname from target path");
         goto done;
     }
     appname++;
     if (*appname == '\0')
     {
-        fprintf(stderr, "Failed to get appname from target path");
+        _err("Failed to get appname from target path");
         goto done;
     }
 
@@ -313,7 +308,7 @@ int _package(int argc, const char* argv[])
                 sizeof(sign_engine_args) / sizeof(sign_engine_args[0]),
                 sign_engine_args) != 0)
         {
-            fprintf(stderr, "Failed to sign enclave file");
+            _err("Failed to sign enclave file");
             goto done;
         }
     }
@@ -340,7 +335,7 @@ int _package(int argc, const char* argv[])
                 sizeof(sign_engine_args) / sizeof(sign_engine_args[0]),
                 sign_engine_args) != 0)
         {
-            fprintf(stderr, "Failed to sign enclave file");
+            _err("Failed to sign enclave file");
             goto done;
         }
     }
@@ -362,7 +357,7 @@ int _package(int argc, const char* argv[])
         // Sign and copy everything into app.signed directory
         if (_sign(sizeof(sign_args) / sizeof(sign_args[0]), sign_args) != 0)
         {
-            fprintf(stderr, "Failed to sign enclave file");
+            _err("Failed to sign enclave file");
             goto done;
         }
     }
@@ -376,12 +371,12 @@ int _package(int argc, const char* argv[])
     // as named sections in the image
     if (snprintf(scratch_path, PATH_MAX, "%s/bin/myst", tmp_dir) >= PATH_MAX)
     {
-        fprintf(stderr, "File path to long: %s/bin/myst", tmp_dir);
+        _err("File path to long: %s/bin/myst", tmp_dir);
         goto done;
     }
     if (elf_load(scratch_path, &elf) != 0)
     {
-        fprintf(stderr, "Failed to load %s/bin/myst", tmp_dir);
+        _err("Failed to load %s/bin/myst", tmp_dir);
         goto done;
     }
 
@@ -390,18 +385,12 @@ int _package(int argc, const char* argv[])
             scratch_path, PATH_MAX, "%s/lib/openenclave/mystenc.so", tmp_dir) >=
         PATH_MAX)
     {
-        fprintf(
-            stderr,
-            "File path to long: %s/openenclave/lib/mystenc.so",
-            tmp_dir);
+        _err("File path to long: %s/openenclave/lib/mystenc.so", tmp_dir);
         goto done;
     }
     if (_add_image_to_elf_section(&elf, scratch_path, ".mystenc") != 0)
     {
-        fprintf(
-            stderr,
-            "Failed to add %s to enclave section .mystenc",
-            scratch_path);
+        _err("Failed to add %s to enclave section .mystenc", scratch_path);
         goto done;
     }
 
@@ -409,15 +398,13 @@ int _package(int argc, const char* argv[])
     if (snprintf(scratch_path, PATH_MAX, "%s/lib/libmystcrt.so", tmp_dir) >=
         PATH_MAX)
     {
-        fprintf(stderr, "File path to long: %s/lib/libmystcrt.so", tmp_dir);
+        _err("File path to long: %s/lib/libmystcrt.so", tmp_dir);
         goto done;
     }
     if (_add_image_to_elf_section(&elf, scratch_path, ".libmystcrt") != 0)
     {
-        fprintf(
-            stderr,
-            "Failed to add image %s to enclave section .lioscrt",
-            scratch_path);
+        _err(
+            "Failed to add image %s to enclave section .lioscrt", scratch_path);
         goto done;
     }
 
@@ -425,13 +412,12 @@ int _package(int argc, const char* argv[])
     if (snprintf(scratch_path, PATH_MAX, "%s/lib/libmystkernel.so", tmp_dir) >=
         PATH_MAX)
     {
-        fprintf(stderr, "File path to long: %s/lib/libmystkernel.so", tmp_dir);
+        _err("File path to long: %s/lib/libmystkernel.so", tmp_dir);
         goto done;
     }
     if (_add_image_to_elf_section(&elf, scratch_path, ".libmystkernel") != 0)
     {
-        fprintf(
-            stderr,
+        _err(
             "Failed to add image %s to enclave section .libmystkernel",
             scratch_path);
         goto done;
@@ -440,8 +426,7 @@ int _package(int argc, const char* argv[])
     // Add the rootfs to myst
     if (_add_image_to_elf_section(&elf, rootfs_file, ".mystrootfs") != 0)
     {
-        fprintf(
-            stderr,
+        _err(
             "Failed to add image %s to enclave section .mystrootfs",
             rootfs_file);
         goto done;
@@ -450,8 +435,7 @@ int _package(int argc, const char* argv[])
     // Add the pubkeys to myst
     if (_add_image_to_elf_section(&elf, pubkeys_file, ".mystpubkeys") != 0)
     {
-        fprintf(
-            stderr,
+        _err(
             "Failed to add image %s to enclave section .mystpubkeys",
             pubkeys_file);
         goto done;
@@ -461,8 +445,7 @@ int _package(int argc, const char* argv[])
     if (_add_image_to_elf_section(&elf, roothashes_file, ".mystroothashes") !=
         0)
     {
-        fprintf(
-            stderr,
+        _err(
             "Failed to add image %s to enclave section .mystroothashes",
             roothashes_file);
         goto done;
@@ -471,8 +454,7 @@ int _package(int argc, const char* argv[])
     // Add the config to myst
     if (_add_image_to_elf_section(&elf, config_file, ".mystconfig") != 0)
     {
-        fprintf(
-            stderr,
+        _err(
             "Failed to add image %s to enclave section .mystconfig",
             config_file);
         goto done;
@@ -482,14 +464,13 @@ int _package(int argc, const char* argv[])
     if (snprintf(scratch_path, PATH_MAX, "%s/bin/%s", tmp_dir, appname) >=
         PATH_MAX)
     {
-        fprintf(stderr, "File path to long: %s/bin/%s", tmp_dir, appname);
+        _err("File path to long: %s/bin/%s", tmp_dir, appname);
         goto done;
     }
     int fd = open(scratch_path, O_WRONLY | O_CREAT | O_TRUNC, 0774);
     if (fd == 0)
     {
-        fprintf(
-            stderr,
+        _err(
             "Failed to epn file to write final binary image back to %s",
             scratch_path);
         goto done;
@@ -497,10 +478,7 @@ int _package(int argc, const char* argv[])
     if (myst_write_file_fd(fd, elf.data, elf.size) != 0)
     {
         close(fd);
-        fprintf(
-            stderr,
-            "File to save final binary image back to: %s",
-            scratch_path);
+        _err("File to save final binary image back to: %s", scratch_path);
         goto done;
     }
     close(fd);
@@ -513,19 +491,19 @@ int _package(int argc, const char* argv[])
     // Create destination directory myst/bin
     if ((mkdir("myst", 0775) != 0) && (errno != EEXIST))
     {
-        fprintf(stderr, "Failed to make destination directory myst\n");
+        _err("Failed to make destination directory myst\n");
         goto done;
     }
     if ((mkdir("myst/bin", 0775) != 0) && (errno != EEXIST))
     {
-        fprintf(stderr, "Failed to make destination directory myst/bin\n");
+        _err("Failed to make destination directory myst/bin\n");
         goto done;
     }
 
     // Destination filename
     if (snprintf(scratch_path, PATH_MAX, "myst/bin/%s", appname) >= PATH_MAX)
     {
-        fprintf(stderr, "File path to long: myst/bin/%s", appname);
+        _err("File path to long: myst/bin/%s", appname);
         goto done;
     }
 
@@ -533,7 +511,7 @@ int _package(int argc, const char* argv[])
     if (snprintf(scratch_path2, PATH_MAX, "%s/bin/%s", tmp_dir, appname) >=
         PATH_MAX)
     {
-        fprintf(stderr, "File path to long: %s/bin/%s", tmp_dir, appname);
+        _err("File path to long: %s/bin/%s", tmp_dir, appname);
         goto done;
     }
 
@@ -542,8 +520,7 @@ int _package(int argc, const char* argv[])
 
     if (myst_copy_file(scratch_path2, outfile) != 0)
     {
-        fprintf(
-            stderr,
+        _err(
             "Failed to copy final package from %s to %s",
             scratch_path2,
             outfile);
@@ -648,32 +625,26 @@ int _exec_package(
     /* Check --nobrk option */
     if (cli_getopt(&argc, argv, "--nobrk", NULL) == 0)
     {
-        fprintf(
-            stderr,
-            "--nobrk not allowed for packaged applications."
-            " Can be enabled by setting NoBrk=true in config.json\n");
+        _err("--nobrk not allowed for packaged applications."
+             " Can be enabled by setting NoBrk=true in config.json\n");
         goto done;
     }
 
     /* Check --exec-stack option */
     if (cli_getopt(&argc, argv, "--exec-stack", NULL) == 0)
     {
-        fprintf(
-            stderr,
-            "--exec-stack not allowed for packaged applications."
-            " Can be enabled by setting ExecStack=true in "
-            "config.json\n");
+        _err("--exec-stack not allowed for packaged applications."
+             " Can be enabled by setting ExecStack=true in "
+             "config.json\n");
         goto done;
     }
 
     /* Check --host-uds option */
     if (cli_getopt(&argc, argv, "--host-uds", NULL) == 0)
     {
-        fprintf(
-            stderr,
-            "--host-uds not allowed for packaged applications."
-            " Can be enabled by setting HostUDS=true in "
-            "config.json\n");
+        _err("--host-uds not allowed for packaged applications."
+             " Can be enabled by setting HostUDS=true in "
+             "config.json\n");
         goto done;
     }
 
@@ -696,11 +667,7 @@ int _exec_package(
 
             if (!end || *end != '\0')
             {
-                fprintf(
-                    stderr,
-                    "%s: bad --max-affinity-cpus=%s option\n",
-                    argv[0],
-                    arg);
+                _err("%s: bad --max-affinity-cpus=%s option\n", argv[0], arg);
                 goto done;
             }
 
@@ -716,14 +683,13 @@ int _exec_package(
         {
             if (access(arg, R_OK) != 0)
             {
-                fprintf(stderr, "%s: bad --rootfs option: %s", argv[0], arg);
+                _err("%s: bad --rootfs option: %s", argv[0], arg);
                 goto done;
             }
 
             if (MYST_STRLCPY(options.rootfs, arg) >= sizeof(options.rootfs))
             {
-                fprintf(
-                    stderr,
+                _err(
                     "--rootfs option is too long (> %zu)\n",
                     sizeof(options.rootfs));
                 goto done;
@@ -743,7 +709,7 @@ int _exec_package(
 
     if (!realpath(argv[0], full_app_path))
     {
-        fprintf(stderr, "Invalid path %s\n", argv[0]);
+        _err("Invalid path %s\n", argv[0]);
         goto done;
     }
 
@@ -751,7 +717,7 @@ int _exec_package(
 
     if (!(app_name = strrchr(full_app_path, '/')))
     {
-        fprintf(stderr, "Invalid path (missing slash): %s\n", full_app_path);
+        _err("Invalid path (missing slash): %s\n", full_app_path);
         goto done;
     }
 
@@ -762,46 +728,45 @@ int _exec_package(
     // as well as the directory structure we need
     if ((unpack_dir = mkdtemp(unpack_dir_template)) == NULL)
     {
-        fprintf(stderr, "Failed to create unpack directory\n");
+        _err("Failed to create unpack directory\n");
         goto done;
     }
     if (snprintf(scratch_path, PATH_MAX, "%s/lib", unpack_dir) >= PATH_MAX)
     {
-        fprintf(stderr, "File path %s/lib is too long\n", unpack_dir);
+        _err("File path %s/lib is too long\n", unpack_dir);
         goto done;
     }
     if ((mkdir(scratch_path, DIR_MODE) != 0) && (errno != EEXIST))
     {
-        fprintf(stderr, "Failed to create directory \"%s\".\n", scratch_path);
+        _err("Failed to create directory \"%s\".\n", scratch_path);
         goto done;
     }
     if (snprintf(scratch_path, PATH_MAX, "%s/bin", unpack_dir) >= PATH_MAX)
     {
-        fprintf(stderr, "File path %s/bin is too long\n", unpack_dir);
+        _err("File path %s/bin is too long\n", unpack_dir);
         goto done;
     }
     if ((mkdir(scratch_path, DIR_MODE) != 0) && (errno != EEXIST))
     {
-        fprintf(stderr, "Failed to create directory \"%s\".\n", scratch_path);
+        _err("Failed to create directory \"%s\".\n", scratch_path);
         goto done;
     }
     if (snprintf(scratch_path, PATH_MAX, "%s/lib/openenclave", unpack_dir) >=
         PATH_MAX)
     {
-        fprintf(
-            stderr, "File path %s/lib/openenclave is too long\n", unpack_dir);
+        _err("File path %s/lib/openenclave is too long\n", unpack_dir);
         goto done;
     }
     if ((mkdir(scratch_path, DIR_MODE) != 0) && (errno != EEXIST))
     {
-        fprintf(stderr, "Failed to create directory \"%s\".\n", scratch_path);
+        _err("Failed to create directory \"%s\".\n", scratch_path);
         goto done;
     }
 
     // Load main executable so we can extract sections
     if (load_sections(get_program_file(), &sections) != 0)
     {
-        fprintf(stderr, "failed to load myst image: %s\n", get_program_file());
+        _err("failed to load myst image: %s\n", get_program_file());
         goto done;
     }
 
@@ -809,17 +774,12 @@ int _exec_package(
     if (snprintf(scratch_path, PATH_MAX, "%s/bin/%s", unpack_dir, app_name) >=
         PATH_MAX)
     {
-        fprintf(
-            stderr, "File path %s/bin/%s is too long\n", unpack_dir, app_name);
+        _err("File path %s/bin/%s is too long\n", unpack_dir, app_name);
         goto done;
     }
     if (myst_copy_file(get_program_file(), scratch_path) < 0)
     {
-        fprintf(
-            stderr,
-            "Failed to copy %s to %s\n",
-            get_program_file(),
-            scratch_path);
+        _err("Failed to copy %s to %s\n", get_program_file(), scratch_path);
         goto done;
     }
 
@@ -830,15 +790,14 @@ int _exec_package(
             "%s/lib/openenclave/mystenc.so",
             unpack_dir) >= PATH_MAX)
     {
-        fprintf(
-            stderr, "File path %s/lib/openenclave/ is too long\n", unpack_dir);
+        _err("File path %s/lib/openenclave/ is too long\n", unpack_dir);
         goto done;
     }
 
     if (myst_write_file(
             scratch_path, sections.mystenc_data, sections.mystenc_size) != 0)
     {
-        fprintf(stderr, "Failed to write %s\n", scratch_path);
+        _err("Failed to write %s\n", scratch_path);
         goto done;
     }
 
@@ -851,7 +810,7 @@ int _exec_package(
             sections.mystconfig_size,
             &parsed_data) != 0)
     {
-        fprintf(stderr, "Failed to process configuration\n");
+        _err("Failed to process configuration\n");
     }
     if ((parsed_data.allow_host_parameters == 0) && (argc > 1))
     {
@@ -860,8 +819,7 @@ int _exec_package(
     }
     if (parsed_data.application_path == NULL)
     {
-        fprintf(
-            stderr,
+        _err(
             "No target filename in configuration. This should be the fully "
             "qualified path to the executable within the "
             "%s directory, but should be relative to this directory\n",
@@ -873,14 +831,14 @@ int _exec_package(
        Enable nobrk option only when config.json sets NoBrk=true.
        Else, default to false.
     */
-    options.nobrk = parsed_data.no_brk ? true : false;
-    options.exec_stack = parsed_data.exec_stack ? true : false;
-    options.host_uds = parsed_data.host_uds ? true : false;
+    options.nobrk = parsed_data.no_brk;
+    options.exec_stack = parsed_data.exec_stack;
+    options.host_uds = parsed_data.host_uds;
 
     if ((details = create_region_details_from_package(
              &sections, parsed_data.heap_pages)) == NULL)
     {
-        fprintf(stderr, "Failed to extract all sections\n");
+        _err("Failed to extract all sections\n");
         goto done;
     }
 
@@ -893,20 +851,19 @@ int _exec_package(
 
             if (!(env = getenv("MYST_ROOTFS_PATH")))
             {
-                fprintf(stderr, "MYST_ROOTFS_PATH is undefined\n");
+                _err("MYST_ROOTFS_PATH is undefined\n");
                 goto done;
             }
 
             if (access(env, R_OK) != 0)
             {
-                fprintf(stderr, "MYST_ROOTFS_PATH=%s not found\n", env);
+                _err("MYST_ROOTFS_PATH=%s not found\n", env);
                 goto done;
             }
 
             if (MYST_STRLCPY(options.rootfs, env) >= sizeof(options.rootfs))
             {
-                fprintf(
-                    stderr,
+                _err(
                     "MYST_ROOTFS_PATH is too long (> %zu)\n",
                     sizeof(options.rootfs));
                 goto done;
@@ -926,7 +883,7 @@ int _exec_package(
     exec_args = malloc((num_args + 1) * sizeof(char*));
     if (exec_args == NULL)
     {
-        fprintf(stderr, "out of memory\n");
+        _err("out of memory\n");
         goto done;
     }
     exec_args[0] = parsed_data.application_path;
@@ -944,8 +901,7 @@ int _exec_package(
             "%s/lib/openenclave/mystenc.so",
             unpack_dir) >= PATH_MAX)
     {
-        fprintf(
-            stderr, "File path %s/lib/openenclave/ is too long\n", unpack_dir);
+        _err("File path %s/lib/openenclave/ is too long\n", unpack_dir);
         goto done;
     }
 
@@ -953,7 +909,7 @@ int _exec_package(
         scratch_path, type, flags, exec_args, envp, &mount_mappings, &options);
     if (ret != 0)
     {
-        fprintf(stderr, "Enclave %s returned %d\n", scratch_path, ret);
+        _err("Enclave %s returned %d\n", scratch_path, ret);
         goto done;
     }
 

--- a/tools/myst/myst.edl
+++ b/tools/myst/myst.edl
@@ -159,8 +159,7 @@ enclave
             int epfd,
             [out, count=maxevents] struct epoll_event* events,
             size_t maxevents,
-            int timeout)
-            transition_using_threads;
+            int timeout);
 
         long myst_epoll_ctl_ocall(
             int epfd,

--- a/tools/myst/options.c
+++ b/tools/myst/options.c
@@ -71,6 +71,7 @@ long determine_final_options(
         final_opts->base.exec_stack = parsed_config->exec_stack;
         final_opts->base.unhandled_syscall_enosys =
             parsed_config->unhandled_syscall_enosys;
+        final_opts->base.host_uds = parsed_config->host_uds;
 
         // Some options should not be enabled unless running in debug mode
         if (tee_debug_mode)


### PR DESCRIPTION
### Summary
- Add configuration flag to choose host socket device for Unix domain sockets.  Can be specified via `HostUDS` in JSON config file or `--host-uds` on the command line.
- Turn off switchless ocall for epoll_wait. This is to avoid issues with thread interruption of threads performing switchless calls.