### PR TITLE
Add error checking and retries

### DIFF
--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -73,15 +73,17 @@ pipeline {
         }
         stage('Init Config') {
             steps {
-                sh """
-                   # Initialize dependencies repo
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-config.sh
+                retry(5) {
+                    sh """
+                        # Initialize dependencies repo
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-config.sh
 
-                   # Install global dependencies
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-install.sh
-                   """
+                        # Install global dependencies
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-install.sh
+                    """
+                }
             }
         }
         stage('Setup AZ CLI') {

--- a/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
@@ -73,15 +73,17 @@ pipeline {
         }
         stage('Init Config') {
             steps {
-                sh """
-                   # Initialize dependencies repo
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-config.sh
+                retry(5) {
+                    sh """
+                        # Initialize dependencies repo
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-config.sh
 
-                   # Install global dependencies
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-install.sh
-                   """
+                        # Install global dependencies
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-install.sh
+                    """
+                }
             }
         }
         stage('Build repo source') {

--- a/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
@@ -73,15 +73,17 @@ pipeline {
         }
         stage('Init Config') {
             steps {
-                sh """
-                   # Initialize dependencies repo
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-config.sh
+                retry(5) {
+                    sh """
+                        # Initialize dependencies repo
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-config.sh
 
-                   # Install global dependencies
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-install.sh
-                   """
+                        # Install global dependencies
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-install.sh
+                    """
+                }
             }
         }
         stage('Build repo source') {

--- a/.jenkins/pipelines/standalone/openmp-testsuite.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/openmp-testsuite.Jenkinsfile
@@ -66,15 +66,17 @@ pipeline {
         }
         stage('Init Config') {
             steps {
-                sh """
-                   # Initialize dependencies repo
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-config.sh
+                retry(5) {
+                    sh """
+                        # Initialize dependencies repo
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-config.sh
 
-                   # Install global dependencies
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-install.sh
-                   """
+                        # Install global dependencies
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-install.sh
+                    """
+                }
             }
         }
         stage('Build repo source') {

--- a/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
@@ -65,15 +65,17 @@ pipeline {
         }
         stage('Init Config') {
             steps {
-                sh """
-                   # Initialize dependencies repo
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-config.sh
+                retry(5) {
+                    sh """
+                        # Initialize dependencies repo
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-config.sh
 
-                   # Install global dependencies
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-install.sh
-                   """
+                        # Install global dependencies
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-install.sh
+                    """
+                }
             }
         }
         stage('Build repo source') {

--- a/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
@@ -75,15 +75,17 @@ pipeline {
         }
         stage('Init Config') {
             steps {
-                sh """
-                   # Initialize dependencies repo
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-config.sh
+                retry(5) {
+                    sh """
+                        # Initialize dependencies repo
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-config.sh
 
-                   # Install global dependencies
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-install.sh
-                   """
+                        # Install global dependencies
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-install.sh
+                    """
+                }
             }
         }
         stage('Build repo source') {

--- a/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
@@ -73,15 +73,17 @@ pipeline {
         }
         stage('Init Config') {
             steps {
-                sh """
-                   # Initialize dependencies repo
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-config.sh
+                retry(5) {
+                    sh """
+                        # Initialize dependencies repo
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-config.sh
 
-                   # Install global dependencies
-                   ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
-                   ${JENKINS_SCRIPTS}/global/init-install.sh
-                   """
+                        # Install global dependencies
+                        ${JENKINS_SCRIPTS}/global/wait-dpkg.sh
+                        ${JENKINS_SCRIPTS}/global/init-install.sh
+                    """
+                }
             }
         }
         stage('Build repo source') {

--- a/.jenkins/scripts/global/build-repo-source.sh
+++ b/.jenkins/scripts/global/build-repo-source.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -e
 
 make distclean
 make -j world

--- a/.jenkins/scripts/global/clean-temp.sh
+++ b/.jenkins/scripts/global/clean-temp.sh
@@ -1,2 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
 sudo rm -rf /tmp/myst*
 df

--- a/.jenkins/scripts/global/init-config.sh
+++ b/.jenkins/scripts/global/init-config.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get update

--- a/.jenkins/scripts/global/init-install.sh
+++ b/.jenkins/scripts/global/init-install.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 sudo apt-get install \
   build-essential    \
   lcov               \

--- a/.jenkins/scripts/global/make-build.sh
+++ b/.jenkins/scripts/global/make-build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -e
 
 sudo rm -rf $(git ls-files --others --directory)
 make distclean

--- a/.jenkins/scripts/global/make-sdk-tests.sh
+++ b/.jenkins/scripts/global/make-sdk-tests.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 sudo rm -rf $(git ls-files --others --directory)
 make distclean
 make -j

--- a/.jenkins/scripts/global/make-tests.sh
+++ b/.jenkins/scripts/global/make-tests.sh
@@ -1,1 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
 make -j tests ALLTESTS=1 VERBOSE=1 MYST_SKIP_LTP_TESTS=1

--- a/.jenkins/scripts/global/make-world.sh
+++ b/.jenkins/scripts/global/make-world.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 sudo rm -rf $(git ls-files --others --directory)
 make distclean
 make -j world

--- a/.jenkins/scripts/global/package-install.sh
+++ b/.jenkins/scripts/global/package-install.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -e
 
 rm -rf build
 make release-build

--- a/.jenkins/scripts/global/wait-dpkg.sh
+++ b/.jenkins/scripts/global/wait-dpkg.sh
@@ -1,1 +1,4 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
 while sudo lsof /var/lib/dpkg/lock-frontend | grep dpkg; do sleep 3; done

--- a/.jenkins/scripts/solutions/make-build.sh
+++ b/.jenkins/scripts/solutions/make-build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 sudo rm -rf $(git ls-files --others --directory)
 make distclean


### PR DESCRIPTION
During the init stage, apt-get would silently fail leading to test errors downstream. This should provide a bit of robustness to initialization steps when there are transitory issues such as network connectivity.

E.g.
```
[2022-06-16T07:01:40.675Z]   Unable to connect to azure.archive.ubuntu.com:http:
[2022-06-16T07:01:40.675Z] Err:8 http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 libmbedtls-dev amd64 2.8.0-1
[2022-06-16T07:01:40.675Z]   Unable to connect to azure.archive.ubuntu.com:http:
[2022-06-16T07:01:40.675Z] Err:9 http://azure.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 llvm-7-runtime amd64 1:7-3~ubuntu0.18.04.1
[2022-06-16T07:01:40.675Z]   Unable to connect to azure.archive.ubuntu.com:http:
[2022-06-16T07:01:40.675Z] Err:10 http://azure.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 llvm-7 amd64 1:7-3~ubuntu0.18.04.1
[2022-06-16T07:01:40.675Z]   Unable to connect to azure.archive.ubuntu.com:http:
[2022-06-16T07:01:40.675Z] Err:11 http://azure.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 llvm-7-dev amd64 1:7-3~ubuntu0.18.04.1
[2022-06-16T07:01:40.675Z]   Unable to connect to azure.archive.ubuntu.com:http:
[2022-06-16T07:01:40.675Z] Err:12 http://azure.archive.ubuntu.com/ubuntu bionic/main amd64 libgd-perl amd64 2.66-1build1
```
Signed-off-by: Chris Yan <chrisyan@microsoft.com>