### PR TITLE
fix memalign error in debug-malloc

### DIFF
--- a/kernel/debugmalloc.c
+++ b/kernel/debugmalloc.c
@@ -423,12 +423,18 @@ int myst_debug_posix_memalign(void** memptr, size_t alignment, size_t size)
         return EINVAL;
 
     /*
-    ** [padding][header][block][footer]
+    ** [padding1][header][block][padding2][footer]
     ** ^                ^
     ** |                |
     ** X                Y
     **
-    ** Note: both X and Y are on the alignment boundary
+    ** Note: both X and Y are on the alignment boundary passed to memalign.
+    **
+    ** padding1 aligns the header to that the block will be aligned on the
+    ** boundary given by the alignment parameter to memalign.
+    **
+    ** padding2 can be between 0 and 7 bytes (to align the footer on an 8-byte
+    ** boundary).
     */
 
 #ifdef DEBUG_MEMALIGN

--- a/tests/debugmalloc/Makefile
+++ b/tests/debugmalloc/Makefile
@@ -26,7 +26,10 @@ ifdef PERF
 OPTS += --perf
 endif
 
-OPTS += --thread-stack-size=1048576 --crt-memcheck
+OPTS += --thread-stack-size=1048576
+OPTS += --crt-memcheck
+OPTS += --nobrk
+#OPTS += --memory-size=1g
 
 tests: all
 	$(RUNTEST) $(MYST_EXEC) rootfs /bin/debugmalloc $(OPTS)

--- a/tests/debugmalloc/debugmalloc.c
+++ b/tests/debugmalloc/debugmalloc.c
@@ -3,6 +3,7 @@
 
 #define _GNU_SOURCE
 #include <assert.h>
+#include <malloc.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -44,8 +45,112 @@ void stop()
 {
 }
 
+void test_malloc()
+{
+    void** ptrs;
+    size_t* sizes;
+    const size_t n = 1024*10;
+
+    if (!(ptrs = calloc(n, sizeof(void*))))
+    {
+        fprintf(stderr, "calloc() failed\n");
+        exit(1);
+    }
+
+    if (!(sizes = calloc(n, sizeof(size_t))))
+    {
+        fprintf(stderr, "calloc() failed\n");
+        exit(1);
+    }
+
+    /* malloc */
+    for (size_t i = 0; i < n; i++)
+    {
+        size_t size = rand() % 64 + 1;
+
+        if (!(ptrs[i] = memalign(128, size)))
+        {
+            fprintf(stderr, "memalign() failed\n");
+            exit(1);
+        }
+
+        memset(ptrs[i], '\0', size);
+        sizes[i] = size;
+    }
+
+    /* realloc */
+    for (size_t i = 0; i < n; i++)
+    {
+        size_t size = rand() % 128 + 1;
+
+        memset(ptrs[i], '\0', sizes[i]);
+
+        if (!(ptrs[i] = realloc(ptrs[i], size)))
+        {
+            fprintf(stderr, "malloc() failed\n");
+            exit(1);
+        }
+
+        memset(ptrs[i], '\0', size);
+        sizes[i] = size;
+    }
+
+    /* clear */
+    for (size_t i = 0; i < n; i++)
+    {
+        memset(ptrs[i], '\0', sizes[i]);
+    }
+
+    /* free every other and allocate new */
+    for (size_t i = 0; i < n; i += 2)
+    {
+        size_t size = rand() % 128 + 1;
+
+        memset(ptrs[i], '\0', sizes[i]);
+        free(ptrs[i]);
+        ptrs[i] = NULL;
+        sizes[i] = 0;
+
+        if (!(ptrs[i] = malloc(size)))
+        {
+            fprintf(stderr, "malloc() failed\n");
+            exit(1);
+        }
+
+        memset(ptrs[i], '\0', size);
+        sizes[i] = size;
+    }
+
+    /* free */
+    for (size_t i = 0; i < n; i++)
+    {
+        memset(ptrs[i], '\0', sizes[i]);
+        free(ptrs[i]);
+        sizes[i] = 0;
+        ptrs[i] = NULL;
+    }
+
+    free(ptrs);
+    free(sizes);
+}
+
+void test_malloc2()
+{
+    void* ptr;
+
+    if (!(ptr = memalign(256, 16)))
+    {
+        fprintf(stderr, "memalign() failed\n");
+        exit(1);
+    }
+    free(ptr);
+}
+
 int main(int argc, const char* argv[])
 {
+    test_malloc();
+    debug_malloc_check(true);
+
     size_t count;
     a();
 

--- a/third_party/musl/crt/patch.diff
+++ b/third_party/musl/crt/patch.diff
@@ -963,19 +963,33 @@ index 672b518a..0f9a8057 100644
 +    return libc_malloc_usable_size(p);
 +}
 diff --git a/src/malloc/memalign.c b/src/malloc/memalign.c
-index cf9dfbda..1aba670c 100644
+index cf9dfbda..ac1fca21 100644
 --- a/src/malloc/memalign.c
 +++ b/src/malloc/memalign.c
-@@ -3,7 +3,7 @@
+@@ -3,7 +3,9 @@
  #include <errno.h>
  #include "malloc_impl.h"
  
 -void *__memalign(size_t align, size_t len)
++void *libc_malloc(size_t n);
++
 +void *libc_memalign(size_t align, size_t len)
  {
  	unsigned char *mem, *new;
  
-@@ -51,4 +51,14 @@ void *__memalign(size_t align, size_t len)
+@@ -18,9 +20,9 @@ void *__memalign(size_t align, size_t len)
+ 	}
+ 
+ 	if (align <= SIZE_ALIGN)
+-		return malloc(len);
++		return libc_malloc(len);
+ 
+-	if (!(mem = malloc(len + align-1)))
++	if (!(mem = libc_malloc(len + align-1)))
+ 		return 0;
+ 
+ 	new = (void *)((uintptr_t)mem + align-1 & -align);
+@@ -51,4 +53,14 @@ void *__memalign(size_t align, size_t len)
  	return new;
  }
  


### PR DESCRIPTION
This patch fixes a bug in musl libc ``memalign`` when using debug-malloc. The function ``myst_debug_posix_memalign()`` was calling into musl's ``memalign`` function, which was calling back into ``myst_debug_malloc()``, which would have resulted in a double debug-malloc header and trailer. Consequently, ``free()`` crashed when releasing memory obtained with ``memalign()``.