### PR TITLE
Increase python webserver memory

### DIFF
--- a/solutions/python_webserver/Makefile
+++ b/solutions/python_webserver/Makefile
@@ -9,7 +9,7 @@ ifdef STRACE
 OPTS += --strace
 endif
 
-OPTS += --memory-size=256m --max-affinity-cpus=4
+OPTS += --memory-size=1g --thread-stack-size=1m
 
 ifdef PERF
 OPTS += --perf
@@ -45,6 +45,9 @@ _run:
 	
 run:
 	$(RUNTEST) make -C $(CURDIR) _run
+
+server:
+	$(MYST_EXEC) $(OPTS) rootfs /miniconda/bin/python3 /app/hello_server.py
 
 clean:
 	test -f server.pid && kill -9 `cat server.pid` || true


### PR DESCRIPTION
Python memory allocator usage is proportional to number of cores. With current 256m setting, this leaves insufficient memory for OpenBLAS(used by numpy) allocations on ICX machines. OpenBLAS code doesn't seem to be checking for failed malloc() returns, which causes a segmentation fault. This patch increases the memory size to avoid this situation.

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>