### PR TITLE
Fix issue #946

### DIFF
--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -1252,6 +1252,10 @@ int myst_exec(
 
 done:
 
+    /*To make sure argv is released in case or errors*/
+    if (callback)
+        (*callback)(callback_arg);
+
     if (stack)
         myst_munmap(stack, __myst_kernel_args.main_stack_size);
 


### PR DESCRIPTION
Just observed that the callback wasn't called after done, and added a call to make sure argv is deallocated.