### PR TITLE
Print stacktrace on SIGSEGV exceptions

### DIFF
--- a/include/myst/backtrace.h
+++ b/include/myst/backtrace.h
@@ -7,6 +7,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+size_t myst_backtrace3(void** start_frame, void** buffer, size_t size);
+
 size_t myst_backtrace(void** buffer, size_t size);
 
 void myst_dump_backtrace(void** buffer, size_t size);

--- a/kernel/backtrace.c
+++ b/kernel/backtrace.c
@@ -21,6 +21,11 @@ size_t myst_backtrace_impl(void** start_frame, void** buffer, size_t size)
 
     while (n < size)
     {
+        /*
+        Checks:
+        - frame address lies in some kstack
+        - return address - frame[1], lies within kernel
+        */
         if (!myst_within_stack(frame) || !myst_is_addr_within_kernel(frame[1]))
             break;
 
@@ -34,6 +39,11 @@ size_t myst_backtrace_impl(void** start_frame, void** buffer, size_t size)
 size_t myst_backtrace(void** buffer, size_t size)
 {
     return myst_backtrace_impl(__builtin_frame_address(0), buffer, size);
+}
+
+size_t myst_backtrace3(void** start_frame, void** buffer, size_t size)
+{
+    return myst_backtrace_impl(start_frame, buffer, size);
 }
 
 static int _symtab_get_string(
@@ -146,10 +156,7 @@ void myst_dump_backtrace(void** buffer, size_t size)
             if (_addr_to_func_name(addr, &name) == 0)
                 myst_eprintf("%p: %s()\n", buffer[i], name);
             else
-            {
-                /* ignore unnknown addresses */
-                break;
-            }
+                myst_eprintf("%p: <unknown address>\n", buffer[i]);
         }
     }
 }

--- a/kernel/syslog.c
+++ b/kernel/syslog.c
@@ -30,7 +30,7 @@ void __myst_vsyslog(
     const int pri = (priority & 7);
     const char* name = _names[pri];
 
-    if (!(pri <= __myst_kernel_args.syslog_level))
+    if (__myst_kernel_args.syslog_level < pri)
         return;
 
     switch (pri)


### PR DESCRIPTION
Currently this only prints functions names for exceptions originated in the kernel. Supporting application symbols would require the kernel to store some symbol information about loaded modules.

Sample output from a forced kernel crash -
```
*** Kernel segmentation fault 
0x1007c0448: _fs_read()
0x1007b3904: _fs_read()
0x1007f7080: myst_syscall_read()
0x1007fe9c8: _SYS_read()
0x1008059f8: _syscall()
0x10082b4e2: __morestack()
```

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>