### PR TITLE
Update Makefile to remove Identity_resource_management_and_storage

### DIFF
--- a/solutions/dotnet_azure_sdk/Makefile
+++ b/solutions/dotnet_azure_sdk/Makefile
@@ -2,7 +2,7 @@ TOP=$(abspath ../..)
 include $(TOP)/defs.mak
 
 DIRS = 
-DIRS += Identity_Resource_Management_and_Storage
+# DIRS += Identity_Resource_Management_and_Storage
 DIRS += KeyVault_Keys
 DIRS += KeyVault_Secrets
 DIRS += KeyVault_Certificates


### PR DESCRIPTION
There was a break since azure blob storage does not allow public access now, that we attempted to fix here:https://github.com/deislabs/mystikos/commit/8412a2fd3479e97716706f4727680db199bc8b59, but the fix does not work