### PR TITLE
Fix failures for solutions pipeline

### DIFF
--- a/solutions/cpprestsdk/Dockerfile
+++ b/solutions/cpprestsdk/Dockerfile
@@ -8,7 +8,7 @@ RUN rm -rf /app;mkdir -p /app
 WORKDIR /app
 
 ADD skip-tests.patch .
-RUN git clone https://github.com/Microsoft/cpprestsdk.git casablanca
+RUN git clone --depth 1 --single-branch https://github.com/Microsoft/cpprestsdk.git casablanca
         # apply patch to skip un-wanted tests and compile
 RUN cd casablanca;\
         git apply ../skip-tests.patch;\

--- a/solutions/cpython-tests/Dockerfile
+++ b/solutions/cpython-tests/Dockerfile
@@ -15,7 +15,7 @@ RUN wget https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.ta
     make && \
     make install
 
-RUN git clone --depth 1 --branch $CPYTHON_TAG https://github.com/python/cpython
+RUN git clone --depth 1 --single-branch --branch $CPYTHON_TAG https://github.com/python/cpython
 WORKDIR /cpython
 # Apply patch to skip certain unit tests
 COPY ./test_config_$CPYTHON_TAG/patch /cpython/

--- a/solutions/msgpack_c/Dockerfile
+++ b/solutions/msgpack_c/Dockerfile
@@ -20,9 +20,9 @@ RUN cd googletest-release-1.7.0; \
     mv *.a /usr/lib;cp -r ../include/gtest /usr/include
 
 # clone and compile msgpack repo
-RUN git clone --single-branch --branch cpp_master https://github.com/msgpack/msgpack-c.git msgpack
+RUN git clone --depth 1 --single-branch --branch cpp-3.3.0 https://github.com/msgpack/msgpack-c.git msgpack
 RUN mkdir -p /app/msgpack/build; \
-    cd /app/msgpack/build;git checkout cpp-3.3.0; cmake ..;make
+    cd /app/msgpack/build;cmake ..;make
 RUN mkdir -p /app/tests
 # filter and copy all executable test binaries to another directory
 RUN cd /app/msgpack/build/test; \

--- a/solutions/python_azure_sdk/Dockerfile
+++ b/solutions/python_azure_sdk/Dockerfile
@@ -5,7 +5,7 @@ ARG PACKAGES
 RUN apt update && apt install -y git
 
 WORKDIR /
-RUN git clone -b ${TAG} https://github.com/Azure/azure-sdk-for-python --single-branch --depth 1
+RUN git clone --depth 1 --single-branch --branch ${TAG} https://github.com/Azure/azure-sdk-for-python
 ADD install-dev-requirements.sh ${PACKAGES} /
 RUN chmod +x /install-dev-requirements.sh \
     && /install-dev-requirements.sh

--- a/solutions/python_flask_tests/Dockerfile
+++ b/solutions/python_flask_tests/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.9-slim-bullseye
 WORKDIR /app
 
 RUN apt update && apt install -y git
-# Checkout Flask v2.3.2
-RUN git clone https://github.com/pallets/flask && cd flask && git checkout f3b8f570545200c87465d18386f3fc9f2258307a
+# Checkout Flask v2.3.3
+RUN git clone --depth 1 --single-branch --branch 2.3.3 https://github.com/pallets/flask
 
 WORKDIR /app/flask
 

--- a/solutions/python_web_frameworks/Dockerfile
+++ b/solutions/python_web_frameworks/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.11-alpine
 
 RUN apk add --update --no-cache python3-dev build-base pcre-dev linux-headers
 RUN pip install flask uwsgi

--- a/solutions/pytorch_tests/Dockerfile
+++ b/solutions/pytorch_tests/Dockerfile
@@ -8,5 +8,5 @@ RUN pip3 install pytest expecttest hypothesis==6.52.1 && \
     pip3 install torch==1.10.0+cpu torchvision==0.11.1+cpu torchaudio==0.10.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
 
 WORKDIR /workspace
