### PR TITLE
myst-gdb extension: Memory manager data structure tracker

### DIFF
--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -5,7 +5,8 @@ BUILDDIR=${TOP}/build
 all: ${BUILDDIR}/bin/myst-gdb \
 	${BUILDDIR}/lib/debugger/gdb-sgx-plugin/mprotect.py \
 	${BUILDDIR}/lib/debugger/gdb-sgx-plugin/symbol_analyzer.py \
-	${BUILDDIR}/lib/debugger/gdb-sgx-plugin/print.py
+	${BUILDDIR}/lib/debugger/gdb-sgx-plugin/print.py \
+	${BUILDDIR}/lib/debugger/gdb-sgx-plugin/mman.py \
 
 ${BUILDDIR}/bin/myst-gdb:
 	rm -f ${BUILDDIR}/bin/myst-gdb
@@ -26,11 +27,16 @@ ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/print.py: ${BUILDDIR}/lib/debugger/gdb-s
 	rm -f ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/print.py
 	cp ${CURDIR}/gdb-sgx-plugin/print.py ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/print.py
 
+${BUILDDIR}/lib/debugger/gdb-sgx-plugin/mman.py: ${BUILDDIR}/lib/debugger/gdb-sgx-plugin
+	rm -f ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/mman.py
+	cp ${CURDIR}/gdb-sgx-plugin/mman.py ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/mman.py
+
 clean:
 	rm -f ${BUILDDIR}/bin/myst-gdb
 	rm -f ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/mprotect.py
 	rm -f ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/symbol_analyzer.py
 	rm -f ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/print.py
+	rm -f ${BUILDDIR}/lib/debugger/gdb-sgx-plugin/mman.py
 
 distclean: clean
 	rm -rf ${BUILDDIR}/lib/debugger

