### PR TITLE
Disable test for confidential_ml and mhsm_ssr

### DIFF
--- a/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
+++ b/.jenkins/pipelines/standalone/solutions-tests.Jenkinsfile
@@ -139,12 +139,7 @@ pipeline {
                                      string(credentialsId: "mystikos-sql-db-server-name-${REGION}", variable: 'DB_SERVER_NAME'),
                                      string(credentialsId: "mystikos-maa-url-${REGION}", variable: 'MAA_URL'),
                                      string(credentialsId: 'mystikos-sql-db-userid', variable: 'DB_USERID'),
-                                     string(credentialsId: 'mystikos-sql-db-password', variable: 'DB_PASSWORD'),
-                                     string(credentialsId: 'mystikos-mhsm-client-secret', variable: 'CLIENT_SECRET'),
-                                     string(credentialsId: 'mystikos-mhsm-client-id', variable: 'CLIENT_ID'),
-                                     string(credentialsId: 'mystikos-mhsm-app-id', variable: 'APP_ID'),
-                                     string(credentialsId: 'mystikos-mhsm-aad-url', variable: 'MHSM_AAD_URL'),
-                                     string(credentialsId: 'mystikos-mhsm-ssr-pkey', variable: 'SSR_PKEY')
+                                     string(credentialsId: 'mystikos-sql-db-password', variable: 'DB_PASSWORD')
                     ]) {
                         sh """
                            echo "MYST_NIGHTLY_TEST is set to \${MYST_NIGHTLY_TEST}"

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -1,4 +1,8 @@
-DIRS = docker_aks helloworld java_hello_world rust tensorflow_lite TEE_aware/dotnet TEE_aware/gencreds confidential_ml
+DIRS = docker_aks helloworld java_hello_world rust tensorflow_lite TEE_aware/dotnet TEE_aware/gencreds
+
+ifdef MHSM_AAD_URL
+DIRS += confidential_ml
+endif
 
 .PHONY: run clean
 

--- a/solutions/Makefile
+++ b/solutions/Makefile
@@ -13,7 +13,9 @@ endif
 endif
 endif
 
+ifdef MHSM_AAD_URL
 DIRS += mhsm_ssr
+endif
 DIRS += msgpack_c
 
 DIRS += dotnet


### PR DESCRIPTION
There is no discernable source of the compiled MHSM Client Library (libmhsm_ssr.so), so this deprecates MHSM maintenance and tests that rely on it.