-RUN git clone -b ${TAG} https://github.com/pytorch/pytorch.git --single-branch --depth 1
+RUN git clone --depth 1 --single-branch --branch ${TAG} https://github.com/pytorch/pytorch.git
 WORKDIR /workspace/pytorch

--- a/solutions/pytorch_tests/Dockerfile-build
+++ b/solutions/pytorch_tests/Dockerfile-build
@@ -30,7 +30,7 @@ RUN curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Mini
 FROM dev-base as submodule-update
 ARG PYTORCH_VERSION=v1.10.0
 WORKDIR /opt
-RUN git clone -b ${PYTORCH_VERSION} https://github.com/pytorch/pytorch.git --single-branch --depth 1
+RUN git clone --depth 1 --single-branch --branch ${PYTORCH_VERSION} https://github.com/pytorch/pytorch.git
 WORKDIR /opt/pytorch
 RUN git submodule update --init --recursive --jobs 0
 

--- a/tests/aspnetcore5/Dockerfile.aspnet5
+++ b/tests/aspnetcore5/Dockerfile.aspnet5
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-a50a721-2019112020
 ARG TAG=v5.0.11
 
 WORKDIR /app
-RUN git clone --branch ${TAG} --recursive https://github.com/dotnet/aspnetcore
+RUN git clone --depth 1 --single-branch --recurse-submodules --branch ${TAG} https://github.com/dotnet/aspnetcore
 WORKDIR /app/aspnetcore
 RUN ./build.sh -nobl -c Debug \
     --arch x64 --all \

--- a/tests/aspnetcore6/Dockerfile
+++ b/tests/aspnetcore6/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-a50a721-2019112020
 ARG TAG=v6.0.0-preview.2.21154.6
 
 WORKDIR /app
-RUN git clone --branch ${TAG} --recursive https://github.com/dotnet/aspnetcore
+RUN git clone --depth 1 --single-branch --recurse-submodules --branch ${TAG} https://github.com/dotnet/aspnetcore
 WORKDIR /app/aspnetcore
 RUN ./eng/build.sh -nobl -c Debug \
     --arch x64 --all \

--- a/tests/azure-sdk-for-cpp/Dockerfile
+++ b/tests/azure-sdk-for-cpp/Dockerfile
@@ -4,9 +4,11 @@ RUN apk update && apk upgrade \
     && apk add --no-cache build-base curl zip unzip tar openssl-dev curl-dev \
     && apk add --no-cache g++ wget libxml2-dev make ninja gcc cmake git
 
-RUN git clone https://github.com/Azure/azure-sdk-for-cpp.git
+# Previously this Dockerfile checkouts commit 8fcc1df085eb7dad87084813e19fa6c362bb6734
+# But git clone doesn't support cloning at a specific commit, so replaced with a tag that include commit 8fcc1df
+RUN git clone --depth 1 --single-branch --branch azure-storage-common_12.1.0 https://github.com/Azure/azure-sdk-for-cpp.git
 
-RUN cd azure-sdk-for-cpp && git checkout 8fcc1df085eb7dad87084813e19fa6c362bb6734 \
+RUN cd azure-sdk-for-cpp \
         && mkdir build && cd build \
 		&& cmake .. -DBUILD_TRANSPORT_CURL=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_STORAGE_SAMPLES=ON -DBUILD_TESTING=ON \
 		&& cmake --build .

--- a/tests/azure-sdk-for-cpp/Dockerfile-ubuntu
+++ b/tests/azure-sdk-for-cpp/Dockerfile-ubuntu
@@ -2,11 +2,11 @@ FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y curl zip unzip tar git g++ wget build-essential libssl-dev libcurl4-openssl-dev libxml2-dev cmake
 
-RUN git clone https://github.com/microsoft/vcpkg
+RUN git clone --depth 1 --single-branch https://github.com/microsoft/vcpkg
 
 RUN ./vcpkg/bootstrap-vcpkg.sh
 
-RUN git clone https://github.com/Azure/azure-sdk-for-cpp.git
+RUN git clone --depth 1 --single-branch https://github.com/Azure/azure-sdk-for-cpp.git
 
 RUN cd azure-sdk-for-cpp && mkdir build && cd build \
 		&& cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_STORAGE_SAMPLES=ON -DBUILD_TESTING=ON \

