### PR TITLE
Update makefile in order to build in CDPX

### DIFF
--- a/third_party/openenclave/Makefile
+++ b/third_party/openenclave/Makefile
@@ -67,6 +67,7 @@ openenclave:
 	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/openssl/intel-sgx-ssl )
 	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/snmalloc )
 	( cd openenclave; $(FETCH_SUBMODULE) 3rdparty/symcrypt_engine/SymCrypt-OpenSSL )
+	$(MAKE) configure_oe
 
 configure_oe: $(OPENENCLAVE_BUILD)/Makefile
 


### PR DESCRIPTION
Signed-off-by: Radhika Jandhyala <radhikaj@microsoft.com>

In the cmake step, OE pulls down new libs. So moving configure_oe to the init step of CDPX. Confirmed it can build in CDPX.