### PR TITLE
add the MYST_RELEASE flag to jenkins pipelines

### DIFF
--- a/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/azure-sdk-tests.Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
         TEST_TYPE =         "sdk"
         LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
         PACKAGE_INSTALL =   "${UBUNTU_VERSION == '20.04' ? 'Ubuntu-2004' : 'Ubuntu-1804'}_${PACKAGE_NAME}.${PACKAGE_EXTENSION}"
+        MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'

--- a/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
         TEST_TYPE =         "dotnet"
         LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
         PACKAGE_INSTALL =   "${UBUNTU_VERSION == '20.04' ? 'Ubuntu-2004' : 'Ubuntu-1804'}_${PACKAGE_NAME}.${PACKAGE_EXTENSION}"
+        MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'

--- a/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-p1-tests.Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         TEST_TYPE =         "dotnet"
         LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
         PACKAGE_INSTALL =   "${UBUNTU_VERSION == '20.04' ? 'Ubuntu-2004' : 'Ubuntu-1804'}_${PACKAGE_NAME}.${PACKAGE_EXTENSION}"
-        MYST_RELEASE =      "1"
+        // MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'

--- a/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/dotnet-tests.Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
         PACKAGE_INSTALL =   "${UBUNTU_VERSION == '20.04' ? 'Ubuntu-2004' : 'Ubuntu-1804'}_${PACKAGE_NAME}.${PACKAGE_EXTENSION}"
         TEST_TYPE =         "dotnet"
         LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
+        MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'

--- a/.jenkins/pipelines/standalone/openmp-testsuite.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/openmp-testsuite.Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
     environment {
         MYST_SCRIPTS =      "${WORKSPACE}/scripts"
         JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
+        MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'

--- a/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
     environment {
         MYST_SCRIPTS =      "${WORKSPACE}/scripts"
         JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
+        MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'

--- a/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/pytorch-tests.Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     environment {
         MYST_SCRIPTS =      "${WORKSPACE}/scripts"
         JENKINS_SCRIPTS =   "${WORKSPACE}/.jenkins/scripts"
-        MYST_RELEASE =      "1"
+        // MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'

--- a/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
         TEST_TYPE =         "solutions"
         LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
         PACKAGE_INSTALL =   "${UBUNTU_VERSION == '20.04' ? 'Ubuntu-2004' : 'Ubuntu-1804'}_${PACKAGE_NAME}.${PACKAGE_EXTENSION}"
+        MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'

--- a/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/unit-tests.Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
         TEST_TYPE =         "unit"
         LCOV_INFO =         "lcov-${GIT_COMMIT[0..7]}-${TEST_TYPE}.info"
         PACKAGE_INSTALL =   "${UBUNTU_VERSION == '20.04' ? 'Ubuntu-2004' : 'Ubuntu-1804'}_${PACKAGE_NAME}.${PACKAGE_EXTENSION}"
+        MYST_RELEASE =      "1"
         BUILD_USER = sh(
             returnStdout: true,
             script: 'echo \${USER}'


### PR DESCRIPTION
We are running the pipelines with the release flag since feature additions are at a minimum.

Nightly pipeline run - https://openenclaveci.westus.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FNightly-Pipeline-Manual/detail/Nightly-Pipeline-Manual/89/pipeline/