### PR TITLE
Add syslog level configuration and add info logs during startup

### DIFF
--- a/doc/sign-package.md
+++ b/doc/sign-package.md
@@ -117,6 +117,7 @@ Hostname | `string` | The default hostname exposed to application
 ForkMode | `string` | Specify the mode used for the experimental pseudo fork feature. Refer to [doc/design/fork.md](/doc/design/fork.md) for more details. The default value is `"none"`, which disables the feature.
 Mount | `object` | Set if parameters for informing Mystikos to automatically mount a set of directories or ext2 disk images from the host into the TEE. Refer to [doc/design/mount-config-design.md](/doc/design/mount-config-design.md) for more details. By default no extra mounts are added to the root filesystem.
 UnhandledSyscallEnosys | `boolean \| int` | This option would prevent the termination of a program using myst_panic when the application invokes a syscall that is not handled by the Mystikos kernel. The default value is `false`, which implies that we terminate on unhandled syscalls by default. If `true`, it will cause the syscall to return an ENOSYS error.
+SyslogLevel | `string` | System logger's output level. Should be one of: emerg, alert, crit, err, warn, notice, info or debug. 
 
 ---
 

--- a/include/myst/options.h
+++ b/include/myst/options.h
@@ -32,6 +32,7 @@ typedef struct myst_options
     myst_fork_mode_t fork_mode;
     myst_host_enc_uid_gid_mappings host_enc_uid_gid_mappings;
     myst_strace_config_t strace_config;
+    int syslog_level;
 } myst_options_t;
 
 typedef struct myst_final_options

--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -757,11 +757,15 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     __myst_kernel_args = *args;
     args = &__myst_kernel_args;
 
-    /* set the syslog level, depending on whether in TEE debug mode */
-    if (args->tee_debug_mode)
-        args->syslog_level = LOG_DEBUG;
-    else
-        args->syslog_level = LOG_NOTICE;
+    /* If no syslog level config was specified set defaults depending on whether
+     * in TEE debug mode */
+    if (args->syslog_level == -1)
+    {
+        if (args->tee_debug_mode)
+            args->syslog_level = LOG_DEBUG;
+        else
+            args->syslog_level = LOG_NOTICE;
+    }
 
     /* turn off or reduce various options when TEE is not in debug mode */
     if (!args->tee_debug_mode)
@@ -797,6 +801,8 @@ int myst_enter_kernel(myst_kernel_args_t* args)
      * be used prior to this point */
     if (myst_setup_mman(args->mman_data, args->mman_size) != 0)
         ERAISE(-EINVAL);
+
+    MYST_ILOG("Entered Mystikos kernel.");
 
     /* call global constructors within the kernel */
     myst_call_init_functions();

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -1238,6 +1238,7 @@ int myst_exec(
     if (callback)
         (*callback)(callback_arg);
 
+    MYST_ILOG("Entering CRT.");
     /* enter the C-runtime on the target thread descriptor */
     (*enter)(sp, dynv, myst_syscall, crt_args);
 

--- a/tools/myst/config.h
+++ b/tools/myst/config.h
@@ -76,6 +76,7 @@ typedef struct _config_parsed_data_t
     bool exec_stack;
     bool unhandled_syscall_enosys;
     bool host_uds;
+    int syslog_level;
 
     size_t main_stack_size;
     size_t thread_stack_size;

--- a/tools/myst/enc/enc.c
+++ b/tools/myst/enc/enc.c
@@ -180,8 +180,8 @@ static uint64_t _forward_exception_as_signal_to_kernel(
         // convention as myst_handle_host_signal is expected to be called
         oe_context->rsp = (rsp & -16) - 8;
         oe_context->rbp = rbp;
-        oe_context->rdi = (__typeof(oe_context->rdi))&siginfo;
-        oe_context->rsi = (__typeof(oe_context->rsi))&mcontext;
+        oe_context->rdi = (__typeof(oe_context->rdi)) & siginfo;
+        oe_context->rsi = (__typeof(oe_context->rsi)) & mcontext;
 
         return OE_EXCEPTION_CONTINUE_EXECUTION;
     }
@@ -694,6 +694,7 @@ static long _enter(void* arg_)
                                      : MYST_PROCESS_INIT_STACK_SIZE;
         _kargs.thread_stack_size = final_options.base.thread_stack_size;
         _kargs.host_uds = final_options.base.host_uds;
+        _kargs.syslog_level = final_options.base.syslog_level;
 
         /* whether user-space FSGSBASE instructions are supported */
         _kargs.have_fsgsbase_instructions =

--- a/tools/myst/host/exec.c
+++ b/tools/myst/host/exec.c
@@ -456,6 +456,8 @@ Options:\n\
                             from the output. Can be used in conjunction with any of the above filters \n\
                             E.g: To filter by pid=101, specify - \n\
                             --strace-filter-pid=101\n\
+    --syslog-level=<emerg|alert|crit|err|warn|notice|info|debug>\n\
+                         -- Configure kernel's system logger level \n\
 \n"
 
 int exec_action(int argc, const char* argv[], const char* envp[])
@@ -574,6 +576,14 @@ int exec_action(int argc, const char* argv[], const char* envp[])
                 argv[0]);
             return 1;
         }
