### PR TITLE
Move SQL DB to useast2

### DIFF
--- a/solutions/python_app/Dockerfile
+++ b/solutions/python_app/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -y curl gnupg2 &&\
     curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list &&\
     apt update && \
     apt install -y wget &&\
-    ACCEPT_EULA=Y apt install -y msodbcsql17 &&\
+    ACCEPT_EULA=Y apt install -y msodbcsql18 &&\
     wget -q https://repo.continuum.io/miniconda/Miniconda3-py38_4.8.2-Linux-x86_64.sh &&\
     chmod 755 Miniconda3-py38_4.8.2-Linux-x86_64.sh &&\
     ./Miniconda3-py38_4.8.2-Linux-x86_64.sh -b -p /miniconda &&\

--- a/solutions/python_app/app.py
+++ b/solutions/python_app/app.py
@@ -9,12 +9,17 @@ import tty
 from logzero import logger
 from Crypto.Cipher import AES
 
-def test_pyodbc(server: str, database: str, uid: str, password: str, driver: str, query: str):
+def test_pyodbc(server: str, database: str, driver: str, query: str, uid: str = '', password: str = ''):
     connstr = "Driver=" + driver
     connstr += ";Server=" + server
     connstr += ";Database=" + database
-    connstr += ";UID=" + uid
-    connstr += ";PWD=" + password
+    if uid:
+        connstr += ";User ID=" + uid
+    # Use password authentication if password is provided, otherwise use Managed Identity
+    if password:
+        connstr += ";PWD=" + password
+    else:
+        connstr += ";Authentication=ActiveDirectoryMsi"
 
     try:
         conn = pyodbc.connect(connstr)
@@ -95,9 +100,9 @@ if __name__ == "__main__":
     test_pyodbc(
         server=os.getenv("DB_SERVER_NAME"),
         database=os.getenv("DB_NAME"),
-        uid = os.getenv("DB_USERID"),
-        password = os.getenv("DB_PASSWORD"),
-        driver="{ODBC Driver 17 for SQL Server}",
+        uid = os.getenv("DB_USERID", ""),
+        password = os.getenv("DB_PASSWORD", ""),
+        driver="{ODBC Driver 18 for SQL Server}",
         query="SELECT USER_NAME()")
 
     test_pandas()

--- a/solutions/python_app/config.json
+++ b/solutions/python_app/config.json
@@ -20,5 +20,6 @@
     // The environment variables accessible inside the enclave.
     "EnvironmentVariables": [""],
     // The environment variables we get from the host
-    "HostEnvironmentVariables": ["DB_SERVER_NAME", "DB_NAME", "MAA_ENDPOINT", "DB_USERID", "DB_PASSWORD"]
+    "HostEnvironmentVariables": ["DB_SERVER_NAME", "DB_NAME", "MAA_ENDPOINT", "DB_USERID", "DB_PASSWORD"],
+    "ThreadStackSize": "1m"
 }

--- a/solutions/sql_ae/Dockerfile
+++ b/solutions/sql_ae/Dockerfile
@@ -4,6 +4,6 @@ USER root
 RUN apk add --no-cache bash sudo unixodbc-dev curl krb5-libs libstdc++ mbedtls
 
 RUN mkdir -p /tmp/msodbcinstall && cd /tmp/msodbcinstall && \
-curl --retry 5 --retry-max-time 120 -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.6.1.1-1_amd64.apk
+curl --retry 5 --retry-max-time 120 -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/msodbcsql18_18.3.3.1-1_amd64.apk
 RUN cd /tmp/msodbcinstall && sudo apk add --allow-untrusted $(ls)
 RUN rm -rf /tmp/msodbcinstall

--- a/solutions/sql_ae/Makefile
+++ b/solutions/sql_ae/Makefile
@@ -18,7 +18,7 @@ all: myst app
 	$(MYST) mkcpio $(APPDIR) rootfs
 
 run: appdir
-	$(RUNTEST) $(MYST_EXEC) rootfs /odbc_app classic default $(OPTS)
+	$(RUNTEST) $(MYST_EXEC) rootfs /odbc_app msi default $(OPTS)
 
 myst:
 	$(MAKE) -C $(TOP)/tools/myst
@@ -26,7 +26,7 @@ myst:
 app:
 	rm -rf app/odbc_app $(APPDIR)
 	docker build -t sql_ae.alpine.build -f app-dockerfile .
