### PR TITLE
Codeql fixes

### DIFF
--- a/host/maps.c
+++ b/host/maps.c
@@ -118,7 +118,7 @@ int myst_maps_load(myst_maps_t** maps_out)
             &inode,
             &path_offset);
 
-        if (n < 9)
+        if (n < 10)
         {
             ret = -ENOSYS;
             goto done;

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -314,7 +314,7 @@ static int _add_file_mapping(int fd, off_t offset, void* addr, size_t length)
     bool locked = false;
     size_t index, file_size;
     vectors_t v = _get_vectors();
-    mman_file_handle_t* file_handle;
+    mman_file_handle_t* file_handle = NULL;
 
     if (fd < 0 || offset < 0 || !addr || !length)
         ERAISE(-EINVAL);
@@ -997,8 +997,6 @@ int myst_release_process_mappings(pid_t pid)
     fdlist_t* catchall = NULL;
 
     assert(pid > 0);
-    if (pid <= 0)
-        return -EINVAL;
 
     /* Acquire filesystem lock, as writeback may happen for process owned
      * MAP_SHARED mappings. */

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -5092,8 +5092,7 @@ static long _SYS_prctl(long n, long params[6])
             return (_return(n, -EINVAL));
 
         // ATTN: Linux requires a 16-byte buffer:
-        const size_t n = 16;
-        myst_strlcpy(arg2, myst_get_thread_name(myst_thread_self()), n);
+        myst_strlcpy(arg2, myst_get_thread_name(myst_thread_self()), 16);
         ret = 0;
     }
     else if (option == PR_SET_NAME)

--- a/kernel/udsdev.c
+++ b/kernel/udsdev.c
@@ -857,7 +857,6 @@ static int _udsdev_bind(
 {
     int ret = 0;
     const struct sockaddr_un* sun = (const struct sockaddr_un*)addr;
-    int fd = -1;
 
     if (!dev || !_valid_sock(sock) || !addr || !addrlen)
         ERAISE(-EINVAL);
@@ -903,9 +902,6 @@ static int _udsdev_bind(
     memcpy(&_obj(sock)->bind_addr, sun, sizeof(_obj(sock)->bind_addr));
 
 done:
-
-    if (fd >= 0)
-        close(fd);
 
     return ret;
 }

--- a/tools/myst/enc/syscall.c
+++ b/tools/myst/enc/syscall.c
@@ -631,7 +631,7 @@ static long _getsockname(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
         goto done;
     }
 
-    if (!addr || !addrlen || *addrlen < 0)
+    if (!addr || !addrlen)
     {
         ret = -EINVAL;
         goto done;


### PR DESCRIPTION
**kernel/udsdev.c:_udsdev_bind**
https://github.com/deislabs/mystikos/security/code-scanning/3101
fd was declared in the bind function, but never used. Removed fd references altogether.

**kernel/mmanutils.c:myst_release_process_mappings**
assert(pid > 0) is followed by a check if pid <= 0. Removed the check.
https://github.com/deislabs/mystikos/security/code-scanning/3453

**tools/myst/enc/syscall.c: _getsockname**
https://github.com/deislabs/mystikos/security/code-scanning/2983

Checking for *addrlen < 0, where addrlen is a pointer to socklen_t, an unsigned integer value.

><sys/socket.h> makes available a type, socklen_t, which is an unsigned opaque integral type of length of at least 32 bits. To >forestall portability problems, it is recommended that applications should not use values larger than 232 - 1.

From https://pubs.opengroup.org/onlinepubs/7908799/xns/syssocket.h.html

The confusion seems to be stemming from the getsockname man page which mentions returning EINVAL if addrlen is negative.

Removed the check.

 **mmanutils.c:_add_file_mappings**
https://github.com/deislabs/mystikos/security/code-scanning/3455
pointer value wasn't initalized.

**kernel/syscall.c:_SYS_prctl**
https://github.com/deislabs/mystikos/security/code-scanning/3451
local variable n was shadowing parameter. Changed local usage to use an integer literal instead.

**host/maps.c:myst_maps_load**
https://github.com/deislabs/mystikos/security/code-scanning/3459
https://github.com/deislabs/mystikos/security/code-scanning/3458
Fixed sscanf return check.