--- a/debugger/gdb-sgx-plugin/mman.py
+++ b/debugger/gdb-sgx-plugin/mman.py
@@ -1,0 +1,249 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import gdb
+import math
+import tempfile
+
+class myst_list_t:
+    OFFSETOF_HEAD=0
+    SIZEOF_HEAD=8
+
+    OFFSETOF_TAIL=8
+    SIZEOF_TAIL=8
+
+    OFFSETOF_SIZE=16
+    SIZEOF_SIZE=8
+
+    def __init__(self):
+        self.head = read_int_from_memory(addr + self.OFFSETOF_HEAD, self.SIZEOF_HEAD)
+        self.tail = read_int_from_memory(addr + self.OFFSETOF_TAIL, self.SIZEOF_TAIL)
+        self.size = read_int_from_memory(addr + self.OFFSETOF_SIZE, self.SIZEOF_SIZE)
+
+class myst_list_node_t:
+    OFFSETOF_HEAD=0
+    SIZEOF_HEAD=8
+
+    OFFSETOF_TAIL=8
+    SIZEOF_TAIL=8
+
+    OFFSETOF_SIZE=16
+    SIZEOF_SIZE=8
+
+    def __init__(self):
+        self.head = read_int_from_memory(addr + self.OFFSETOF_HEAD, self.SIZEOF_HEAD)
+        self.tail = read_int_from_memory(addr + self.OFFSETOF_TAIL, self.SIZEOF_TAIL)
+        self.size = read_int_from_memory(addr + self.OFFSETOF_SIZE, self.SIZEOF_SIZE)
+
+class myst_vad_t:
+    OFFSET_NEXT = 0
+    SIZEOF_NEXT = 8
+
+    OFFSETOF_PREV = 8
+    SIZEOF_PREV = 8
+
+    OFFSETOF_ADDR = 16
+    SIZEOF_ADDR = 8
+
+    OFFSETOF_SIZE = 24
+    SIZEOF_SIZE = 8
+
+    OFFSETOF_PROT = 30
+    SIZEOF_PROT = 2
+
+    OFFSETOF_FLAGS = 32
+    SIZEOF_FLAGS = 2
+
+    def __init__(self):
+        self.next = read_int_from_memory(addr + self.OFFSETOF_NEXT, self.SIZEOF_NEXT)
+        self.prev = read_int_from_memory(addr + self.OFFSETOF_PREV, self.SIZEOF_PREV)
+        self.addr = read_int_from_memory(addr + self.OFFSETOF_ADDR, self.SIZEOF_ADDR)
+        self.size = read_int_from_memory(addr + self.OFFSETOF_SIZE, self.SIZEOF_SIZE)
+        self.flags = read_int_from_memory(addr + self.OFFSETOF_FLAGS, self.SIZEOF_FLAGS)
+
+# Definition must align with myst_fdmapping_t structure defined in include/myst/mmanutils.h
+class myst_fdmapping_t:
+    OFFSETOF_USED = 0
+    SIZEOF_USED = 4
+
+    OFFSETOF_OFFSET = 8
+    SIZEOF_OFFSET = 8
+
+    OFFSETOF_FILESZ = 16
+    SIZEOF_FILESZ = 8
+
+    OFFSETOF_MMAN_FILE_HANDLE = 24
+    SIZEOF_MMAN_FILE_HANDLE = 8
+
+    def __init__(self, addr):
+        if addr:
+            self.used = read_int_from_memory(addr + self.OFFSETOF_USED, self.SIZEOF_USED)
+        else:
+            return
+
+        self.offset = read_int_from_memory(addr + self.OFFSETOF_OFFSET, self.SIZEOF_OFFSET)
+        self.filesz = read_int_from_memory(addr + self.OFFSETOF_NEXT, self.SIZEOF_NEXT)
+        self.mman_file_handle = read_int_from_memory(addr + self.OFFSETOF_MMAN_FILE_HANDLE, self.SIZEOF_MMAN_FILE_HANDLE)
+
+class shared_mapping_t:
+    OFFSETOF_BASE=0
+    SIZEOF_BASE=16
+
+    OFFSETOF_SHARERS=16
+    SIZEOF_SHARERS=24
+
+    OFFSETOF_START_ADDR=48
+    SIZEOF_START_ADDR=8
+
+    OFFSETOF_LENGTH=56
+    SIZEOF_LENGTH=8
+
+    OFFSETOF_FILE_SIZE=64
+    SIZEOF_FILE_SIZE=8
+
+    OFFSETOF_FILE_HANDLE=72
+    SIZEOF_FILE_HANDLE=8
+
+    OFFSETOF_OFFSET=80
+    SIZEOF_OFFSET=8
+
+    OFFSETOF_TYPE=88
+    SIZEOF_TYPE=4
+
+    def __init__(self, addr):
+        if addr:
+            self.base = read_int_from_memory(addr + self.OFFSETOF_BASE, self.SIZEOF_BASE)
+        else:
+            return
+
+        self.sharers = read_int_from_memory(addr + self.OFFSETOF_SHARERS, self.SIZEOF_SHARERS)
+        self.start_addr = read_int_from_memory(addr + self.OFFSETOF_START_ADDR, self.SIZEOF_START_ADDR)
+        self.length = read_int_from_memory(addr + self.OFFSETOF_LENGTH, self.SIZEOF_LENGTH)
+        self.file_size = read_int_from_memory(addr + self.OFFSETOF_FILE_SIZE, self.SIZEOF_FILE_SIZE)
+        self.file_handle = read_int_from_memory(addr + self.OFFSETOF_FILE_HANDLE, self.SIZEOF_FILE_HANDLE)
+        self.offset = read_int_from_memory(addr + self.OFFSETOF_OFFSET, self.SIZEOF_OFFSET)
+        self.type = read_int_from_memory(addr + self.OFFSETOF_TYPE, self.SIZEOF_TYPE)
+
+class MystShmfsInitBreakpoint(gdb.Breakpoint):
+    def __init__(self):
+        super(MystShmfsInitBreakpoint, self).__init__('myst_shmfs_setup_hook', internal=False)
+
+    def stop(self):
+        mman_tracker.shared_mappings = int(gdb.parse_and_eval('(uint64_t)shmem_list'))    
+
+class MystMmanInitBreakpoint(gdb.Breakpoint):
+    def __init__(self):
+        super(MystMmanInitBreakpoint, self).__init__('myst_mman_init_debug_hook', internal=False)
+
+    def stop(self):
+        mman_tracker.mman_base = int(gdb.parse_and_eval('(uint64_t)_mman->base'))
+        mman_tracker.mman_start = int(gdb.parse_and_eval('(uint64_t)_mman->start'))
+        mman_tracker.mman_end = int(gdb.parse_and_eval('(uint64_t)_mman->end'))
+        mman_tracker.mman_size = int(gdb.parse_and_eval('(uint64_t)_mman->size'))
+        mman_tracker.file_mappings_vec = int(gdb.parse_and_eval('(uint64_t)__myst_kernel_args.fdmappings_data'))
+        mman_tracker.file_mappings_vec_size = int(gdb.parse_and_eval('(uint64_t)__myst_kernel_args.fdmappings_size'))
+        mman_tracker.process_ownership_vec = int(gdb.parse_and_eval('(uint64_t)__myst_kernel_args.mman_pids_data'))
+        mman_tracker.process_ownership_vec_size = int(gdb.parse_and_eval('(uint64_t)__myst_kernel_args.mman_pids_size'))
+        mman_tracker.prot_vector = int(gdb.parse_and_eval('(uint64_t)_mman->prot_vector'))
+        
+        print("mman base= %x start=%x end=%x size=%d" % (mmam_tracker.mman_base, mman_tracker.mman_start, mman_tracker.mman_end, mman_tracker.mman_size))
+
+        # Continue execution.
+        return False
+
+class MystMmanTracker:
+
+    def __init__(self):
+        self._welcome()
+
+    # Dispatch the command
+    def dispatch(self, arg0, *args):
+        if arg0 == "-p":
+            self._dump_maps_by_pids(*args)
+        elif arg0 == "-h":
+            self._help()
+        else:
+            self._get_map_by_addr(arg0, *args)
+    
+    def shutdown(self):
+        pass # do shutdown things
+
+    def _welcome(self):
+        self._print('\nmyst-gdb has been configured to track mman data structures.' +
+                    '\nType myst-mman for more information\n')
+
+    def _print(self, msg):
+        print('\033[0;32m%s\033[0m' % msg)
+
+    def _help(self):
+        msg = 'myst-mman: Mystikos heap memory tracker\n' \
+            'Commands:\n' \
+            '  \033[0;32mmyst-mman <address-expression> \033[0m\n' \
+            '    Print details for memory region associated with address.\n' \
+            '    Examples:\n' \
+            '      gdb) myst-prot $rip \n' \
+            '  \033[0;32mmyst-mman [-h]\033[0m\n' \
+            '    Print help\n' \
+            '  \033[0;32mmyst-mman [-p] <pid>\033[0m\n' \
+            '  \033[0;32mmyst-mman [-d]\033[0m\n' \
+            '    Dump memory data structures\n'
+        print(msg)
+
+    def _is_valid_heap_addr_range(self, addr, length):
+        if length >= 0 and addr >= mman_tracker.mman_base and addr <= mman_tracker.mman_end:
+            addr_end = addr + length
+            if addr_end <= mman_tracker.mman_end:
+                return True
+        return False
+
+    def _get_page_index(addr, length):
+        pass
+
+    def _get_map_by_addr(self, addr_str, get_all=None):
+        # Evaluate the address expression.
+        addr = int(gdb.parse_and_eval(addr_str))
+        print('address: %s = 0x%x' % (addr_str, addr))
+
+        if not self._is_valid_heap_addr_range(addr, 0):
+            print('invalid address!! Not in mman controlled region.')
+            return
+        # TODO
+
+mman_tracker = None
+
+
+command = """
+define myst-mman
+  if $argc == 4
+      python mman_tracker.dispatch("$arg0", $arg1, $arg2, $arg3)
+  end
+  if $argc == 3
+      python mman_tracker.dispatch("$arg0", $arg1, $arg2)
+  end
+  if $argc == 2
+      python mman_tracker.dispatch("$arg0", $arg1)
+  end
+  if $argc == 1
+      python mman_tracker.dispatch("$arg0")
+  end
+  if $argc == 0
+      python mman_tracker.dispatch("-h")
+  end
+end
+"""
+
+if __name__ == "__main__":
+    mman_tracker = MystMmanTracker()
+    # Register breakpoints
+    MystMmanInitBreakpoint()
+    MystShmfsInitBreakpoint()
+
+    # Register command with gdb.
+    with tempfile.NamedTemporaryFile('w') as f:
+        f.write(command)
+        f.flush()
+        gdb.execute('source %s' % f.name)
+    def exit_handler(event):
+       global mman_tracker
+       mman_tracker.shutdown()
+    gdb.events.exited.connect(exit_handler)

