### PR TITLE
Pandas CI fix: Check only for error code

### DIFF
--- a/solutions/pandas_tests/Makefile
+++ b/solutions/pandas_tests/Makefile
@@ -66,10 +66,7 @@ run-partial: rootfs
 	diff -B -w test_summary expected-test-summary
 
 run-dst: rootfs
-	rm result_test_dst || true
-	$(MYST_EXEC) rootfs $(OPTS) $(PYTEST_CMD) $(TEST_DST) 2>&1 > result_test_dst || true
-	sed -i '$$d' result_test_dst
-	diff -B -w result_test_dst expected_test_dst
+	./run-test-dst.sh $(MYST_EXEC) rootfs $(OPTS) $(PYTEST_CMD) $(TEST_DST)
 
 _run: rootfs
 	$(MAKE) run-partial

--- a/solutions/pandas_tests/expected_test_dst
+++ b/solutions/pandas_tests/expected_test_dst
@@ -1,14 +1,0 @@
-[1m============================= test session starts ==============================[0m
-platform linux -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0
-rootdir: /, configfile: pytest.ini
-plugins: hypothesis-6.52.1
-[1mcollecting ... [0m[1mcollected 0 items / 1 error                                                    [0m
-
-==================================== ERRORS ====================================
-[31m[1m_ ERROR collecting usr/local/lib/python3.9/site-packages/pandas/tests/tseries/offsets/test_dst.py _[0m
-[1m[31m/usr/local/lib/python3.9/site-packages/pandas/tests/tseries/offsets/test_dst.py[0m:190: in <module>
-    float(pytz.__version__) <= 2020.1,  # type: ignore[attr-defined]
-[1m[31mE   ValueError: could not convert string to float: '2022.2.1'[0m
-=========================== short test summary info ============================
-ERROR ../usr/local/lib/python3.9/site-packages/pandas/tests/tseries/offsets/test_dst.py
-!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!

--- a/solutions/pandas_tests/run-test-dst.sh
+++ b/solutions/pandas_tests/run-test-dst.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Run program passed in cmdline args
+$*
+
+# expected error code is 2
+if [ "$?" != "2" ]; then
+    exit 1
+fi


### PR DESCRIPTION
We run the test with the expected error code. Once the [pandas PR](https://github.com/pandas-dev/pandas/pull/48065) gets reflected in released Pypi pandas package, this workaround can be removed.

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>