### PR TITLE
Create parent directories of mount point target

### DIFF
--- a/kernel/enter.c
+++ b/kernel/enter.c
@@ -115,7 +115,7 @@ static int _create_and_mount(
 
         if (errornum == -ENOENT)
             // target do not exist, create directory
-            ECHECK(myst_syscall_mkdir(locals->normalized_target.buf, 0777));
+            ECHECK(myst_mkdirhier(locals->normalized_target.buf, 0777));
         else if (errornum == 0 && !S_ISDIR(buf.st_mode))
             // target exists but is not directory
             ERAISE(-ENOTDIR);


### PR DESCRIPTION
During startup mystikos creates mount point target directories if they do not exist, but not its parent directories. This PR changes that to create the intermediate path components as well.