### PR TITLE
Fix Code scanning filesystem TOCTOU

### DIFF
--- a/utils/cpio.c
+++ b/utils/cpio.c
@@ -1172,14 +1172,9 @@ int myst_cpio_test(const char* path)
     int fd = -1;
     const char magic[] = MYST_CPIO_MAGIC_INITIALIZER;
     char buf[sizeof(magic)];
-    struct stat file_stat;
 
     if (!path)
         ERAISE(-EINVAL);
-
-    ret = stat(path, &file_stat);
-    if (ret != 0)
-        ERAISE(-ENOENT);
 
     if ((fd = open(path, O_RDONLY)) < 0)
     {


### PR DESCRIPTION
There is a stat(pathname) followed by open(pathname). Code scanning alerts this as a possible TOCTOU if the file was modified between these two calls.
This patch removes the stat(), as it is only used for validating file existence, which open() also performs.

https://github.com/deislabs/mystikos/security/code-scanning/4137