--- a/debugger/myst-gdb
+++ b/debugger/myst-gdb
@@ -31,6 +31,7 @@ LD_PRELOAD=$OE_GDB_PTRACE_PATH gdb \
 	  -iex "source $MYST_GDB_PLUGIN_DIR/print.py" \
 	  -iex "source $MYST_GDB_PLUGIN_DIR/mprotect.py" \
 	  -iex "source $MYST_GDB_PLUGIN_DIR/symbol_analyzer.py" \
+	  -iex "source $MYST_GDB_PLUGIN_DIR/mman.py" \
 	  -iex "set environment LD_PRELOAD" \
 	  -iex "add-auto-load-safe-path /usr/lib" \
 	  "$@"

--- a/include/myst/kernel.h
+++ b/include/myst/kernel.h
@@ -5,6 +5,7 @@
 #define _MYST_KERNEL_H
 
 #include <limits.h>
+#include <myst/defs.h>
 #include <myst/kstack.h>
 #include <myst/syscallext.h>
 #include <myst/tcall.h>
@@ -104,6 +105,14 @@ typedef struct _myst_strace_config
 
 typedef struct myst_kernel_args
 {
+    /* The pids[] vector for the memory management pages */
+    void* mman_pids_data;
+    size_t mman_pids_size;
+
+    /* The fdmappings[] vector for fd-mman mappings */
+    void* fdmappings_data;
+    size_t fdmappings_size;
+
     /* The image that contains the kernel and crt etc. */
     const void* image_data;
     size_t image_size;
@@ -167,14 +176,6 @@ typedef struct myst_kernel_args
     /* The read-write-execute memory management pages */
     void* mman_data;
     size_t mman_size;
-
-    /* The pids[] vector for the memory management pages */
-    void* mman_pids_data;
-    size_t mman_pids_size;
-
-    /* The fdmappings[] vector for fd-mman mappings */
-    void* fdmappings_data;
-    size_t fdmappings_size;
 
     /* The CPIO root file system image */
     char rootfs[PATH_MAX];
@@ -284,6 +285,12 @@ typedef struct myst_kernel_args
     myst_wanted_secrets_t* wanted_secrets;
 
 } myst_kernel_args_t;