--- a/tests/coreclr/p0-net6.0-ubuntu/Dockerfile
+++ b/tests/coreclr/p0-net6.0-ubuntu/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-20200508132555-78cbb55 as builder
 
 WORKDIR /build
-RUN git clone --single-branch --branch release/6.0 https://github.com/dotnet/runtime.git
+RUN git clone --depth 1 --single-branch --branch release/6.0 https://github.com/dotnet/runtime.git
 WORKDIR /build/runtime/
 
 # Build clr+libs+clr.tests in debug

--- a/tests/coreclr/p0-net6.0-ubuntu/Dockerfile.release
+++ b/tests/coreclr/p0-net6.0-ubuntu/Dockerfile.release
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-20200508132555-78cbb55 as builder
 
 WORKDIR /build
-RUN git clone --single-branch --branch release/6.0 https://github.com/dotnet/runtime.git
+RUN git clone --depth 1 --single-branch --branch release/6.0 https://github.com/dotnet/runtime.git
 WORKDIR /build/runtime/
 
 # Build clr+libs+clr.tests in release

--- a/tests/coreclr/p1-net6.0-ubuntu/Dockerfile
+++ b/tests/coreclr/p1-net6.0-ubuntu/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-20210311173918-cb64fc0 as builder
 
 WORKDIR /build
-RUN git clone --single-branch --branch release/6.0 https://github.com/dotnet/runtime.git
+RUN git clone --depth 1 --single-branch --branch release/6.0 https://github.com/dotnet/runtime.git
 WORKDIR /build/runtime/
 
 # Build clr+libs+clr.tests in debug

--- a/tests/coreclr/p1-net6.0-ubuntu/Dockerfile.release
+++ b/tests/coreclr/p1-net6.0-ubuntu/Dockerfile.release
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-20210311173918-cb64fc0 as builder
 
 WORKDIR /build
-RUN git clone --single-branch --branch release/6.0 https://github.com/dotnet/runtime.git
+RUN git clone --depth 1 --single-branch --branch release/6.0 https://github.com/dotnet/runtime.git
 WORKDIR /build/runtime/
 
 # Build clr+libs+clr.tests in release

--- a/tests/glibc/Dockerfile
+++ b/tests/glibc/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
 
 # checkout glibc
 WORKDIR /
-RUN git clone -b ${TAG} https://sourceware.org/git/glibc.git
+RUN git clone --depth 1 --single-branch --branch ${TAG} https://sourceware.org/git/glibc.git
 WORKDIR /glibc
 COPY patch.diff .
 RUN git apply patch.diff

--- a/tests/sockperf/Dockerfile
+++ b/tests/sockperf/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.7 as builder
 RUN apk update && apk upgrade
 RUN apk add build-base perl make automake autoconf m4 git libexecinfo-dev
 
-RUN git clone -b sockperf_v2 --single-branch  https://github.com/Mellanox/sockperf.git
+RUN git clone --single-branch --branch sockperf_v2 https://github.com/Mellanox/sockperf.git
 
 WORKDIR /sockperf
 

--- a/tests/sockperf/Dockerfile_ubuntu
+++ b/tests/sockperf/Dockerfile_ubuntu
@@ -3,7 +3,7 @@ FROM ubuntu:20.04 as builder
 RUN apt-get update && apt-get install -y \
     build-essential perl make automake autoconf m4 git libtool-bin
 
-RUN git clone -b sockperf_v2 --single-branch  https://github.com/Mellanox/sockperf.git
+RUN git clone --single-branch --branch sockperf_v2 https://github.com/Mellanox/sockperf.git
 
 WORKDIR /sockperf
 


### PR DESCRIPTION
#### solutions/python_web_frameworks

Latest version of uwsgi (2.0.22) is not compatible with Python 3.12, so Pin Python to 3.11
https://github.com/unbit/uwsgi/issues/2566

#### solutions/python_flask_tests

Flask 2.3.2 is using a deprecated version of Werkzeug, so bump it to 2.3.3