### PR TITLE
fix gcov build optimization error

### DIFF
--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -730,7 +730,9 @@ static void _print_boottime(void)
 static myst_thread_t _main_thread;
 
 #pragma GCC push_options
+#ifndef MYST_ENABLE_GCOV
 #pragma GCC optimize "-O2"
+#endif
 int myst_enter_kernel(myst_kernel_args_t* args)
 {
     int ret = 0;
@@ -930,10 +932,7 @@ int myst_enter_kernel(myst_kernel_args_t* args)
     /* Run the main program: wait for SYS_exit to perform longjmp() */
     if (myst_setjmp(&thread->jmpbuf) == 0)
     {
-        myst_crt_args_t crt_args = {
-            args->wanted_secrets,
-            args->crt_memcheck
-        };
+        myst_crt_args_t crt_args = {args->wanted_secrets, args->crt_memcheck};
         /* enter the C-runtime on the target thread descriptor */
         if ((tmp_ret = myst_exec(
                  thread,


### PR DESCRIPTION
The pragma O2 is fighting the O0 that we build gcov with, so we are disabling it for the gcov build.

CC pipeline to confirm: https://openenclaveci.westus.cloudapp.azure.com/blue/organizations/jenkins/Mystikos%2FCode-Coverage/detail/Code-Coverage/128/pipeline
