### PR TITLE
Enable CodeQL manual run and change auto run to 9am local time

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 16 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,7 @@ name: "CodeQL"
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
1. Add ability to manually trigger CodeQL workflow
2. Change auto run time from 5pm (00:00 UTC time) to 9am Los Angles time zone (16:00 UTC time)