+
+// If offsets change, update references in debugger/gdb-sgx-plugin/mman.py
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_kernel_args_t, mman_pids_data) == 0);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_kernel_args_t, mman_pids_size) == 8);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_kernel_args_t, fdmappings_data) == 16);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_kernel_args_t, fdmappings_size) == 24);
 
 typedef int (*myst_kernel_entry_t)(myst_kernel_args_t* args);
 

--- a/include/myst/list.h
+++ b/include/myst/list.h
@@ -25,6 +25,15 @@ struct myst_list_node
     myst_list_node_t* next;
 };
 
+// If offsets change, update references in debugger/gdb-sgx-plugin/mman.py
+MYST_STATIC_ASSERT(sizeof(myst_list_t) == 24);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_list_t, head) == 0);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_list_t, tail) == 8);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_list_t, size) == 16);
+MYST_STATIC_ASSERT(sizeof(myst_list_node_t) == 16);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_list_node_t, prev) == 0);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_list_node_t, next) == 8);
+
 MYST_INLINE void myst_list_remove(myst_list_t* list, myst_list_node_t* node)
 {
     if (node->prev)

--- a/include/myst/mman.h
+++ b/include/myst/mman.h
@@ -4,6 +4,7 @@
 #ifndef _MYST_INTERNAL_MMAN_H
 #define _MYST_INTERNAL_MMAN_H
 
+#include <myst/defs.h>
 #include <myst/rspinlock.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -51,8 +52,6 @@ typedef struct myst_vad
     /* Mapping flags for this region: MYST_MAP_???? */
     uint16_t flags;
 } myst_vad_t;