+
+        if (get_syslog_level_opts(&argc, argv, &options.syslog_level) != 0)
+            _err(
+                "%s: invalid --syslog-level option. Should be one of - "
+                "\"emerg\", "
+                "\"alert\", \"crit\", \"err\", \"warn\", \"notice\", "
+                "\"info\", \"debug\".",
+                argv[0]);
 
         /* Get MYST_MEMCHECK environment variable */
         {

--- a/tools/myst/host/exec_linux.c
+++ b/tools/myst/host/exec_linux.c
@@ -122,6 +122,8 @@ Options:\n\
                             from the output. Can be used in conjunction with any of the above filters \n\
                             E.g: To filter by pid=101, specify - \n\
                             --strace-filter-pid=101\n\
+    --syslog-level=<emerg|alert|crit|err|warn|notice|info|debug>\n\
+                         -- Configure kernel's system logger level \n\
 \n\
 "
 
@@ -202,6 +204,13 @@ static void _get_options(
             "%s: invalid --fork-mode option. Only \"none\", "
             "\"pseudo\" and \"pseudo_wait_for_exit_exec\" are currently "
             "supported\n",
+            argv[0]);
+
+    if (get_syslog_level_opts(argc, argv, &opts->syslog_level) != 0)
+        _err(
+            "%s: invalid --syslog-level option. Should be one of - \"emerg\", "
+            "\"alert\", \"crit\", \"err\", \"warn\", \"notice\", \"info\", "
+            "\"debug\".",
             argv[0]);
 
     /* Get --max-affinity-cpus */
@@ -542,6 +551,7 @@ static int _enter_kernel(
     kernel_args.exec_stack = final_options.base.exec_stack;
     kernel_args.perf = final_options.base.perf;
     kernel_args.host_uds = final_options.base.host_uds;
+    kernel_args.syslog_level = final_options.base.syslog_level;
 
     /* check whether FSGSBASE instructions are supported */
     if (test_user_space_fsgsbase() == 0)

--- a/tools/myst/host/utils.c
+++ b/tools/myst/host/utils.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <syslog.h>
 #include <unistd.h>
 
 #include <myst/args.h>
@@ -20,6 +21,7 @@
 #include <myst/strings.h>
 #include <myst/which.h>
 
+#include "../shared.h"
 #include "utils.h"
 
 char _program[PATH_MAX];
@@ -297,6 +299,34 @@ int get_fork_mode_opts(
             *fork_mode = myst_fork_pseudo_wait_for_exit_exec;
         }
         else
+            return -1;
+    }
+
+    return 0;
+}
+
+/* if --syslog-level=<arg> option present and arg is one of the valid values - 0
+ * through 7, returns 0 and sets the syslog_level pointer. For other values of
+ * arg, returns -1. If --syslog-level option not present, sets syslog_level to
+ * -1.
+ */
+int get_syslog_level_opts(int* argc, const char* argv[], int* syslog_level)
+{
+    const char* arg = NULL;
+
+    if (syslog_level == 0)
+        return -1;
+
+    *syslog_level = -1;
+
+    if (cli_getopt(argc, argv, "--syslog-level", &arg) == 0)
+    {
+        if (arg == NULL)
+            return -1;
+
+        *syslog_level = myst_syslog_level_str_to_int(arg);
+        if (*syslog_level == -1)
+            // unknown syslog level
             return -1;
     }
 

--- a/tools/myst/host/utils.h
+++ b/tools/myst/host/utils.h
@@ -59,6 +59,8 @@ int get_fork_mode_opts(
     const char* argv[],
     myst_fork_mode_t* fork_mode);
 
+int get_syslog_level_opts(int* argc, const char* argv[], int* syslog_level);
+
 long myst_add_symbol_file_by_path(
     const char* path,
     const void* text_data,

--- a/tools/myst/options.c
+++ b/tools/myst/options.c
@@ -72,6 +72,7 @@ long determine_final_options(
         final_opts->base.unhandled_syscall_enosys =
             parsed_config->unhandled_syscall_enosys;
         final_opts->base.host_uds = parsed_config->host_uds;
+        final_opts->base.syslog_level = parsed_config->syslog_level;
 
         // Some options should not be enabled unless running in debug mode
         if (tee_debug_mode)

--- a/tools/myst/shared.h
+++ b/tools/myst/shared.h
@@ -27,4 +27,6 @@ long determine_final_options(
     const char* target_env_var,
     myst_args_t* mount_mappings);
 
+int myst_syslog_level_str_to_int(const char* syslog_level_str);
+
 #endif /* _MYST_MYST_SHARED_H */


### PR DESCRIPTION
### Summary
- Syslog level can be specified either via --syslog-level command line option or SyslogLevel in the JSON configuration.
- Added info logs on mystikos kernel entry and before jumping to C runtime. These can be helpful to debug startup failures.

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>