-	docker run --rm -v $(CURDIR)/app:/app sql_ae.alpine.build bash -c "gcc -g -fshort-wchar -fPIC -o /app/cksp.so -shared /app/cksp.c -I/opt/microsoft/msodbcsql17/include; gcc -g -o /app/odbc_app -fshort-wchar /app/odbc_app.c /app/odbc_helper.c -lodbc -ldl -I/opt/microsoft/msodbcsql17/include"
+	docker run --rm -v $(CURDIR)/app:/app sql_ae.alpine.build bash -c "gcc -g -fshort-wchar -fPIC -o /app/cksp.so -shared /app/cksp.c -I/opt/microsoft/msodbcsql18/include; gcc -g -o /app/odbc_app -fshort-wchar /app/odbc_app.c /app/odbc_helper.c -lodbc -ldl -I/opt/microsoft/msodbcsql18/include"
 	sudo chown $(USER):$(GROUP) app/odbc_app
 	$(TOP)/scripts/appbuilder Dockerfile
 	cp app/odbc_app $(APPDIR)/odbc_app
@@ -35,8 +35,8 @@ app:
 	ls -l $(APPDIR)/odbc_app $(APPDIR)/cksp.so; date
 
 run-host:
-	gcc -g -fshort-wchar -fPIC -o cksp.so -shared app/cksp.c -I/opt/microsoft/msodbcsql17/include
-	gcc -g -o odbc_app -fshort-wchar app/odbc_app.c app/odbc_helper.c -lodbc -ldl -I/opt/microsoft/msodbcsql17/include
+	gcc -g -fshort-wchar -fPIC -o cksp.so -shared app/cksp.c -I/opt/microsoft/msodbcsql18/include
+	gcc -g -o odbc_app -fshort-wchar app/odbc_app.c app/odbc_helper.c -lodbc -ldl -I/opt/microsoft/msodbcsql18/include
 	./odbc_app msi default
 
 clean:

--- a/solutions/sql_ae/app-dockerfile
+++ b/solutions/sql_ae/app-dockerfile
@@ -5,6 +5,6 @@ RUN apk add --no-cache unixodbc-dev curl build-base bash
 
 WORKDIR /app/msodbcinstall
 
-RUN curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.6.1.1-1_amd64.apk && apk add --allow-untrusted $(ls)
+RUN curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/msodbcsql18_18.3.3.1-1_amd64.apk && apk add --allow-untrusted $(ls)
 
 

--- a/solutions/sql_ae/app/odbc_app.c
+++ b/solutions/sql_ae/app/odbc_app.c
@@ -52,9 +52,10 @@ int main(int argc, char** argv)
                     CONNSTR_MAX_LEN,
                     "Server=%s;Database=%s;"
                     "Authentication=ActiveDirectoryMsi;"
-                    "Driver={ODBC Driver 17 for SQL Server};"
+                    "Driver={ODBC Driver 18 for SQL Server};"
                     "ColumnEncryption=SGX-AAS,%s/attest/"
-                    "SgxEnclave?api-version=2018-09-01-preview",
+                    "SgxEnclave?api-version=2018-09-01-preview"
+                    "Encrypt=Yes;TrustServerCertificate=Yes",
                     db_server,
                     db_name,
                     maa_url) >= CONNSTR_MAX_LEN)
@@ -70,10 +71,11 @@ int main(int argc, char** argv)
                     CONNSTR_MAX_LEN,
                     "Server=%s;Database=%s;"
                     "Authentication=ActiveDirectoryMsi;"
-                    "UID=%s;"
-                    "Driver={ODBC Driver 17 for SQL Server};"
+                    "User Id=%s;"
+                    "Driver={ODBC Driver 18 for SQL Server};"
                     "ColumnEncryption=SGX-AAS,%s/attest/"
-                    "SgxEnclave?api-version=2018-09-01-preview",
+                    "SgxEnclave?api-version=2018-09-01-preview"
+                    "Encrypt=Yes;TrustServerCertificate=Yes",
                     db_server,
                     db_name,
                     db_uid,
@@ -102,9 +104,10 @@ int main(int argc, char** argv)
                 CONNSTR_MAX_LEN,
                 "Server=%s;Database=%s;"
                 "UID=%s;PWD=%s;"
-                "Driver={ODBC Driver 17 for SQL Server};"
+                "Driver={ODBC Driver 18 for SQL Server};"
                 "ColumnEncryption=SGX-AAS,%s/attest/"
-                "SgxEnclave?api-version=2018-09-01-preview",
+                "SgxEnclave?api-version=2018-09-01-preview"
+                "Encrypt=Yes;TrustServerCertificate=Yes",
                 db_server,
                 db_name,
                 db_uid,


### PR DESCRIPTION
SQL DB moved to useast2 (from useast and canadacentral). This affects Code Coverage, and solutions tests. Specifically, the python_app and sql_ae solutions were updated to use MSI. There is still support for user/password even though we do not use it in the test.

This also updates to ODBC Driver 18 and to use Entra ID for authentication with MSI.