-
-_Static_assert(sizeof(myst_vad_t) == 40, "");
 
 #define MYST_MMAN_MAGIC 0xcc8e1732ebd80b0b
 
@@ -113,6 +112,23 @@ typedef struct myst_mman
     char err[MYST_MMAN_ERROR_SIZE];
 
 } myst_mman_t;
+
+// If offsets change, update references in debugger/gdb-sgx-plugin/mman.py
+MYST_STATIC_ASSERT(sizeof(myst_vad_t) == 40);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_vad_t, next) == 0);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_vad_t, prev) == 8);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_vad_t, addr) == 16);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_vad_t, size) == 24);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_vad_t, prot) == 32);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_vad_t, flags) == 34);
+
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_mman_t, base) == 16);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_mman_t, size) == 24);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_mman_t, prot_vector) == 32);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_mman_t, start) == 40);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_mman_t, end) == 48);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_mman_t, brk) == 56);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_mman_t, vad_list) == 96);
 
 int myst_mman_init(myst_mman_t* heap, uintptr_t base, size_t size);
 

--- a/include/myst/mmanutils.h
+++ b/include/myst/mmanutils.h
@@ -36,6 +36,19 @@ typedef struct myst_fdmapping
     mman_file_handle_t* mman_file_handle;
 } myst_fdmapping_t;
 
+// If offsets change, update references in debugger/gdb-sgx-plugin/mman.py
+MYST_STATIC_ASSERT(sizeof(mman_file_handle_t) == 48);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(mman_file_handle_t, base) == 0);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(mman_file_handle_t, fs) == 16);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(mman_file_handle_t, file) == 24);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(mman_file_handle_t, inode) == 32);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(mman_file_handle_t, npages) == 40);
+MYST_STATIC_ASSERT(sizeof(myst_fdmapping_t) == 32);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_fdmapping_t, used) == 0);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_fdmapping_t, offset) == 8);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_fdmapping_t, filesz) == 16);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(myst_fdmapping_t, mman_file_handle) == 24);
+
 int myst_setup_mman(void* data, size_t size);
 
 int myst_teardown_mman(void);

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -97,9 +97,10 @@ static vectors_t _get_vectors(void)
     return v;
 }
 
-void myst_mman_init_debug_hook(myst_mman_t* mman)
+void myst_mman_init_debug_hook(myst_mman_t* mman, myst_kernel_args_t* kargs)
 {
     assert(mman);
+    assert(kargs);
 }
 
 int myst_setup_mman(void* data, size_t size)
@@ -118,7 +119,7 @@ int myst_setup_mman(void* data, size_t size)
     if (myst_mman_init(&_mman, (uintptr_t)_mman_start, _mman_size) != 0)
         goto done;
 
-    myst_mman_init_debug_hook(&_mman);
+    myst_mman_init_debug_hook(&_mman, &__myst_kernel_args);
 
 #ifdef SCRUB
     /* Scrubbing unmapped memory causes memory reads due to musl libc */

--- a/kernel/mmanutils.c
+++ b/kernel/mmanutils.c
@@ -97,6 +97,11 @@ static vectors_t _get_vectors(void)
     return v;
 }
 
