### PR TITLE
Copy host address before access

### DIFF
--- a/include/myst/clock.h
+++ b/include/myst/clock.h
@@ -13,8 +13,13 @@ struct clock_ctrl
     long monotime0;
     volatile long now;
     unsigned long interval;
-    volatile int done;
+    // Using long to make the size of this struct a multiplier of 8 bytes
+    volatile long done;
 };
+
+_Static_assert(
+    sizeof(struct clock_ctrl) == 40,
+    "Size of clock_ctrl should be multiplier of 8 bytes");
 
 int myst_setup_clock(struct clock_ctrl*);
 

--- a/third_party/openenclave/Makefile
+++ b/third_party/openenclave/Makefile
@@ -6,7 +6,7 @@ BUILDDIR=${TOP}/build
 
 URL=https://github.com/openenclave/openenclave
 BRANCH=master
-COMMIT=d8e6c143eef73bce8306960c874b694e5317e02e
+COMMIT=d8e1004945f255a7b7b62f4cb3bb43e0e3a83c0a
 
 OPENENCLAVE_INSTALL_PREFIX=$(BUILDDIR)/openenclave
 OPENENCLAVE_SRC = $(CURDIR)/openenclave


### PR DESCRIPTION
Also, changed `struct clock` to make its size a multiplier of 8 bytes.
Signed-off-by: Zijie Wu <zijiewu@microsoft.com>