### PR TITLE
Update Azure sdk KeyVault test

### DIFF
--- a/solutions/dotnet_azure_sdk/KeyVault_Keys/Dockerfile
+++ b/solutions/dotnet_azure_sdk/KeyVault_Keys/Dockerfile
@@ -1,11 +1,12 @@
 # stage 1: build
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /app
 COPY src .
-RUN dotnet publish -o publish -f netcoreapp3.1 -r linux-musl-x64 /p:PublishTrimmed=true
+RUN dotnet publish -o publish -r linux-x64 /p:PublishTrimmed=true
 
 # stage 2: run
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
+
 WORKDIR /app
-RUN apk add --no-cache icu-libs
 COPY --from=build /app/publish .

--- a/solutions/dotnet_azure_sdk/KeyVault_Keys/src/Sample1_HelloWorldAsync.csproj
+++ b/solutions/dotnet_azure_sdk/KeyVault_Keys/src/Sample1_HelloWorldAsync.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Move to dotnet version 6.0
- Update to v4.4.0 of Azure.Security.KeyVault.Keys library

Signed-off-by: Vikas Tikoo <vikasamar@gmail.com>