+void myst_mman_init_debug_hook(myst_mman_t* mman)
+{
+    assert(mman);
+}
+
 int myst_setup_mman(void* data, size_t size)
 {
     int ret = -1;
@@ -112,6 +117,8 @@ int myst_setup_mman(void* data, size_t size)
 
     if (myst_mman_init(&_mman, (uintptr_t)_mman_start, _mman_size) != 0)
         goto done;
+
+    myst_mman_init_debug_hook(&_mman);
 
 #ifdef SCRUB
     /* Scrubbing unmapped memory causes memory reads due to musl libc */

--- a/kernel/sharedmem.c
+++ b/kernel/sharedmem.c
@@ -68,6 +68,21 @@ typedef struct shared_mapping
     shmem_type_t type;
 } shared_mapping_t;
 
+// If offsets change, update references in debugger/gdb-sgx-plugin/mman.py
+MYST_STATIC_ASSERT(sizeof(proc_w_count_t) == 24);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(proc_w_count_t, base) == 0);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(proc_w_count_t, pid) == 16);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(proc_w_count_t, nmaps) == 20);
+MYST_STATIC_ASSERT(sizeof(shared_mapping_t) == 88);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(shared_mapping_t, base) == 0);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(shared_mapping_t, sharers) == 16);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(shared_mapping_t, start_addr) == 40);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(shared_mapping_t, length) == 48);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(shared_mapping_t, file_size) == 56);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(shared_mapping_t, file_handle) == 64);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(shared_mapping_t, offset) == 72);
+MYST_STATIC_ASSERT(MYST_OFFSETOF(shared_mapping_t, type) == 80);
+
 static myst_list_t _shared_mappings;
 static myst_fs_t* _posix_shmfs;
 

--- a/kernel/sharedmem.c
+++ b/kernel/sharedmem.c
@@ -73,6 +73,11 @@ static myst_fs_t* _posix_shmfs;
 
 static int _add_proc_to_sharers(shared_mapping_t* sm, pid_t pid);
 
+void myst_shmfs_setup_hook(myst_list_t* shmem_list)
+{
+    assert(shmem_list != NULL);
+}
+
 int shmfs_setup()
 {
     int ret = 0;
@@ -96,6 +101,8 @@ int shmfs_setup()
         myst_eprintf("cannot mount shm file system\n");
         ERAISE(-EINVAL);
     }
+
+    myst_shmfs_setup_hook(&_shared_mappings);
 
 done:
     return ret;

--- a/tests/gdb/Makefile
+++ b/tests/gdb/Makefile
@@ -14,7 +14,7 @@ GDB_CMDS=--batch \
 	-ex "backtrace" \
 	--args
 
-GDB_MATCH=Breakpoint 2, .................. in print_hello ()
+GDB_MATCH=Breakpoint 4, .................. in print_hello ()
 
 # runtest timeouts cause gdb to hang
 export NOTIMEOUT=1


### PR DESCRIPTION
PR adds support for tracking the various memory manager data structures. From a user perspective, it currently allows querying for mapping details given an address. With the data structures being tracked its also possible to print mappings by process(not part of this PR), equivalent of `info proc mappings` in gdb.

Current querying experience:

For MAP_SHARED mappings -
```
(gdb) myst-mman addr
address: addr = 0x10436a000
start_addr: 0x10436a000 end_addr: 0x10436b000 size=4096(0x1000)
Page protection = PROT_READ|PROT_WRITE
MAP_SHARED mapping, type: Regular file
File mapping info: offset=0 filesz=10
Owning processes: 
101
102
```

For MAP_PRIVATE mappings -
```
(gdb) myst-mman $rip
address: $rip = 0x10438c9fe
start_addr=0x10438c000 end_addr=0x10438e000 size=8192(0x2000)
Page protection = PROT_READ|PROT_EXEC
MAP_PRIVATE mapping, owning process: 101
File mapping info: offset=4096 filesz=25456
```
