### PR TITLE
Fix broken sigining of EXT2 rootfs

### DIFF
--- a/samples/helloworld/ext2rootfs/Makefile
+++ b/samples/helloworld/ext2rootfs/Makefile
@@ -28,7 +28,9 @@ package.pem:
 
 package: package.pem ext2rootfs
 	echo "Generating a signed package"
-	@myst package-sgx --roothash=roothash appdir package.pem ../config.json
+	@myst package-sgx --roothash=roothash package.pem ../config.json
+
+export MYST_ROOTFS_PATH=$(CURDIR)/ext2rootfs
 
 run: package
 	echo "Running Mystikos packaged application. No myst exec-sgx necessary"

--- a/tests/sign/Makefile
+++ b/tests/sign/Makefile
@@ -1,0 +1,59 @@
+TOP=$(abspath ../..)
+include $(TOP)/defs.mak
+
+APPDIR = appdir
+CFLAGS = -fPIC
+LDFLAGS = -Wl,-rpath=$(MUSL_LIB)
+
+all:
+	$(MAKE) myst
+	$(MAKE) rootfs
+
+rootfs: hello.c
+	mkdir -p $(APPDIR)/bin
+	$(CC) $(CFLAGS) -o $(APPDIR)/bin/hello hello.c $(LDFLAGS)
+	$(MYST) mkext2 $(APPDIR) rootfs
+
+OPTS =
+
+ifdef STRACE
+OPTS += --strace
+endif
+
+ifdef PERF
+OPTS += --perf
+endif
+
+OPTS += --thread-stack-size=1048576
+
+tests: all
+	$(RUNTEST) $(MYST_EXEC) rootfs /bin/hello $(OPTS)
+	$(MAKE) sign
+	$(MAKE) verify
+	$(MAKE) fail
+	@ echo "=== passed all tests"
+
+private.pem:
+	openssl genrsa -out private.pem -3 3072
+
+sign: private.pem
+	$(MYST) fssig --roothash rootfs > roothash
+	rm -rf hello.signed
+	$(MYST) sign-sgx rootfs private.pem config.json --roothash=roothash
+
+verify:
+	( cd hello.signed; ./bin/myst exec-sgx rootfs /bin/hello $(OPTS) )
+
+myst:
+	$(MAKE) -C $(TOP)/tools/myst
+
+clean:
+	rm -rf $(APPDIR) rootfs export ramfs hello.signed roothash private.pem
+
+##
+## Negative test to verify that hacking rootfs fails loading.
+##
+fail:
+	$(MAKE) sign
+	$(MYST) mkext2 --force $(APPDIR) hello.signed/rootfs
+	$(MAKE) verify 2> /dev/null; test $$? -eq 2

--- a/tests/sign/README.md
+++ b/tests/sign/README.md
@@ -1,0 +1,5 @@
+sign
+====
+
+This test verifies that a simple Mystikos application can be signed and
+executed.

--- a/tests/sign/config.json
+++ b/tests/sign/config.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.1",
+    "Debug": 1,
+    "ProductID": 1,
+    "SecurityVersion": 1,
+    "MemorySize": "40m",
+    "ThreadStackSize": "16m",
+    "ApplicationPath": "/bin/hello",
+    "ApplicationParameters": [],
+    "HostApplicationParameters": false,
+    "EnvironmentVariables": [],
+    "HostEnvironmentVariables": []
+}

--- a/tests/sign/hello.c
+++ b/tests/sign/hello.c
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, const char* argv[])
+{
+    printf("Hello!\n");
+    printf("=== passed test (%s)\n", argv[0]);
+
+    return 0;
+}


### PR DESCRIPTION
Signing of EXT2 images (using ``myst sign``) was copying the entire EXT2 rootfs into the enclave image rather than a stub.

Added ``./tests/sign`` to verify signing of EXT4-based images. Added negative test too.